### PR TITLE
Streamline quickstart guide to industry standard

### DIFF
--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -1,180 +1,122 @@
 ---
 title: Quickstart
-description: Follow this guide to prepare your agent for testing
+description: Build and deploy your first AI agent in minutes
 ---
 
 <Info>
-  Before you begin, make sure you've signed up for an account. You can find detailed instructions [here](/get-started/account-creation).
+  Before you begin, make sure you've [signed up for an account](/get-started/account-creation).
 </Info>
 
-Welcome to PolyAI's quickstart guide for voice and webchat agents. This should give you a brief overview of the main capabilities available to you
-as a user of the Agent Studio platform, but there are many more features you can learn about by browsing the documentation or asking the AI assistant at the top of your window.
+Get your AI agent up and running in four steps. This guide covers the essentials—create an agent, add knowledge, test it, and deploy.
 
-## Creating an agent
+## Prerequisites
+
+- A PolyAI account with access to Agent Studio
+- Basic information about your use case (e.g., customer support, reservations, FAQ)
 
 <Steps>
-  <Step title="Start the creation process">
-    After logging in, click **"Create agent"** to start the process.
+  <Step title="Create your agent">
+    Click **Create agent** from the home page.
 
-![create-agent](/images/quickstart/create-agent.png)
+    Configure the basics:
+    - **Agent name** – Internal identifier for your project
+    - **Response language** – Primary language for responses
+    - **Voice** – Select from available TTS voices
+    - **Welcome greeting** – First message callers hear
 
-<Info>
-  You can also **duplicate** an existing agent from the home page by clicking the three dots information icon next to a profile.
-   ![duplicate-agent](/images/quickstart/duplicate-agent.png)
-   The duplicated profile will have the same name as the original, but appended with `(copy)`. You can also export and import existing agents from `.bin` files.
-</Info>
+    Click **Next** to enter Agent Studio.
 
+    ![create-agent](/images/quickstart/create-agent.png)
+
+    <Tip>
+      You can also duplicate an existing agent by clicking the three-dot menu next to any agent on the home page.
+    </Tip>
   </Step>
 
-  <Step title="Set a name, response language, voice, and greeting line">
+  <Step title="Add knowledge">
+    Navigate to **Managed Topics** in the left sidebar.
 
-    Full page: [**Voice**](/voice/introduction), [**Agent settings**](/agent-settings/introduction)
+    Click **Add topic** and provide:
+    - **Topic name** – What this topic covers (e.g., "Store hours")
+    - **Sample questions** – 5–10 ways users might ask (e.g., "When are you open?")
+    - **Answer** – The response your agent should give
 
-Create a new agent by entering an **agent name**, **response language**, **voice**, and **the welcome greeting**.
+    Click **Save** to create the topic.
 
-You can also set a project ID here, which will determine your URL.
+    ![add-kb-item](/images/quickstart/add-kb-item.png)
 
-After completing these steps, click **"Next"**.
+    <Info>
+      Changes are saved as **Drafts**. Publish to **Sandbox** to test them. Learn more about [environments and versions](/environments-and-versions/introduction).
+    </Info>
 
-![general](/images/quickstart/general.png)
+    **Optional:** Add more topics to expand your agent's capabilities. You can also:
+    - Upload PDFs or URLs to auto-generate topics
+    - Connect external knowledge sources like Zendesk or Google Sheets
+    - Add [actions](/managed-topics/how-to-setup-action/introduction) to trigger functions or flows
 
+    See the full [Managed Topics guide](/managed-topics/introduction) for details.
   </Step>
 
-<Step title="Entering Agent Studio and Managed Topics">
+  <Step title="Test your agent">
+    Click the **phone icon** <Icon icon="phone" size={18} /> in the top-right corner to start an in-browser call.
 
-Once you have created your agent, you will see is blank Managed Topics. Other functionality and settings are available on the left-side navigation bar.
+    Select **Sandbox** from the environment dropdown and begin speaking.
 
-![general](/images/quickstart/home.png)
+    ![test-call](/images/test-call.png)
 
-</Step>
+    You can also test via:
+    - **Webchat** – Click the chat icon to open a text-based conversation
+    - **Phone** – [Connect a number](/telephony/introduction) and call it directly
 
