### PR TITLE
docs(release-notes): consolidate Conversations and Diagnosis bullets …

### DIFF
--- a/releases/notes/26.05.mdx
+++ b/releases/notes/26.05.mdx
@@ -25,10 +25,9 @@ See [PolyScore](/analytics/polyscore) for the scoring model and eligibility.
 
 The Conversations page is now organized around channel scopes, saved views, layered diagnosis, and an integrated review side panel — purpose-built for analyzing conversations at scale.
 
-- **Voice and Webchat scopes** — separate tabs with their own columns and views.
+- **Voice and Webchat as separate scopes** — each with their own saved views, column layouts, and an integrated review side panel that opens without leaving the table.
 - **Saved views** — built-in **Production** and **Test** System Views, plus your own **Custom Views** as pinned tabs. Duplicate, set as default, and share filters as a link.
-- **Review side panel** — clicking a row opens **Transcription / Scores / Details / Custom metrics** tabs in place.
-- **Diagnosis as a toggle group** — layer Conversation variables, Flows, Tool calls, Sources, Latency, Logs, and more independently on the Transcription tab. Choices persist as you move between conversations.
+- **Diagnosis toggle group** — debugging layers (tool calls, flows, variables, latency, logs, sources) are now independent toggles that persist as you move between conversations.
 
 See [Conversation review](/analytics/conversations/review), [Views](/analytics/conversations/views), and [Diagnosis](/analytics/conversations/diagnosis) for the full walkthrough.
 


### PR DESCRIPTION
…in 26.05

Combines the Voice/Webchat scopes bullet with the Review side panel bullet, and tightens the Diagnosis toggle group entry per the latest copy review.