### PR TITLE
docs(api-reference): add end-to-end quickstart and slick landing dash…

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,55 +1,351 @@
 ---
-title: 'Getting started'
-description: 'The three PolyAI API families, regional base URLs, authentication with API keys, and Conversations API versioning.'
+title: "API reference"
+sidebarTitle: "Overview"
+mode: "wide"
+description: "Build, run, and observe PolyAI agents from your own systems. Three API families, one platform, sub-300ms calls in production."
+keywords:
+  - API
+  - REST API
+  - PolyAI API
+  - getting started
+  - authentication
+  - endpoints
 ---
 
-Set up your API integration with PolyAI. Learn which API family to use, how to authenticate, and which version to pick for each integration.
+{/* ─────────────────────────  HERO  ───────────────────────── */}
 
-## API families at a glance
+<div style={{
+  position: 'relative',
+  margin: '0 0 2.5rem',
+  padding: '2.5rem 2rem',
+  borderRadius: '20px',
+  background: 'linear-gradient(135deg, #4a7c10 0%, #3a6b08 55%, #1f3a04 100%)',
+  color: '#f9faf3',
+  overflow: 'hidden',
+  boxShadow: '0 24px 60px -28px rgba(74, 124, 16, 0.45)',
+}}>
+  <div style={{
+    position: 'absolute',
+    top: '-40%',
+    right: '-10%',
+    width: '420px',
+    height: '420px',
+    background: 'radial-gradient(closest-side, rgba(217, 238, 80, 0.35), transparent 70%)',
+    pointerEvents: 'none',
+  }} />
+  <div style={{
+    position: 'absolute',
+    bottom: '-50%',
+    left: '-10%',
+    width: '380px',
+    height: '380px',
+    background: 'radial-gradient(closest-side, rgba(217, 238, 80, 0.18), transparent 70%)',
+    pointerEvents: 'none',
+  }} />
 
-PolyAI exposes three distinct API families, each with its own base URL pattern, auth model, and audience.
+  <div style={{ position: 'relative', maxWidth: '780px' }}>
+    <div style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+      padding: '0.35rem 0.8rem',
+      borderRadius: '999px',
+      background: 'rgba(217, 238, 80, 0.18)',
+      border: '1px solid rgba(217, 238, 80, 0.35)',
+      fontSize: '0.8rem',
+      fontWeight: 500,
+      letterSpacing: '0.04em',
+      textTransform: 'uppercase',
+      color: '#d9ee50',
+    }}>
+      <span style={{
+        width: '8px',
+        height: '8px',
+        borderRadius: '50%',
+        background: '#d9ee50',
+        boxShadow: '0 0 12px #d9ee50',
+      }} />
+      PolyAI Platform · API Reference
+    </div>
 
-| Family | What it's for | Base URL pattern | Examples |
-| ------ | ------------- | ---------------- | -------- |
-| **Build & deploy** | Programmatically build, configure, and ship agents | `api.{region}.poly.ai/v1/agents/…` | [Agents API](/api-reference/agents/introduction) |
-| **Runtime & data** | Runtime interaction with an agent and post-call data | `api.{region}.platform.polyai.app/{version}/…` | [Chat](/api-reference/chat/introduction), [Conversations](/api-reference/conversations/introduction), [Handoff](/api-reference/handoff/introduction), [Concurrent Calls](/api-reference/concurrent-calls/introduction), [DNI](/api-reference/dni/introduction), [External Events](/api-reference/external-events/introduction), [Outbound Calling](/api-reference/outbound/introduction) |
-| **Monitoring** | Observe, alert on, and receive events from running agents | `api.{region}.poly.ai/v1/…` | [Alerts](/api-reference/alerts/introduction), [Webhooks](/api-reference/webhooks/introduction) |
+    <h1 style={{
+      margin: '1rem 0 0.6rem',
+      fontSize: '2.6rem',
+      lineHeight: 1.1,
+      fontWeight: 700,
+      color: '#fff',
+    }}>
+      Build voice agents from code.
+    </h1>
 
-The **build & deploy** and **monitoring** families share the `poly.ai` host. The **runtime & data** family lives on `platform.polyai.app`. They are separate services with separate API keys.
+    <p style={{
+      margin: '0 0 1.6rem',
+      fontSize: '1.1rem',
+      lineHeight: 1.5,
+      color: 'rgba(255, 255, 255, 0.85)',
+      maxWidth: '640px',
+    }}>
+      Three REST API families cover the full lifecycle — ship agents, run conversations, and observe everything in production. No SDK required.
+    </p>
 
-### Agents API vs Conversations API
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+      <a href="/api-reference/quickstart" style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.7rem 1.2rem',
+        borderRadius: '12px',
+        background: '#d9ee50',
+        color: '#1f3a04',
+        fontWeight: 600,
+        textDecoration: 'none',
+        boxShadow: '0 8px 24px -8px rgba(217, 238, 80, 0.55)',
+      }}>
+        Quickstart →
+      </a>
+      <a href="#api-families" style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.7rem 1.2rem',
+        borderRadius: '12px',
+        background: 'rgba(255, 255, 255, 0.08)',
+        border: '1px solid rgba(255, 255, 255, 0.18)',
+        color: '#fff',
+        fontWeight: 500,
+        textDecoration: 'none',
+      }}>
+        Browse APIs
+      </a>
+      <a href="/api-reference/error-codes" style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        padding: '0.7rem 1.2rem',
+        borderRadius: '12px',
+        background: 'transparent',
+        border: '1px solid rgba(255, 255, 255, 0.18)',
+        color: 'rgba(255, 255, 255, 0.85)',
+        fontWeight: 500,
+        textDecoration: 'none',
+      }}>
+        Error codes
+      </a>
+    </div>
+  </div>
 