-<Step title="Add a Managed Topic">
-
-![add-kb-item](/images/quickstart/add-kb-item.png)
-
-Let's get started by giving your agent some information it can use.
-
-Full page: [**Managed Topics**](/managed-topics/introduction)
-
-To teach your agent factual information, you can add **Managed Topics**.
-Each item contains:
-- A topic title (for example, "The café's opening hours")
-- A set of sample questions that users might ask (e.g., "When do you close?")
-- The answer content your agent should return (e.g., "The café is closed on Mondays…").
-
-You can also add [Actions](/managed-topics/how-to-setup-action/introduction) to connect knowledge items with functions, APIs, or follow-up flows.
-
-<Tip>
-  When editing or adding knowledge, changes are saved as **Drafts**. You can then publish to the **Sandbox** for internal testing before moving to **Pre-release** or **Live** environments. For more information on the deployment pipeline, visit the [environments and versions](/environments-and-versions/introduction) feature page.
-</Tip>
-
-</Step>
-
-<Step title="Change your language model">
-
-    Go to **Settings → Model** to select which LLM will power your agent. The default is **GPT-4o Mini**, but others like **Claude 3.5 Haiku** or PolyAI's **Raven** are also available depending on use case.
-
-Full page: [**Model Selection**](/agent-settings/model-use)
-
- </Step>
-
-  <Step title="[Voice agents only] Select a number for telephony integration">
-    Full page: [**Telephony Integration**](/telephony/introduction)
-
-You may buy a number or connect an existing number for your agent. You can also skip this step and return later.
-
-![telephony](/images/quickstart/telephony.png)
-
-</Step>
-
-<Step title="[Webchat agents only] Design your chat widget">
-  Full page: [**Webchat**](/webchat/introduction)
-
-Use the **Webchat Customize tab** to set how the widget will look on your site.
-You can update the:
-
-- **Header text** – the title shown in the chat window (e.g. “Cafe Assistant Cassandra”).
-- **Primary color** – controls the header background and action elements like buttons. Enter a hex code or use the color picker.
-
-The right-hand panel shows a **live preview** of your widget, updating instantly as you change settings. This lets you verify styling, branding, and greeting text before publishing.
-
-![webchat customization example](/images/quickstart/webchat.png)
-
-<Info>
-After changing styles, you must redeploy the widget under **Test and install → Generate script tag** so updates appear on your site.
-</Info>
-
-</Step>
-
-  <Step title="[Advanced] Integrate functions into your Managed Topics">
-
-    Full page: [**Functions**](/function/introduction)
-
-**What they do**: Functions allow you to add dynamic, programmable behavior to your agent, and allow you to handle external API calls, retrieve specific data, and use that data to make decisions based on real-time context.
-
-Example use case: An agent retrieving shipping information for a customer query about an order.
-
-![functions](/images/quickstart/functions.png)
-
+    See [Agent chat](/get-started/agent-chat) for more testing options.
   </Step>
 
-  <Step title="[Advanced] Add a flow to your project">
+  <Step title="Deploy to production">
+    Once testing is complete, promote your agent through the deployment pipeline:
 
-    Full page: [**Flows**](/flows/introduction)
+    1. Go to **Environments and Versions** in the left sidebar
+    2. Click **Promote to Pre-release** for user acceptance testing
+    3. Click **Promote to Live** to make your agent production-ready
 
-**What they do**: Flows are designed for managing multi-step conversations, like booking a table at a restaurant, resetting a password, or collecting feedback.
+    Each environment can have its own phone number and configuration.
 
-Example use case: A customer reservation flow for a restaurant, with steps to ask for the date, time, and number of people before confirming the booking, as well as handling any problems that might arise along the way.
+    ![active-publish](/images/deployment/publish.png)
 
-![flows](/images/quickstart/flows.png)
-
+    <Tip>
+      You can roll back to any previous version if issues arise. See the [deployment pipeline guide](/environments-and-versions/introduction) for details.
+    </Tip>
   </Step>
-
-  <Step title="Test your agent (webchat, browser call, or phone)">
-
-    Full page: [**Agent Chat**](/get-started/agent-chat)
-
-    You can test your agent without deploying by:
-    - Using the **webchat interface**
-     - Making an **in-browser voice call** using the phone icon
-    - Calling from a connected number
-
-  </Step>
-
-    <Step title="Publish your agent">
-
-       Full page: [Environments & versions](/environments-and-versions/introduction)
-
-       Once you have completed setup:
-       * Publish your agent to the **Sandbox** for internal testing.
-       * Promote to **Pre-release** for user testing and QA.
-       * Finally, promote it to **Live** to once it production-ready.
-
-       Each environment can be linked to a separate phone number and has rollback capabilities.
-
-    </Step>
-
 </Steps>
 
-By following these steps, you can create a personalized and effective agent tailored to your needs.
+## Next steps
 
-## How does my agent work?
+<CardGroup cols={2}>
+  <Card title="Add advanced features" icon="code" href="/function/introduction">
+    Use functions to connect APIs, retrieve data, and add dynamic behavior
+  </Card>
+  <Card title="Build conversation flows" icon="diagram-project" href="/flows/introduction">
+    Create multi-step workflows for bookings, forms, and complex interactions
+  </Card>
+  <Card title="Configure voice settings" icon="microphone" href="/voice/introduction">
+    Customize TTS, add multiple voices, and tune audio management
+  </Card>
+  <Card title="Monitor performance" icon="chart-line" href="/analytics/dashboards/introduction">
+    Track conversations, analyze metrics, and improve your agent over time
+  </Card>
+</CardGroup>
 
