### PR TITLE
fix: correct classes and objects docs against source and API schema

### DIFF
--- a/sms/introduction.mdx
+++ b/sms/introduction.mdx
@@ -140,7 +140,11 @@ Sends a free-form SMS message to a specified phone number.
 
 ```python
 # Send to the current caller
-conv.send_sms(conv.caller_number, "Your appointment is confirmed for tomorrow at 2pm.")
+conv.send_sms(
+    to_number=conv.caller_number,
+    from_number="+441234567890",  # your Twilio number
+    content="Your appointment is confirmed for tomorrow at 2pm."
+)
 ```
 
 ### `conv.send_sms_template`
@@ -149,7 +153,7 @@ Sends a pre-configured SMS template by **template name** (the title you defined 
 
 ```python
 # Send a template to the current caller
-conv.send_sms_template(conv.caller_number, "reservation_confirmation")
+conv.send_sms_template(to_number=conv.caller_number, template="reservation_confirmation")
 ```
 
 The second argument is the template **name** (the title from Build > SMS), not an ID. For example, if your template is titled `prescription_refill`, use `conv.send_sms_template(conv.caller_number, 'prescription_refill')`.

--- a/tools/classes/conv-object.mdx
+++ b/tools/classes/conv-object.mdx
@@ -87,7 +87,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
     
     **Attachment object structure**:
     - `content_url` (str) – URL to the main content of the attachment
-    - `content_type` (str) – The type of the attachment (`"image"` or `"weblink"`)
+    - `content_type` (str) – The type of the attachment (`"image"`, `"weblink"`, or `"unspecified"`)
     - `title` (str, optional) – Title of the attachment
     - `preview_image_url` (str, optional) – URL to a preview image for the attachment
     - `call_to_action` (str, optional) – Text for the call-to-action button or link
@@ -436,7 +436,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
 
     **Attachment fields**:
     - `content_url` (str) – URL to the main content of the attachment
-    - `content_type` (str) – The type of the attachment (`"image"` or `"weblink"`)
+    - `content_type` (str) – The type of the attachment (`"image"`, `"weblink"`, or `"unspecified"`)
     - `title` (str, optional) – Title of the attachment
     - `preview_image_url` (str, optional) – URL to a preview image for the attachment
     - `call_to_action` (str, optional) – Text for the call-to-action button or link
@@ -444,6 +444,7 @@ The Conversation object (conv) provides access to conversation data and tools fo
     **Attachment types**:
     - `"weblink"` – Displays the title, preview image, and call-to-action text. Clicking navigates the user to `content_url`.
     - `"image"` – Displays the title (if present), but no call-to-action. `preview_image_url` should be a lower resolution image, and `content_url` should be the full resolution image. Clicking shows the higher resolution version.
+    - `"unspecified"` – No specific rendering behaviour is applied.
     
     **Example**:
     ```python

--- a/tools/classes/conv-utils.mdx
+++ b/tools/classes/conv-utils.mdx
@@ -108,8 +108,11 @@ Parameters:
   - `"gpt-4o-mini"` – GPT-4o Mini (faster, lower cost)
   - `"gpt-4.1"` – GPT-4.1
   - `"gpt-4.1-mini"` – GPT-4.1 Mini
-  - `"gpt-4.1-nano"` – GPT-4.1 Nano (fastest, lowest cost)
-  - `"gpt-5.2-chat"` – GPT-5.2 Chat (latest)
+  - `"gpt-4.1-nano"` – GPT-4.1 Nano (fast, low cost)
+  - `"gpt-5"` – GPT-5 (full reasoning model, highest capability)
+  - `"gpt-5-mini"` – GPT-5 Mini (balanced speed and capability)
+  - `"gpt-5-nano"` – GPT-5 Nano (fastest, lowest latency)
+  - `"gpt-5-chat"` – GPT-5 Chat (optimised for conversation)
   - `"claude-3.5-haiku"` – Claude 3.5 Haiku (fast)
   - `"claude-sonnet-4"` – Claude Sonnet 4
 
@@ -119,7 +122,7 @@ Returns:
 Raises:
 - `ChatCompletionError` if the request fails.
 
-<Warning>`prompt_llm` makes a synchronous LLM call during the conversation turn. This adds latency – choose a smaller model (e.g. `gpt-5-nano`) when speed matters, and avoid calling it multiple times in a single turn.</Warning>
+<Warning>`prompt_llm` makes a synchronous LLM call during the conversation turn. This adds latency — choose a smaller model (e.g. `"gpt-5-nano"` or `"gpt-4.1-nano"`) when speed matters, and avoid calling it multiple times in a single turn.</Warning>
 
 ## `validate_entity`
 
@@ -142,6 +145,7 @@ Parameters:
   - `conv.utils.DateConfig()`
   - `conv.utils.TimeConfig()`
   - `conv.utils.NumericConfig()`
+  - `conv.utils.QuantityConfig()`
   - `conv.utils.CurrencyConfig()`
   - `conv.utils.NameConfig()`
   - `conv.utils.AlphanumericConfig()`
@@ -152,29 +156,6 @@ Returns:
 - `EntityValidationResponse` with `valid`, `value`, and validation details. Some config types expose additional fields – for example, `PhoneNumberConfig` results include `country_code` and `number`. Available fields vary by config type.
 
 <Warning>Entity values are always returned as strings, even for numeric entity types. Cast with `int()` or `float()` before numeric comparisons.</Warning>
-
-## `geocode_address`
-
-Geocode a full address string using configured mapping services.
-
-```python
-address = conv.utils.geocode_address(
-  full_address="123 Main St, New York, NY 10001",
-  provider="google_maps"
-)
-```
-
-Parameters:
-- `full_address` (str): The complete address string to geocode.
-- `provider` (str, optional): Geocoding provider (`"google_maps"` or `"mapbox"`). Default `"google_maps"`.
-
-Returns:
-- An `Address` instance with geocoded coordinates populated where available.
-
-Raises:
-- `ExtractionError` if geocoding fails or the address cannot be resolved.
-
-<Note>This feature is available on select plans. Contact your PolyAI representative to check availability for your project.</Note>
 
 ## Notes
 

--- a/tools/classes/voice.mdx
+++ b/tools/classes/voice.mdx
@@ -25,9 +25,6 @@ conv.set_voice(
         stability=1.0,          # Recommended starting point (Robust); eleven_v3 only supports 0.0, 0.5, 1.0
         similarity_boost=0.7,
         speed=1.0,              # Optional: 0.7–1.2, adjusts speech rate
-        style=0.0,              # Optional: 0.0–1.0, controls stylistic expressiveness
-        clarity=0.8,            # Optional: controls crispness of enunciation
-        latency_mode="swift",   # Optional: aligns with interaction-style settings
     )
 )
 ```
@@ -52,16 +49,21 @@ conv.set_voice(
         emotions=[
             Emotion(EmotionKind.POSITIVITY, EmotionIntensity.HIGH)
         ],
-        model_id="sonic"  # or "sonic-preview"
+        model_id="sonic"  # or any Cartesia-compatible identifier e.g. "sonic-3-2025-10-27"
     )
 )
 ```
 
 <Note>Some Cartesia voices are faster than expected at the default speed. Test your chosen voice at `speed=0.0` before deploying, and adjust toward `-1.0` if the output is too fast.</Note>
 
-**Emotion options:**
+**Emotion options (legacy models):**
 - `EmotionKind`: `ANGER`, `POSITIVITY`, `SURPRISE`
 - `EmotionIntensity`: `LOWEST`, `LOW`, `HIGH`, `HIGHEST`
+
+**Sonic 3 parameters**: When using a Sonic 3 model ID, the following additional parameters are supported:
+- `volume` (float, optional) – controls output volume (e.g. 0.5–2.0).
+- `emotion` (str, optional) – emotion string (e.g. `"happy"`).
+- `language` (str, optional) – language code (e.g. `"en"`).
 
 ### Example: Rime
 
@@ -176,9 +178,6 @@ When configuring a voice, make sure the language code in the `provider_voice_id`
 
 ## Additional options
 
-- **clarity** – fine-tunes articulation sharpness per utterance (0.0–1.0).
-- **latency_mode** – chooses a response profile ("swift", "balanced", "precise", "turbo") consistent with [Interaction style](/audio-management/introduction#interaction-style).
-- **stability** – controls tone variability across runs.
-- **style** – controls stylistic expressiveness (ElevenLabs: `0.0`–`1.0`).
-- **speed** – adjusts speech rate (ElevenLabs: `0.7`–`1.2`; other providers may differ).
+- **stability** – controls tone variability across runs (ElevenLabs).
+- **speed** – adjusts speech rate (ElevenLabs: `0.7`–`1.2`; PlayHT: `0.1`–`5.0`; other providers may differ).
 - **randomize_voice()** – supports external providers for weighted selection.

--- a/tools/classes/voice.mdx
+++ b/tools/classes/voice.mdx
@@ -11,7 +11,6 @@ The PolyAI platform supports flexible voice selection for external providers suc
 ## Provider classes
 
 When picking models, adjusting stability, or accessing third-party providers – use provider-specific TTSVoice classes.
-You can also optionally adjust **clarity** and **latency_mode** to match the agent's interaction style.
 
 ### Example: ElevenLabs
 

--- a/tools/start-function.mdx
+++ b/tools/start-function.mdx
@@ -231,7 +231,8 @@ See [return values](/tools/return-values) for the full list of supported return 
         conv.set_variant(language)
 
         if language == "es":
-            conv.voice = Voice(provider="cartesia", ...)
+            from polyai.voice import CartesiaVoice
+            conv.set_voice(CartesiaVoice(provider_voice_id="your-voice-id"))
         return str()
     ```
   </Accordion>