-The two are frequently confused. Use this table to pick the right one:
+  {/* Stat strip */}
+  <div style={{
+    position: 'relative',
+    marginTop: '2rem',
+    paddingTop: '1.4rem',
+    borderTop: '1px solid rgba(255, 255, 255, 0.12)',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+    gap: '1.2rem',
+  }}>
+    {[
+      { value: '3', label: 'API families' },
+      { value: '< 300ms', label: 'Median agent latency' },
+      { value: '24+', label: 'Languages' },
+      { value: '3', label: 'Regions: US · UK · EU' },
+    ].map((s) => (
+      <div key={s.label}>
+        <div style={{ fontSize: '1.6rem', fontWeight: 700, color: '#d9ee50' }}>{s.value}</div>
+        <div style={{ fontSize: '0.85rem', color: 'rgba(255, 255, 255, 0.7)', marginTop: '0.15rem' }}>{s.label}</div>
+      </div>
+    ))}
+  </div>
+</div>
 
-|                | Agents API                          | Conversations API                         |
-| -------------- | ----------------------------------- | ----------------------------------------- |
-| **Purpose**    | Build and deploy agents             | Read call data and transcripts            |
-| **Direction**  | Write (create, update, deploy)      | Read (query, retrieve)                    |
-| **Base URL**   | `api.{region}.poly.ai/v1/agents/…`  | `api.{region}.platform.polyai.app/v3/…`   |
-| **Auth**       | API key (workspace-scoped)          | API key (project-scoped)                  |
-| **Who uses it**| Developers automating agent builds  | Analysts, integrations pulling call data  |
+{/* ─────────────────────────  API FAMILIES  ───────────────────────── */}
 
-In short: **Agents API creates and ships agents. Conversations API tells you what those agents did on calls.**
+<h2 id="api-families" style={{ marginTop: '2.5rem', marginBottom: '0.25rem' }}>The three API families</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1.5rem' }}>
+  Pick the family that matches your job. Each has its own base URL, key, and audience.
+</p>
 
-## Base URLs
+<div style={{
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+  gap: '1.2rem',
+  marginBottom: '2.5rem',
+}}>
+  {/* Build & deploy */}
+  <a href="/api-reference/agents/introduction" style={{
+    display: 'block',
+    padding: '1.5rem',
+    borderRadius: '16px',
+    background: 'linear-gradient(160deg, rgba(74, 124, 16, 0.06), rgba(74, 124, 16, 0.01))',
+    border: '1px solid rgba(74, 124, 16, 0.18)',
+    textDecoration: 'none',
+    color: 'inherit',
+    transition: 'transform 160ms ease, box-shadow 160ms ease',
+  }}>
+    <div style={{
+      width: '44px',
+      height: '44px',
+      borderRadius: '12px',
+      background: '#4a7c10',
+      color: '#d9ee50',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '1.3rem',
+      marginBottom: '0.9rem',
+    }}>🛠️</div>
+    <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#4a7c10' }}>
+      Build & deploy
+    </div>
+    <h3 style={{ margin: '0.3rem 0 0.5rem', fontSize: '1.25rem' }}>Agents API</h3>
+    <p style={{ margin: '0 0 0.8rem', fontSize: '0.95rem', color: '#4b5563', lineHeight: 1.5 }}>
+      Programmatically create agents, edit behavior and knowledge, branch, and ship through environments.
+    </p>
+    <code style={{ fontSize: '0.78rem', color: '#3a6b08', background: 'rgba(74, 124, 16, 0.08)', padding: '0.2rem 0.5rem', borderRadius: '6px' }}>
+      api.{`{region}`}.poly.ai
+    </code>
+  </a>
 
-### Runtime and data APIs (regional)
+  {/* Runtime & data */}
+  <a href="/api-reference/conversations/introduction" style={{
+    display: 'block',
+    padding: '1.5rem',
+    borderRadius: '16px',
+    background: 'linear-gradient(160deg, rgba(56, 109, 191, 0.06), rgba(56, 109, 191, 0.01))',
+    border: '1px solid rgba(56, 109, 191, 0.2)',
+    textDecoration: 'none',
+    color: 'inherit',
+  }}>
+    <div style={{
+      width: '44px',
+      height: '44px',
+      borderRadius: '12px',
+      background: '#386dbf',
+      color: '#fff',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '1.3rem',
+      marginBottom: '0.9rem',
+    }}>⚡</div>
+    <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#386dbf' }}>
+      Runtime & data
+    </div>
+    <h3 style={{ margin: '0.3rem 0 0.5rem', fontSize: '1.25rem' }}>Conversations, Chat, Handoff…</h3>
+    <p style={{ margin: '0 0 0.8rem', fontSize: '0.95rem', color: '#4b5563', lineHeight: 1.5 }}>
+      Interact with running agents and read post-call data. Transcripts, audio, metrics, sessions.
+    </p>
+    <code style={{ fontSize: '0.78rem', color: '#244a86', background: 'rgba(56, 109, 191, 0.08)', padding: '0.2rem 0.5rem', borderRadius: '6px' }}>
+      api.{`{region}`}-1.platform.polyai.app
+    </code>
+  </a>
 