-Full page: [Processing order](/essentials/order)
+## How your agent works
 
-Once your agent is setup, here is how it will process calls:
+When a user interacts with your agent, the following happens:
 
-	1.	Caller speaks: The agent receives the caller's input as an audio stream.
-	2.	ASR Service: Transcribes the audio into text.
-	3.	LLM Service: Interprets the request and determines an appropriate response.
-	4.	TTS Service: Converts the response back into speech and delivers it to the caller.
+1. **User speaks or types** – Audio is captured (voice) or text is received (chat)
+2. **ASR transcribes** – Speech is converted to text (voice only)
+3. **LLM processes** – The model retrieves relevant knowledge and generates a response
+4. **TTS synthesizes** – Text is converted back to speech (voice only)
+5. **Response delivered** – The agent replies to the user
 
-This cycle allows for real-time, responsive interactions. For a deeper breakdown of processing steps, see the advanced conversation flow processing order page.
-
-<Tip>To tune your agent's latency and style of reply, try adjusting the **Interaction Style** slider under [**Audio Management**](/audio-management/introduction). Choose between **Turbo**, **Swift**, **Balanced**, or **Precise**.</Tip>
+This cycle repeats for each turn in the conversation. See [processing order](/essentials/order) for a detailed breakdown.
 
 <Tip>
-  You can set a custom disclaimer message to precede the call using an alternate voice.
-     ![multi-voice](/images/quickstart/multivoice.png)
-  You can also assign **multiple voices** to your agent using the **Multi-voice UI** under Voice settings. Voices can be distributed across calls by percentage.
+  Adjust the **Interaction Style** slider under [Audio Management](/audio-management/introduction) to tune latency and response behavior. Choose between **Turbo**, **Swift**, **Balanced**, or **Precise**.
 </Tip>

--- a/learn/guides/get-started/create-a-project.mdx
+++ b/learn/guides/get-started/create-a-project.mdx
@@ -79,6 +79,24 @@ In Agent Studio, creating a project is a short sequence:
 
 After creation, you land in the agent workspace. By default, this will be the **Managed Topics**, in an empty state ("You don't have any topics") with an **Add topic** button.
 
+### Understanding the Agent Studio interface
+
+The Agent Studio workspace is organized into three main areas:
+
+<CardGroup cols={3}>
+  <Card title="Left sidebar" icon="sidebar">
+    Navigation for all agent configuration areas (Build, Voice, Configure, Manage)
+  </Card>
+  <Card title="Center canvas" icon="window">
+    Main workspace where you edit topics, functions, flows, and view analytics
+  </Card>
+  <Card title="Right sidebar" icon="panel-right">
+    Context-sensitive tools like chat testing, call testing, and version history
+  </Card>
+</CardGroup>
+
+The right sidebar can be toggled open/closed and provides quick access to testing tools without leaving your current page.
+
 <AccordionGroup>
   <Accordion title="Confirm agent identity" icon="circle-check">
     - <input type="checkbox"  /> The header shows the agent name and language.

--- a/managed-topics/introduction.mdx
+++ b/managed-topics/introduction.mdx
@@ -6,6 +6,19 @@ The Managed Topics (MTs) are the brain of your agent. Each topic defines a singl
 
 Well-structured entries keep answers clear, safe, and meaningful.
 
+## The Managed Topics interface
+
+![managed-topics-interface](/images/kb-interface.png)
+
+The Managed Topics page provides tools to organize and manage your agent's knowledge:
+
+- **Search bar** – Find topics by name, sample questions, or content
+- **Filter dropdown** – Filter by category, active status, or action type
+- **Topic cards** – Each card shows the topic name, category, and a preview of sample questions
+- **Add topic button** – Create new topics or import from CSV/URL/PDF
+
+Click any topic card to open the editor and modify its content, sample questions, or actions.
+
 ## How retrieval works
 
 ![retrieval](/images/kb-rag-ven.png)


### PR DESCRIPTION
Transformed the quickstart from an 11-step walkthrough into a focused 4-step guide following industry best practices. The new version emphasizes the core workflow (create, add knowledge, test, deploy) with prerequisites, next steps cards, and streamlined content that links to detailed documentation rather than explaining everything inline.

## Files changed
- `get-started/quickstart.mdx` - Complete rewrite with 4 focused steps, prerequisites section, next steps cards, and simplified "How your agent works" explanation