### PR TITLE
Fix formatting in conv-object documentation

### DIFF
--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -32,6 +32,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="project_id">
     **Description**: Project ID of the current agent. This is the same project ID visible in your Studio URL: `https://studio.poly.ai/account/{account_id}/project/{project_id}/...`
+    
     **Example**:
     ```python
     log.info(f"Project ID: {conv.project_id}")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -333,6 +333,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="translations">
     **Description**: Proxy for accessing localized translations. Access translation keys as attributes to get the translated text for the current language.
+    
     **Example**:
     ```python
     greeting = conv.translations.welcome_message

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -12,6 +12,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="id">
     **Description**: Unique identifier of the conversation.
+    
     **Example**:
     ```python
     log.info(f"Conversation ID: {conv.id}")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -21,6 +21,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="account_id">
     **Description**: PolyAI account ID that owns this project. This is the same account ID visible in your Studio URL: `https://studio.poly.ai/account/{account_id}/...`
+    
     **Example**:
      ```python
     log.info(f"Account: {conv.account_id}")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -428,6 +428,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="discard_recording">
     **Description**: Prevents saving the current call recording, e.g. when sensitive data is detected.
+    
     **Example**:
     ```python
     if conv.state.get("contains_pii"):

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -392,6 +392,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="goto_flow">
     **Description**: Transition to another flow at turn end.
+    
     **Example**:
     ```python
     conv.goto_flow("verification")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -250,6 +250,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="transcript_alternatives">
     **Description**: List of ASR alternatives for the last user utterance. Each alternative includes the transcribed text and a confidence score.
+    
     **Example**:
     ```python
     for alt in conv.transcript_alternatives:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -597,6 +597,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="goto_csat_flow">
     **Description**: Trigger a transition to the CSAT (Customer Satisfaction) survey flow for voice calls.
+    
     **Example**:
     ```python
     if conv.state.get("call_completed"):

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -492,6 +492,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="send_sms">
     **Description**: Queue a plain-text SMS.
+    
     **Example**:
     ```python
     conv.send_sms(to_number=conv.caller_number, from_number="+441234567890", content="Thanks for calling — here’s your link: https://…")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -588,6 +588,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="clear_asr_biasing">
     **Description**: Clear any previously set ASR biasing for future turns.
+    
     **Example**:
     ```python
     conv.clear_asr_biasing()

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -363,6 +363,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="say">
     **Description**: Override the next utterance.
+    
     **Example**:
     ```python
     conv.say("I’ve made that change for you.")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -208,6 +208,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="sms_templates">
     **Description**: Dictionary of SMS templates (dict[str, SMSTemplate]).
+    
     **Example**:
     ```python
     template_body = conv.sms_templates["booking_confirmation"].content

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -85,6 +85,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="sip_headers">
     **Description**: Dictionary of SIP headers (dict[str, str]) provided by the carrier.
+    
     **Example**:
     ```python
     source_ip = conv.sip_headers.get("X-Src-IP")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -343,6 +343,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="response_suggestions">
     **Description**: List of quick-reply suggestions for the next agent message. Only supported on webchat channels.
+    
     **Example**:
     ```python
     for suggestion in conv.response_suggestions:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -180,6 +180,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="metric_events">
     **Description**: List of metric event objects queued for analytics.
+    
     **Example**:
     ```python
     for metric in conv.metric_events:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -75,6 +75,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="attachments">
     **Description**: List of file attachments received or queued for sending (list[Attachment]).
+    
     **Example**:
     ```python
     for file in conv.attachments:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -265,6 +265,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="real_time_config">
     **Description**: Returns a dictionary of real-time configuration values defined in Configuration Builder.
+    
     **Example**:
     ```python
     config = conv.real_time_config

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -163,6 +163,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="current_step">
     **Description**: Step name currently executing within the active flow.
+    
     **Example**:
     ```python
     log.info(f"Current step: {conv.current_step}")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -150,6 +150,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="state">
     **Description**: Dictionary-like store that persists values across turns.
+    
     **Example**:
     ```python
     conv.state["attempts"] = conv.state.get("attempts", 0) + 1

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -303,6 +303,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="functions">
     **Description**: Executor for calling other functions defined in the project. Access functions using dot notation.
