### PR TITLE
Add accent color to theme

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,8 @@
   "colors": {
     "primary": "#161617",
     "light": "#FCFCFC",
-    "dark": "#161617"
+    "dark": "#161617",
+    "accent": "#CBDF4C"
   },
   "favicon": "/favicon.png",
   "navigation": {


### PR DESCRIPTION
Added the company accent color `#CBDF4C` (rgb(203, 223, 76)) to the documentation theme configuration. This introduces a visual flourish that complements the existing primary, light, and dark colors.

**Files changed:**
- `docs.json` - Added `accent` color property to the `colors` configuration