-The Conversations, Chat, Handoff, Concurrent Calls, DNI, External Events, and Outbound Calling APIs use regional base URLs:
+  {/* Monitoring */}
+  <a href="/api-reference/webhooks/introduction" style={{
+    display: 'block',
+    padding: '1.5rem',
+    borderRadius: '16px',
+    background: 'linear-gradient(160deg, rgba(180, 90, 30, 0.07), rgba(180, 90, 30, 0.01))',
+    border: '1px solid rgba(180, 90, 30, 0.2)',
+    textDecoration: 'none',
+    color: 'inherit',
+  }}>
+    <div style={{
+      width: '44px',
+      height: '44px',
+      borderRadius: '12px',
+      background: '#b45a1e',
+      color: '#fff',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '1.3rem',
+      marginBottom: '0.9rem',
+    }}>📡</div>
+    <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#b45a1e' }}>
+      Monitoring
+    </div>
+    <h3 style={{ margin: '0.3rem 0 0.5rem', fontSize: '1.25rem' }}>Alerts & Webhooks</h3>
+    <p style={{ margin: '0 0 0.8rem', fontSize: '0.95rem', color: '#4b5563', lineHeight: 1.5 }}>
+      Receive real-time events when calls complete, alerts fire, or handoffs happen. Stop polling.
+    </p>
+    <code style={{ fontSize: '0.78rem', color: '#7a3a10', background: 'rgba(180, 90, 30, 0.08)', padding: '0.2rem 0.5rem', borderRadius: '6px' }}>
+      api.{`{region}`}.poly.ai
+    </code>
+  </a>
+</div>
 
-| Region | Base URL |
-| ------ | -------- |
-| US     | `https://api.us-1.platform.polyai.app` |
-| UK     | `https://api.uk-1.platform.polyai.app` |
-| EUW    | `https://api.euw-1.platform.polyai.app` |
+{/* ─────────────────────────  COMMON TASKS  ───────────────────────── */}
 
-Most endpoints follow this pattern:
+<h2 style={{ marginTop: '2rem', marginBottom: '0.25rem' }}>I want to...</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1.5rem' }}>
+  Task-oriented entry points. Jump straight to a working example.
+</p>
 
-`https://api.{region}.platform.polyai.app/{version}/{account_id}/{project_id}/…`
+<CardGroup cols={2}>
+  <Card title="Make my first API call" icon="rocket" href="/api-reference/quickstart">
+    End-to-end how-to: key → list conversations → fetch transcript → audio → webhooks. ~15 min.
+  </Card>
+  <Card title="Pull conversation data" icon="database" href="/api-reference/conversations/introduction">
+    Query transcripts, metrics, and audio for analytics and compliance pipelines.
+  </Card>
+  <Card title="Build & deploy an agent" icon="hammer" href="/api-reference/agents/introduction">
+    Create agents, edit behavior and knowledge, promote sandbox → pre-release → live.
+  </Card>
+  <Card title="Get notified on events" icon="bell" href="/api-reference/webhooks/introduction">
+    Register a webhook endpoint and receive signed POSTs on conversation and handoff events.
+  </Card>
+  <Card title="Send a chat message" icon="comments" href="/api-reference/chat/introduction">
+    Drive a text-based conversation programmatically with create, respond, close.
+  </Card>
+  <Card title="Trigger an outbound call" icon="phone-arrow-up-right" href="/api-reference/outbound/introduction">
+    Place a programmatic outbound call to a target number and track its status.
+  </Card>
+</CardGroup>
+
+{/* ─────────────────────────  REGIONS / BASE URLS  ───────────────────────── */}
+
+<h2 style={{ marginTop: '2.5rem' }}>Pick your region</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1.25rem' }}>
+  Your key is provisioned to a region. The host differs by API family — the platform.polyai.app host carries a <code>-1</code> suffix, the poly.ai host doesn't.
+</p>
+
+<div style={{
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+  gap: '1rem',
+  marginBottom: '1.5rem',
+}}>
+  {[
+    { flag: '🇺🇸', region: 'US', runtime: 'api.us-1.platform.polyai.app', build: 'api.us.poly.ai' },
+    { flag: '🇬🇧', region: 'UK', runtime: 'api.uk-1.platform.polyai.app', build: 'api.uk.poly.ai' },
+    { flag: '🇪🇺', region: 'EU', runtime: 'api.euw-1.platform.polyai.app', build: 'api.eu.poly.ai' },
+  ].map((r) => (
+    <div key={r.region} style={{
+      padding: '1.1rem 1.2rem',
+      borderRadius: '14px',
+      border: '1px solid rgba(0,0,0,0.08)',
+      background: 'rgba(217, 238, 80, 0.04)',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.6rem' }}>
+        <span style={{ fontSize: '1.4rem' }}>{r.flag}</span>
+        <span style={{ fontWeight: 600, fontSize: '1rem' }}>{r.region}</span>
+      </div>
+      <div style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: '#386dbf', fontWeight: 600 }}>Runtime · data</div>
+      <code style={{ display: 'block', fontSize: '0.8rem', marginBottom: '0.6rem', wordBreak: 'break-all' }}>{r.runtime}</code>
+      <div style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: '#4a7c10', fontWeight: 600 }}>Build · monitoring</div>
+      <code style={{ display: 'block', fontSize: '0.8rem', wordBreak: 'break-all' }}>{r.build}</code>
+    </div>
+  ))}
+</div>
+
+<Warning>
+Do not use `https://api.poly.ai` without a region prefix — it returns an error. Always include the region.
+</Warning>
 
 ### Finding your `account_id` and `project_id`
 