+    
     **Example**:
     ```python
     result = conv.functions.lookup_order()

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -419,6 +419,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="add_attachments">
     **Description**: Attach one or more files to the current conversation record.
+    
     **Example**:
     ```python
     conv.add_attachments([{"url": "https://example.com/invoice.pdf", "filename": "invoice.pdf"}])

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -438,6 +438,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="generate_external_events">
     **Description**: Sends a structured webhook event to the configured external endpoint.
+    
     **Example**:
     ```python
     conv.generate_external_events("booking_completed", payload={"id": "1234"})

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -140,6 +140,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="callee_number">
     **Description**: Number dialled by the caller.
+    
     **Example**:
     ```python
     if conv.callee_number.endswith("1001"):

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -198,6 +198,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="variant">
     **Description**: Variant object for the active variant, or None.
+    
     **Example**:
     ```python
     if conv.variant:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -401,6 +401,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="exit_flow">
     **Description**: Exit the current flow.
+    
     **Example**:
     ```python
     conv.exit_flow()

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -410,6 +410,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="set_variant">
     **Description**: Manually set the active variant.
+    
     **Example**:
     ```python
     conv.set_variant("evening")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -113,6 +113,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="integration_data">
     **Description**: Combined payload of integration metadata and attributes (dict[str, Any]).
+    
     **Example**:
     ```python
     crm_id = conv.integration_data.get("contact_id")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -225,6 +225,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="history">
     **Description**: Chronological list of UserInput and AgentResponse events so far.
+    
     **Example**:
     ```python
     for event in conv.history:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -293,6 +293,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="entities">
     **Description**: Dictionary of entity validation results collected from the conversation (dict[str, EntityValidationResult]).
+    
     **Example**:
     ```python
     if "email" in conv.entities:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -501,6 +501,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="send_sms_template">
     **Description**: Queue a pre-configured SMS template.
+    
     **Example**:
     ```python
     conv.send_sms_template(to_number=conv.caller_number, template="booking_confirmation")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -551,7 +551,9 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="set_voice">
     **Description**: Change the TTS voice for the current conversation moving forward.
+    
     **Parameters**: voice (TTSVoice) – the voice configuration to use.
+    
     **Example**:
     ```python
     from polyai.voice import ElevenLabsVoice

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -42,7 +42,9 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="env">
     **Description**: Current environment.
+    
     **Values**: "sandbox", "pre-release", "live"
+    
     **Example**:
     ```python
     if conv.env == "live":

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -322,6 +322,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="generic_external_events">
     **Description**: List of external events initiated by `generate_external_event`. Each event contains `ext_event_id`, `send_to_llm`, `created_at`, `data`, and `content_type`.
+    
     **Example**:
     ```python
     for event in conv.generic_external_events:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -563,7 +563,9 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="set_language">
     **Description**: Change the language for the current conversation moving forward.
+    
     **Parameters**: language (str) – ISO 639 language code (e.g., "en-US", "es-ES", "fr-FR").
+    
     **Example**:
     ```python
     conv.set_language("es-US")

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -240,6 +240,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="handoffs">
     **Description**: Dictionary of configured hand-off destinations (dict[str, HandoffConfig]).
+    
     **Example**:
     ```python
     if "support" in conv.handoffs:

--- a/function/classes/conv-object.mdx
+++ b/function/classes/conv-object.mdx
@@ -510,6 +510,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
   <Accordion title="write_metric">
     **Description**: Write a custom metric to the analytics pipeline.
+    
     **Example**:
     ```python
     conv.write_metric("agent_handoff", 1)


### PR DESCRIPTION
Fixed formatting issues in the Conversation object documentation where Description, Values, Example, and Parameters fields were appearing on the same line without proper spacing. Added blank lines between these fields to improve readability and maintain consistent formatting throughout the documentation.

**Files changed:**
- `function/classes/conv-object.mdx` - Added proper spacing between Description, Values, Example, and Parameters fields in all Accordion components