### PR DESCRIPTION
## Summary

Scrupulous audit of all classes/objects and conv-level configuration pages against the \`genai_lambda_runtime\` source and Lambda API schema. Two passes — corrects factual errors, removes phantom methods, and fixes broken code examples.

## Changes

**\`tools/classes/voice.mdx\`**
- Remove \`style\`, \`clarity\`, \`latency_mode\` from ElevenLabsVoice example and intro — these params don't exist in the source class or Lambda API schema (\`additionalProperties: false\`)
- Add CartesiaVoice Sonic 3 params: \`volume\`, \`emotion\`, \`language\`
- Clarify CartesiaVoice \`model_id\` accepts any Cartesia-compatible identifier, not just \`"sonic"\`/\`"sonic-preview"\`

**\`tools/classes/conv-object.mdx\`**
- Add \`"unspecified"\` as a valid \`content_type\` for \`Attachment\`, matching the \`Literal\` in \`attachment.py\`

**\`tools/classes/conv-utils.mdx\`**
- Fix \`"gpt-5.2-chat"\` → \`"gpt-5-chat"\` (wrong name raises \`ValueError\` at runtime)
- Add missing models: \`gpt-5\`, \`gpt-5-mini\`, \`gpt-5-nano\`
- Remove \`geocode_address\` section entirely — method does not exist anywhere in the runtime source
- Add missing \`QuantityConfig\` to \`validate_entity\` entity config list

**\`tools/start-function.mdx\`**
- Fix broken voice example: \`conv.voice = Voice(provider="cartesia", ...)\` → \`conv.set_voice(CartesiaVoice(...))\`

**\`sms/introduction.mdx\`**
- Fix \`conv.send_sms()\` example which was missing the required \`from_number\` argument

## Test plan

- [ ] Spot-check voice examples in a sandbox function using ElevenLabs and Cartesia
- [ ] Confirm \`prompt_llm\` accepts \`"gpt-5-chat"\` without error
- [ ] Confirm \`validate_entity\` accepts \`QuantityConfig\`
- [ ] Verify no broken links or MDX lint errors on changed pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)