-Your `account_id` and `project_id` are the first two path segments of your Agent Studio URL, immediately after the host:
+Your `account_id` and `project_id` are the first two path segments of your Agent Studio URL:
 
 ```
 https://studio.<region>.poly.ai/<account_id>/<project_id>/...
@@ -81,83 +377,12 @@ Both the slug form (visible in the URL) and the prefixed form are accepted in AP
   The `account_id` path parameter corresponds to the **workspace** in Agent Studio. Its prefixed form starts with `ws-` (for example `ws-fd112d8f`) — not `ACCOUNT-`. Older docs may still refer to the prefixed form as `ACCOUNT-xxxxxxx`; the value you see in Agent Studio (prefixed with `ws-`) is the correct one to use.
 </Note>
 
-The same identifiers are exposed inside Agent Studio functions as `conv.account_id` and `conv.project_id` — see the [Conversation object reference](/tools/classes/conv-object#account_id).
+{/* ─────────────────────────  AUTH  ───────────────────────── */}
 
-### Agents API, Alerts, and Webhooks
-
-The [Agents API](/api-reference/agents/introduction), [Alerts API](/api-reference/alerts/introduction), and [Webhooks API](/api-reference/webhooks/introduction) use a separate set of regional base URLs:
-
-| Region | Base URL |
-| ------ | -------- |
-| US     | `https://api.us.poly.ai` |
-| UK     | `https://api.uk.poly.ai` |
-| EU     | `https://api.eu.poly.ai` |
-
-Endpoint patterns:
-
-- Agents API: `https://api.{region}.poly.ai/v1/agents/…`
-- Alerts, Webhooks: `https://api.{region}.poly.ai/v1/…`
-
-<Warning>
-Do not use `https://api.poly.ai` without a region prefix – it will return an error. Always include the region (e.g. `api.us.poly.ai`).
-</Warning>
-
-## Conversations API versions
-
-Only the Conversations API is versioned. All other APIs are currently unversioned.
-
-### v3 – current and recommended
-
-v3 is the fully supported release of the Conversations API.
-It runs on PolyAI's event-sourced data platform and improves on v1 by offering:
-
-- reliable ingestion and querying at scale
-- empty strings ("") instead of `null` for empty text fields
-- additional turn-level fields such as `latency`, `translated_user_input` and `english_agent_response`
-- consistent ISO8601 timestamps across conversations, turns, and metrics
-
-Endpoint pattern:
-
-`https://api.{region}.platform.polyai.app/v3/{account_id}/{project_id}/conversations`
-
-<Tip>Most customers should use v3, the latest most performant version.</Tip>
-
-Authentication for v3 is managed by PolyAI.
-Ask your PolyAI representative to provision a v3 key and confirm the project and region it is scoped to.
-
-### v2
-
-v2 has the same schema as v3 but differs in authentication methods. Customers on v2 can continue using v2. New customers should use v3.
-
-### v1 – legacy
-
-v1 uses an earlier, less scalable data pipeline and the legacy auth model.
-
-Endpoint pattern:
-
-`https://api.{region}.platform.polyai.app/v1/{account_id}/{project_id}/conversations`
-
-#### Deprecation plan
-
-<Warning>
-**v1 Conversations API is scheduled for deprecation.**
-- **2 March 2026**: v1 moves to best-effort support (no SLA guarantees).
-- **31 August 2026**: v1 remains available but no support will be provided.
-
-Plan your migration to v3 before these dates.
-</Warning>
-
-### Which version should I use?
-
-- All new integrations should use v3.
-- Customers on v1 should plan their migration before support ends.
-- v2 is only relevant for maintaining existing legacy integrations.
-
-## Authentication
-
-PolyAI uses API keys for all externally exposed endpoints.
-
-Include your key using the `x-api-key` header:
+<h2 style={{ marginTop: '2.5rem' }}>Authenticate</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
+  Every PolyAI API uses an API key sent in the <code>x-api-key</code> header. Keys are provisioned by PolyAI — runtime and build keys are separate.
+</p>
 
 <CodeGroup>
 
@@ -180,25 +405,146 @@ data = response.json()
 ```typescript TypeScript
 const response = await fetch(
   "https://api.<region>.platform.polyai.app/v3/ws-xxxxxxxx/PROJECT-xxx/conversations",
-  {
-    headers: { "x-api-key": "YOUR_API_KEY" },
-  }
+  { headers: { "x-api-key": "YOUR_API_KEY" } },
 );
 const data = await response.json();
 ```
 
 </CodeGroup>
 
-### API key provisioning
+<div style={{
+  marginTop: '1rem',
+  padding: '1rem 1.25rem',
+  borderRadius: '12px',
+  background: 'rgba(217, 238, 80, 0.12)',
+  border: '1px solid rgba(74, 124, 16, 0.2)',
+  fontSize: '0.92rem',
+}}>
+  <strong>Key hygiene.</strong> Treat keys as secrets. Never commit or embed in client-side code. If a key leaks, contact PolyAI to rotate immediately.
+</div>
 
-- Legacy (v1/v2) keys
-  May already exist and follow a legacy authentication model.
+{/* ─────────────────────────  AGENTS VS CONVERSATIONS  ───────────────────────── */}
 
-- Conversations API v3 keys
-  Keys are provisioned by PolyAI.
+<h2 style={{ marginTop: '2.5rem' }}>Agents API vs. Conversations API</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
+  These two get confused most often. Use this table to pick the right one.
+</p>
 
-### Security notes
+|                  | Agents API                          | Conversations API                         |
+| ---------------- | ----------------------------------- | ----------------------------------------- |
+| **Purpose**      | Build and deploy agents             | Read call data and transcripts            |
+| **Direction**    | Write (create, update, deploy)      | Read (query, retrieve)                    |
+| **Base URL**     | `api.{region}.poly.ai/v1/agents/…`  | `api.{region}.platform.polyai.app/v3/…`   |
+| **Auth**         | API key (workspace-scoped)          | API key (project-scoped)                  |
+| **Who uses it**  | Developers automating agent builds  | Analysts, integrations pulling call data  |
 
