### PR TITLE
docs: remove marketing copy from homepage

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -25,8 +25,6 @@ keywords:
 
 PolyAI is the Agentic Dialog Platform for building voice and chat agents that complete real customer tasks — taking bookings, processing payments, filing claims, handling escalations — across 24+ languages, with sub-300ms responses.
 
-It's the same platform behind production agents at major banks, hotels, and healthcare providers — environments where accuracy and compliance are non-negotiable.
-
 - **Built for resolution, not deflection.** [Raven](/agent-settings/raven), [flows](/flows/introduction), and [grounded knowledge](/managed-topics/introduction) work together so the agent finishes the task.
 - **Voice-first and multilingual.** Sub-300ms responses across 24+ languages.
 - **Three surfaces for the same agent.** [Agent Studio](/get-started/introduction) for visual configuration, the [ADK](/extend/adk) for a local Git-based workflow, and the [REST APIs](/api-reference/introduction) for programmatic control.


### PR DESCRIPTION
## Summary
- Removes the sentence "It's the same platform behind production agents at major banks, hotels, and healthcare providers — environments where accuracy and compliance are non-negotiable." from the homepage intro.

## Test plan
- [ ] Verify homepage renders correctly without the removed line

🤖 Generated with [Claude Code](https://claude.com/claude-code)