-- Treat API keys as secrets.
-- Never embed keys in client-side code or commit them to source control.
-- If a key is exposed, contact PolyAI immediately so it can be rotated.
+In short: **Agents API creates and ships agents. Conversations API tells you what those agents did on calls.**
+
+{/* ─────────────────────────  VERSIONING  ───────────────────────── */}
+
+<h2 style={{ marginTop: '2.5rem' }}>Versioning</h2>
+
+Only the Conversations API is versioned today. Everything else is unversioned.
+
+<div style={{
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+  gap: '1rem',
+  margin: '1rem 0 1.5rem',
+}}>
+  <div style={{
+    padding: '1rem 1.2rem',
+    borderRadius: '14px',
+    border: '2px solid #4a7c10',
+    background: 'rgba(74, 124, 16, 0.05)',
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+      <strong style={{ fontSize: '1.1rem' }}>v3</strong>
+      <span style={{ fontSize: '0.7rem', fontWeight: 600, padding: '0.15rem 0.5rem', borderRadius: '999px', background: '#4a7c10', color: '#fff' }}>Recommended</span>
+    </div>
+    <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
+      Event-sourced, scalable, full schema with latency and translation fields. Use for all new integrations.
+    </p>
+  </div>
+  <div style={{
+    padding: '1rem 1.2rem',
+    borderRadius: '14px',
+    border: '1px solid rgba(0,0,0,0.1)',
+  }}>
+    <strong style={{ fontSize: '1.1rem' }}>v2</strong>
+    <p style={{ margin: '0.5rem 0 0', fontSize: '0.9rem', color: '#374151' }}>
+      Same schema as v3, legacy auth model. Continue if already integrated.
+    </p>
+  </div>
+  <div style={{
+    padding: '1rem 1.2rem',
+    borderRadius: '14px',
+    border: '1px solid rgba(180, 90, 30, 0.3)',
+    background: 'rgba(180, 90, 30, 0.04)',
+  }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
+      <strong style={{ fontSize: '1.1rem' }}>v1</strong>
+      <span style={{ fontSize: '0.7rem', fontWeight: 600, padding: '0.15rem 0.5rem', borderRadius: '999px', background: '#b45a1e', color: '#fff' }}>Sunsetting</span>
+    </div>
+    <p style={{ margin: 0, fontSize: '0.9rem', color: '#374151' }}>
+      Best-effort from 2 Mar 2026 · unsupported from 31 Aug 2026. Migrate to v3.
+    </p>
+  </div>
+</div>
+
+{/* ─────────────────────────  BROWSE  ───────────────────────── */}
+
+<h2 style={{ marginTop: '2.5rem' }}>Browse the catalog</h2>
+<p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
+  Every endpoint, grouped by API.
+</p>
+
+<CardGroup cols={3}>
+  <Card title="Agents" icon="hammer" href="/api-reference/agents/introduction" />
+  <Card title="Conversations v3" icon="comments" href="/api-reference/conversations/introduction" />
+  <Card title="Chat" icon="message" href="/api-reference/chat/introduction" />
+  <Card title="Data" icon="database" href="/api-reference/data/introduction" />
+  <Card title="Handoff" icon="people-arrows" href="/api-reference/handoff/introduction" />
+  <Card title="Outbound calling" icon="phone-arrow-up-right" href="/api-reference/outbound/introduction" />
+  <Card title="Concurrent calls" icon="gauge-high" href="/api-reference/concurrent-calls/introduction" />
+  <Card title="DNI" icon="hashtag" href="/api-reference/dni/introduction" />
+  <Card title="External events" icon="bolt" href="/api-reference/external-events/introduction" />
+  <Card title="Messaging" icon="paper-plane" href="/api-reference/messaging/introduction" />
+  <Card title="WebRTC gateway" icon="signal" href="/api-reference/webrtc-gateway/introduction" />
+  <Card title="Alerts" icon="bell" href="/api-reference/alerts/introduction" />
+  <Card title="Webhooks" icon="webhook" href="/api-reference/webhooks/introduction" />
+  <Card title="Error codes" icon="circle-exclamation" href="/api-reference/error-codes" />
+</CardGroup>
+
+{/* ─────────────────────────  HELP  ───────────────────────── */}
+
+<div style={{
+  marginTop: '2.5rem',
+  padding: '1.5rem 1.75rem',
+  borderRadius: '16px',
+  background: 'linear-gradient(135deg, rgba(74, 124, 16, 0.08), rgba(217, 238, 80, 0.12))',
+  border: '1px solid rgba(74, 124, 16, 0.15)',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1.2rem',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+}}>
+  <div>
+    <strong style={{ fontSize: '1.05rem' }}>Need a key or stuck on auth?</strong>
+    <p style={{ margin: '0.25rem 0 0', fontSize: '0.95rem', color: '#374151' }}>
+      v3 Conversations keys are provisioned by your PolyAI representative. Agents API access goes through <a href="mailto:developers@poly.ai">developers@poly.ai</a>.
+    </p>
+  </div>
+  <a href="mailto:developers@poly.ai" style={{
+    padding: '0.65rem 1.1rem',
+    borderRadius: '12px',
+    background: '#4a7c10',
+    color: '#fff',
+    textDecoration: 'none',
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+  }}>
+    Email developers@poly.ai
+  </a>
+</div>

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -1,0 +1,431 @@
+---
+title: "API quickstart"
+sidebarTitle: "Quickstart"
+description: "Make your first PolyAI API call, walk a real end-to-end integration, and subscribe to webhook events — in under 15 minutes."
+keywords:
+  - quickstart
+  - getting started
+  - first API call
+  - tutorial
+  - end to end
+  - integration
+---
+
+This guide takes you from an empty terminal to a working post-call data pipeline: pull yesterday's conversations, fetch one with full transcript and audio, and subscribe to a webhook so you don't have to poll. Every step uses real endpoints and copy-pasteable code.
+
+If you just want the conceptual map of the API families (Build & deploy vs. Runtime & data vs. Monitoring), read the [API overview](/api-reference/introduction) first. This page assumes you've picked the [Conversations](/api-reference/conversations/introduction) and [Webhooks](/api-reference/webhooks/introduction) APIs and want to ship.
+
+## What you'll build
+
+By the end of this guide you'll have:
+
+1. Authenticated against the PolyAI API
+2. Listed conversations from the last 24 hours
+3. Fetched a single conversation with its full turn-by-turn transcript
+4. Downloaded the audio recording for that call
+5. Registered a webhook endpoint so PolyAI pushes new conversations to you in real time
+
+Everything below uses the recommended Conversations API **v3** and the Webhooks API. Replace the placeholder values where indicated.
+
+## Prerequisites
+
+<Steps>
+  <Step title="Get an API key">
+    PolyAI provisions API keys — they aren't self-serve yet for runtime APIs.
+
+    - Ask your PolyAI representative for a **v3 Conversations API key** scoped to the project and region you want to query.
+    - The same key works for the [Data API](/api-reference/data/introduction), [Handoff](/api-reference/handoff/introduction), [Chat](/api-reference/chat/introduction), and other runtime APIs on the `platform.polyai.app` host.
+    - For the [Agents API](/api-reference/agents/introduction), [Alerts](/api-reference/alerts/introduction), and [Webhooks](/api-reference/webhooks/introduction), email [developers@poly.ai](mailto:developers@poly.ai) for a separate workspace-scoped key.
+
+    Treat the key like a password. Never commit it or embed it in client-side code.
+  </Step>
+
+  <Step title="Find your account ID and project ID">
+    Open Agent Studio. Your IDs are the first two segments of the URL after the host:
+
+    ```
+    https://studio.{region}.poly.ai/{account_id}/{project_id}/agent
+    ```
+
+    For example, `https://studio.uk.poly.ai/acme-uk/acme-team-4/agent` gives `account_id=acme-uk` and `project_id=acme-team-4`. Both the slug form and the prefixed form (`ws-xxxxxxxx`, `PROJECT-xxxxxxxx`) are valid in API paths. The `account_id` workspace prefix is `ws-`, not `ACCOUNT-`.
+  </Step>
+
+  <Step title="Pick the right base URL">
+    Runtime and data APIs live on regional hosts under `platform.polyai.app`. Match the region your project is provisioned in:
+
+    | Region | Base URL                                  |
+    | ------ | ----------------------------------------- |
+    | US     | `https://api.us-1.platform.polyai.app`    |
+    | UK     | `https://api.uk-1.platform.polyai.app`    |
+    | EUW    | `https://api.euw-1.platform.polyai.app`   |
+
+    <Warning>
+    The Webhooks API uses a different host family (`api.{region}.poly.ai`, no `-1` suffix). Don't mix them up — it's the most common source of 404s. See [base URLs](/api-reference/introduction#base-urls) for the full table.
+    </Warning>
+  </Step>
+
+  <Step title="Set environment variables">
+    Stash your key and IDs in environment variables so they stay out of code samples and source control.
+
+    ```bash
+    export POLYAI_API_KEY="your_api_key_here"
+    export POLYAI_BASE_URL="https://api.us-1.platform.polyai.app"
+    export POLYAI_ACCOUNT_ID="ws-xxxxxxxx"
+    export POLYAI_PROJECT_ID="PROJECT-xxxxxxxx"
+    ```
+
+    Every example below assumes these are set.
+  </Step>
+</Steps>
+
+## Step 1: Make your first call
+
+A quick smoke test confirms the key, IDs, region, and network path all line up. List a single conversation from the last 24 hours:
+
+<CodeGroup>
+
+```bash curl
+START=$(date -u -d "24 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+END=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+curl -X GET \
+  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations?start_time=$START&end_time=$END&limit=1" \
+  -H "x-api-key: $POLYAI_API_KEY"
+```
+
+```python Python
+import os
+from datetime import datetime, timedelta, timezone
+import requests
+
+base_url = os.environ["POLYAI_BASE_URL"]
+account_id = os.environ["POLYAI_ACCOUNT_ID"]
+project_id = os.environ["POLYAI_PROJECT_ID"]
+headers = {"x-api-key": os.environ["POLYAI_API_KEY"]}
+
+end = datetime.now(timezone.utc)
+start = end - timedelta(hours=24)
+
+response = requests.get(
+    f"{base_url}/v3/{account_id}/{project_id}/conversations",
+    headers=headers,
+    params={
+        "start_time": start.isoformat().replace("+00:00", "Z"),
+        "end_time": end.isoformat().replace("+00:00", "Z"),
+        "limit": 1,
+    },
+)
+response.raise_for_status()
+print(response.json())
+```
+
+```typescript TypeScript
+const baseUrl = process.env.POLYAI_BASE_URL!;
+const accountId = process.env.POLYAI_ACCOUNT_ID!;
+const projectId = process.env.POLYAI_PROJECT_ID!;
+const headers = { "x-api-key": process.env.POLYAI_API_KEY! };
+
+const end = new Date();
+const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+
+const params = new URLSearchParams({
+  start_time: start.toISOString(),
+  end_time: end.toISOString(),
+  limit: "1",
+});
+
+const res = await fetch(
+  `${baseUrl}/v3/${accountId}/${projectId}/conversations?${params}`,
+  { headers },
+);
+if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+console.log(await res.json());
+```
+
+</CodeGroup>
+
+A successful response returns a JSON object with a `conversations` array and a `cursor` field. If you get `401`, the key is wrong or missing. If you get `404`, the region host or IDs are wrong. See [troubleshooting](#troubleshooting) below.
+
+<Tip>
+No conversations in the last 24 hours? Place a test call against your sandbox agent — see [Quickstart > Test your agent](/get-started/quickstart) — and re-run the request.
+</Tip>
+
+## Step 2: Page through a full day of calls
+
+The smoke test used `limit=1`. For real workloads, use a larger `limit` and walk pages with the opaque `cursor` field. Cursors stay stable as new conversations arrive, so the iteration is safe to run during business hours.
+
+<CodeGroup>
+
+```python Python
+def iter_conversations(start, end, page_size=200):
+    cursor = None
+    while True:
+        params = {
+            "start_time": start,
+            "end_time": end,
+            "limit": page_size,
+            "client_env": "live",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        page = requests.get(
+            f"{base_url}/v3/{account_id}/{project_id}/conversations",
+            headers=headers,
+            params=params,
+        )
+        page.raise_for_status()
+        body = page.json()
+
+        for conv in body["conversations"]:
+            yield conv
+
+        cursor = body.get("cursor")
+        if not cursor:
+            return
+
+for conv in iter_conversations(start.isoformat(), end.isoformat()):
+    print(conv["id"], conv["num_turns"], conv["total_duration"])
+```
+
+```typescript TypeScript
+async function* iterConversations(startIso: string, endIso: string, pageSize = 200) {
+  let cursor: string | null = null;
+  do {
+    const params = new URLSearchParams({
+      start_time: startIso,
+      end_time: endIso,
+      limit: String(pageSize),
+      client_env: "live",
+    });
+    if (cursor) params.set("cursor", cursor);
+
+    const res = await fetch(
+      `${baseUrl}/v3/${accountId}/${projectId}/conversations?${params}`,
+      { headers },
+    );
+    if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+    const body = await res.json();
+
+    for (const conv of body.conversations) yield conv;
+    cursor = body.cursor;
+  } while (cursor);
+}
+
+for await (const conv of iterConversations(start.toISOString(), end.toISOString())) {
+  console.log(conv.id, conv.num_turns, conv.total_duration);
+}
+```
+
+</CodeGroup>
+
+<Tip>
+Use `client_env=live` (the default) for production traffic, `sandbox` for your test calls, or `pre-release` for staging. Mixing environments is a common source of "no results" confusion.
+</Tip>
+
+## Step 3: Fetch one conversation with its transcript
+
+The list response includes per-conversation summaries plus the `turns` array — but if you want a single conversation in detail, hit the by-ID endpoint:
+
+<CodeGroup>
+
+```bash curl
+curl -X GET \
+  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations/CONVERSATION_ID" \
+  -H "x-api-key: $POLYAI_API_KEY"
+```
+
+```python Python
+conv_id = "your_conversation_id"
+res = requests.get(
+    f"{base_url}/v3/{account_id}/{project_id}/conversations/{conv_id}",
+    headers=headers,
+)
+res.raise_for_status()
+conv = res.json()
+
+for turn in conv["turns"]:
+    speaker = "USER " if turn["user_input"] else "AGENT"
+    text = turn["user_input"] or turn["agent_response"]
+    print(f"{turn['user_input_datetime']}  {speaker}  {text}")
+```
+
+```typescript TypeScript
+const convId = "your_conversation_id";
+const convRes = await fetch(
+  `${baseUrl}/v3/${accountId}/${projectId}/conversations/${convId}`,
+  { headers },
+);
+const conv = await convRes.json();
+
+for (const turn of conv.turns) {
+  const speaker = turn.user_input ? "USER " : "AGENT";
+  const text = turn.user_input || turn.agent_response;
+  console.log(`${turn.user_input_datetime}  ${speaker}  ${text}`);
+}
+```
+
+</CodeGroup>
+
+See the [conversation object reference](/api-reference/conversations/introduction#response-structure) for the full field list (latency metrics, intents, entities, handoff metadata, translation outputs).
+
+<Warning>
+If `num_turns > 0` but `turns` is empty, transcript visibility is disabled at the project level. Open **API Keys > Configuration** on the workspace homepage and enable **Conversation transcript**. See [transcript visibility](/api-reference/conversations/introduction#transcript-visibility) for the full diagnosis.
+</Warning>
+
+## Step 4: Download the audio recording
+
+Voice calls have an audio recording, fetched via a separate endpoint. The response is a binary stream — write it to disk or pipe it to your storage.
+
+<CodeGroup>
+
+```bash curl
+curl -X GET \
+  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations/CONVERSATION_ID/audio" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  --output conversation.wav
+```
+
+```python Python
+res = requests.get(
+    f"{base_url}/v3/{account_id}/{project_id}/conversations/{conv_id}/audio",
+    headers=headers,
+    stream=True,
+)
+res.raise_for_status()
+
+with open(f"{conv_id}.wav", "wb") as f:
+    for chunk in res.iter_content(chunk_size=1 << 14):
+        f.write(chunk)
+```
+
+```typescript TypeScript
+const audioRes = await fetch(
+  `${baseUrl}/v3/${accountId}/${projectId}/conversations/${convId}/audio`,
+  { headers },
+);
+if (!audioRes.ok) throw new Error(`${audioRes.status}`);
+
+import { writeFile } from "node:fs/promises";
+const buf = Buffer.from(await audioRes.arrayBuffer());
+await writeFile(`${convId}.wav`, buf);
+```
+
+</CodeGroup>
+
+Recordings are only generated for voice channels (`VOICE-SIP`). Chat conversations (`WEBCHAT`, `CHAT`) return `404` on this endpoint — filter on `channel` before calling.
+
+## Step 5: Stop polling, subscribe to webhooks
+
+Polling the list endpoint every few minutes works, but it wastes requests and adds lag. PolyAI can push a JSON payload to a URL of yours every time a call ends, an alert fires, or a handoff happens. Set it up once and your pipeline becomes event-driven.
+
+The Webhooks API lives on the `poly.ai` host family — base URL changes:
+
+```bash
+export POLYAI_PLATFORM_URL="https://api.us.poly.ai"  # not us-1
+```
+
+### Register an endpoint
+
+<CodeGroup>
+
+```bash curl
+curl -X POST "$POLYAI_PLATFORM_URL/v1/webhooks/endpoints" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://your-service.example.com/polyai-events",
+    "description": "Post-call ingestion",
+    "events": ["conversation.completed", "handoff.created"]
+  }'
+```
+
+```python Python
+res = requests.post(
+    f"{os.environ['POLYAI_PLATFORM_URL']}/v1/webhooks/endpoints",
+    headers={**headers, "Content-Type": "application/json"},
+    json={
+        "url": "https://your-service.example.com/polyai-events",
+        "description": "Post-call ingestion",
+        "events": ["conversation.completed", "handoff.created"],
+    },
+)
+res.raise_for_status()
+endpoint = res.json()
+print(endpoint["id"], endpoint["signing_secret"])
+```
+
+</CodeGroup>
+
+Store the `signing_secret` securely — you'll need it to verify every incoming request.
+
+### Verify the signature
+
+PolyAI signs each delivery with HMAC-SHA256 in the `X-PolyAI-Signature` header. Reject any request whose signature doesn't match.
+
+```python Python
+import hashlib
+import hmac
+from flask import Flask, request, abort
+
+app = Flask(__name__)
+SIGNING_SECRET = os.environ["POLYAI_WEBHOOK_SECRET"].encode()
+
+@app.post("/polyai-events")
+def handle():
+    body = request.get_data()
+    sig = request.headers.get("X-PolyAI-Signature", "")
+
+    expected = hmac.new(SIGNING_SECRET, body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        abort(401)
+
+    event = request.get_json()
+    if event["type"] == "conversation.completed":
+        process_conversation(event["data"]["conversation_id"])
+    return "", 204
+```
+
+Respond with a 2xx status within 5 seconds. PolyAI retries on non-2xx responses with exponential backoff — keep the handler thin and offload work to a queue. See the [Webhooks API](/api-reference/webhooks/introduction) for the full event catalog, retry semantics, and signing-secret rotation.
+
+## Step 6: Promote from sandbox to live
+
+You probably built and tested against your sandbox environment. To run against production traffic, change one parameter:
+
+```python
+params["client_env"] = "live"  # was "sandbox" or "pre-release"
+```
+
+Webhook endpoints fire across all environments by default. If you only want production events, filter on `data.environment == "live"` in your handler, or register separate endpoints per environment.
+
+## Troubleshooting
+
+| Symptom                                        | Likely cause                                                                                       | Fix                                                                                                                  |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `401 Unauthorized`                             | Missing or wrong `x-api-key` header, or key revoked.                                               | Check the env var is set; ask PolyAI to confirm the key is active.                                                   |
+| `403 Forbidden`                                | Key is valid but lacks permission for this project or scope.                                       | Confirm the key was provisioned for the project ID in the URL.                                                       |
+| `404 Not Found` on conversations endpoint      | Wrong base URL (most often `api.us.poly.ai` instead of `api.us-1.platform.polyai.app`).            | Use the `platform.polyai.app` host with the regional `-1` suffix for runtime/data APIs.                              |
+| `404 Not Found` on webhooks endpoint           | You hit the runtime host. Webhooks live on `api.{region}.poly.ai`.                                 | Use `api.us.poly.ai` (no `-1`) for Agents, Alerts, Webhooks.                                                          |
+| Empty `conversations` array                    | Time window has no calls, or wrong `client_env` (live vs. sandbox).                                | Place a test call, widen the time window, or set `client_env=sandbox`.                                               |
+| `turns` is empty but `num_turns > 0`           | Transcript visibility is off at the project level.                                                 | Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio.                               |
+| `429 Too Many Requests`                        | You hit the rate limit.                                                                            | Back off using the `Retry-After` header; switch from offset to cursor pagination for large pulls.                    |
+| Webhook handler never fires                    | Endpoint not yet active, or signature verification rejecting valid requests.                       | Hit your handler URL directly; log the request body and computed signature; confirm the secret matches what you saved. |
+
+For the full error-code reference, see [Error codes](/api-reference/error-codes).
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="API overview" icon="map" href="/api-reference/introduction">
+    The three API families, base URLs, and version policy.
+  </Card>
+  <Card title="Conversations API reference" icon="comments" href="/api-reference/conversations/introduction">
+    Full schema, retrieval modes, pagination, and streaming.
+  </Card>
+  <Card title="Agents API" icon="hammer" href="/api-reference/agents/introduction">
+    Build and deploy agents programmatically.
+  </Card>
+  <Card title="Webhooks API" icon="bell" href="/api-reference/webhooks/introduction">
+    Event types, retries, and signature verification in depth.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -636,6 +636,7 @@
             "group": "API reference",
             "pages": [
               "api-reference/introduction",
+              "api-reference/quickstart",
               "api-reference/error-codes"
             ]
           },


### PR DESCRIPTION
…board

- New api-reference/quickstart.mdx walks devs from key → list → fetch transcript → audio → webhooks in ~15 min, with curl/Python/ TypeScript samples and a troubleshooting table.
- Redesigned api-reference/introduction.mdx (mode: wide) as a visual landing dashboard: gradient hero with stat strip, three colour-coded API-family cards, task-oriented 'I want to...' grid, region picker, auth snippet, agents-vs-conversations table, versioning callouts, full catalog grid, and a help banner.
- Wired the new quickstart into the API reference nav group in docs.json (between introduction and error-codes).
- Aligned all account_id placeholders on the corrected ws-xxxxxxxx workspace prefix (not ACCOUNT-xxx).