### PR TITLE
docs: add Outbound SMS API, rename messaging/SMS/integrations paths

### DIFF
--- a/api-reference/outbound-sms/endpoint/send-sms.mdx
+++ b/api-reference/outbound-sms/endpoint/send-sms.mdx
@@ -1,0 +1,136 @@
+---
+title: 'Send an outbound SMS'
+api: 'POST /v1/outbound-sms'
+description: 'Send an SMS message and create a reply-enabled conversation session.'
+---
+
+Sends an SMS message to the specified user number and opens a new conversation session. The message behaves like a greeting message, so it is fully part of the conversation context that the agent can access. If the user replies, the agent handles the conversation as a normal SMS session.
+
+<Warning>
+It is your responsibility to ensure that messages are sent in compliance with applicable laws and regulations, including [A2P 10DLC registration](/voice-channel/message-templates#a2p-10dlc-registration-us-and-canada) for US and Canadian numbers.
+</Warning>
+
+## Request
+
+### Headers
+
+<ParamField header="X-PolyAi-Auth-Token" type="string" required>
+  Your PolyAI API key, provisioned in the **API keys** tab under your account section in Agent Studio.
+</ParamField>
+
+<ParamField header="X-TOKEN-ID" type="string" required>
+  Connector ID for the target project. Contact your PolyAI representative.
+</ParamField>
+
+<ParamField header="Content-Type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+### Body
+
+<ParamField body="message" type="string">
+  The plain-text message to send to the user.
+</ParamField>
+
+<ParamField body="user_number" type="string" required>
+  Recipient phone number in E.164 format (e.g. `+14155551234`).
+</ParamField>
+
+<ParamField body="agent_number" type="string">
+  Sender phone number in E.164 format. Must be one of the Twilio numbers provisioned for your project. If omitted, the API picks one automatically from the numbers available for the connector token's environment.
+</ParamField>
+
+## Response
+
+| Status | Description |
+| ------ | ----------- |
+| `202 Accepted` | Message will be sent and a conversation session will be created. |
+| `400 Bad Request` | Invalid body, missing fields, bad E.164 format, or `agent_number` not provisioned for the project. |
+| `401 Unauthorized` | Missing or invalid `X-PolyAi-Auth-Token`. |
+| `403 Forbidden` | API key account does not match the connector's account. |
+| `404 Not Found` | Connector not found, or no Twilio numbers provisioned for this project. |
+| `429 Too Many Requests` | Per-project rate limit exceeded. |
+| `500 Internal Server Error` | Unexpected server error. |
+
+The `202` response has an empty body.
+
+## Example
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.us-1.platform.polyai.app/v1/outbound-sms \
+  -H "X-PolyAi-Auth-Token: YOUR_API_KEY" \
+  -H "X-TOKEN-ID: YOUR_CONNECTOR_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Hi Jane, your appointment is confirmed for tomorrow at 2pm. Reply to this message if you need to reschedule.",
+    "user_number": "+14155551234"
+  }'
+```
+
+```python Python
+import requests
+
+url = "https://api.us-1.platform.polyai.app/v1/outbound-sms"
+headers = {
+    "X-PolyAi-Auth-Token": "YOUR_API_KEY",
+    "X-TOKEN-ID": "YOUR_CONNECTOR_ID",
+    "Content-Type": "application/json",
+}
+payload = {
+    "message": "Hi Jane, your appointment is confirmed for tomorrow at 2pm. Reply to this message if you need to reschedule.",
+    "user_number": "+14155551234",
+}
+
+response = requests.post(url, json=payload, headers=headers)
+print(response.status_code)  # 202
+```
+
+```javascript JavaScript
+const response = await fetch(
+  'https://api.us-1.platform.polyai.app/v1/outbound-sms',
+  {
+    method: 'POST',
+    headers: {
+      'X-PolyAi-Auth-Token': 'YOUR_API_KEY',
+      'X-TOKEN-ID': 'YOUR_CONNECTOR_ID',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      message:
+        'Hi Jane, your appointment is confirmed for tomorrow at 2pm. Reply to this message if you need to reschedule.',
+      user_number: '+14155551234',
+    }),
+  }
+);
+
+console.log(response.status); // 202
+```
+
+</CodeGroup>
+
+This can lead to a conversation like:
+
+| Direction | Message |
+| --------- | ------- |
+| **Agent →** | Hi Jane, your appointment is confirmed for tomorrow at 2pm. Reply to this message if you need to reschedule. |
+| **← User** | Can I move it to 3pm instead? |
+| **Agent →** | Of course — I've rescheduled your appointment to 3pm tomorrow. See you then! |
+
+## Error response format
+
+All error responses return a JSON object:
+
+```json
+{
+  "detail": "A human-readable description of the error."
+}
+```
+
+## Notes
+
+- **Agent number selection** — by default the API picks from the Twilio numbers provisioned for your project for the environment linked to the connector token. Pass `agent_number` to override; it must be one of the provisioned numbers or the request is rejected with a `400`.
+- **Rate limits** are applied per project. If you hit a `429`, back off and retry.
+- **Inactivity timeout** — if the conversation is engaged (the user has replied), after 24 hours of inactivity a warning message is sent. If the user replies within 10 minutes, the conversation stays open and a new 24-hour inactivity timer starts. Otherwise the session terminates.
+- **Number availability** — not every country supports SMS. Check [Number availability & compliance](/voice-channel/number-availability) for country-by-country details, throughput limits, and regulatory links before sending to a new region.

--- a/api-reference/outbound-sms/introduction.mdx
+++ b/api-reference/outbound-sms/introduction.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Outbound SMS API'
+sidebarTitle: 'Overview'
+description: 'Send SMS messages to end users and open reply-enabled conversation sessions.'
+---
+
+The Outbound SMS API lets you programmatically send SMS messages to end users through your PolyAI agent. Each request creates a new conversation session — the agent delivers the message via Twilio and can handle any replies from the user.
+
+## Prerequisites
+
+- An API key provisioned via Agent Studio — create one in the **API keys** tab under your account section (passed as `X-PolyAi-Auth-Token`)
+- A connector ID for the target project (passed as `X-TOKEN-ID`). Contact your PolyAI representative.
+- At least one Twilio phone number provisioned for the project. The API automatically selects from the project's available numbers for the token's environment (dev, sandbox, live) unless you specify one via `agent_number`.
+
+## Base URL
+
+Replace `<cluster>` with the region for your deployment:
+
+| Cluster | Region | Base URL |
+| ------- | ------ | -------- |
+| `us-1`  | United States | `https://api.us-1.platform.polyai.app` |
+| `uk-1`  | United Kingdom | `https://api.uk-1.platform.polyai.app` |
+| `euw-1` | EU West | `https://api.euw-1.platform.polyai.app` |
+
+## Authentication
+
+All requests require two headers for authentication:
+
+```bash
+curl -X POST https://api.<cluster>.platform.polyai.app/v1/outbound-sms \
+  -H "X-PolyAi-Auth-Token: YOUR_API_KEY" \
+  -H "X-TOKEN-ID: YOUR_CONNECTOR_ID" \
+  -H "Content-Type: application/json"
+```
+
+## How it works
+
+1. **Send message** — POST to `/v1/outbound-sms` with the recipient number and message text.
+2. **Session created** — The API creates a new conversation session. The message behaves like a greeting message, so it is fully part of the conversation context that the agent can access.
+3. **User replies** — If the user replies, the agent handles the conversation as a normal SMS session.
+4. **Inactivity timeout** — If the conversation is engaged (the user has replied) and goes idle for 24 hours, a warning message is sent. If the user replies within 10 minutes the session stays open; otherwise it terminates.
+
+## Agent number selection
+
+By default the API picks from the Twilio numbers provisioned for the connector token's environment. You can override this by passing `agent_number` in the request body — the number must be one of the provisioned numbers or the request is rejected with a `400`.
+
+## Number availability & compliance
+
+Not every country supports SMS, and the number type you use affects throughput, cost, and lead time. Before sending outbound SMS in a new country, check [Number availability & compliance](/voice-channel/number-availability) for country-by-country details, regulatory links, and the [A2P Campaign Pre-Scanner](https://www.a2pcheck.com/) to validate your setup against carrier requirements.
+
+For US and Canadian numbers, [A2P 10DLC registration](/voice-channel/message-templates#a2p-10dlc-registration-us-and-canada) is required — carriers block messages entirely without it.
+
+## Rate limits
+
+Rate limits are applied per project. If you receive a `429`, back off and retry with exponential backoff.

--- a/docs.json
+++ b/docs.json
@@ -303,8 +303,8 @@
               {
                 "group": "SMS",
                 "pages": [
-                  "sms/introduction",
-                  "sms/number-availability"
+                  "voice-channel/message-templates",
+                  "voice-channel/number-availability"
                 ]
               },
               {
@@ -380,9 +380,10 @@
               {
                 "group": "Chat",
                 "pages": [
-                  "webchat/introduction",
-                  "webchat/chat-configuration",
-                  "webchat/multichannel"
+                  "messaging-channel/introduction",
+                  "messaging-channel/advanced/chat-configuration",
+                  "messaging-channel/multichannel",
+                  "messaging-channel/ios-sdk"
                 ]
               },
               {
@@ -428,7 +429,7 @@
               {
                 "group": "APIs",
                 "pages": [
-                  "api/introduction"
+                  "integrations/api/introduction"
                 ]
               },
               {
@@ -864,6 +865,13 @@
             ]
           },
           {
+            "group": "Outbound SMS API",
+            "pages": [
+              "api-reference/outbound-sms/introduction",
+              "api-reference/outbound-sms/endpoint/send-sms"
+            ]
+          },
+          {
             "group": "Webhooks API",
             "pages": [
               "api-reference/webhooks/introduction",
@@ -1124,6 +1132,30 @@
     }
   },
   "redirects": [
+    {
+      "source": "/webchat/introduction",
+      "destination": "/messaging-channel/introduction"
+    },
+    {
+      "source": "/webchat/chat-configuration",
+      "destination": "/messaging-channel/advanced/chat-configuration"
+    },
+    {
+      "source": "/webchat/multichannel",
+      "destination": "/messaging-channel/multichannel"
+    },
+    {
+      "source": "/sms/introduction",
+      "destination": "/voice-channel/message-templates"
+    },
+    {
+      "source": "/sms/number-availability",
+      "destination": "/voice-channel/number-availability"
+    },
+    {
+      "source": "/api/introduction",
+      "destination": "/integrations/api/introduction"
+    },
     {
       "source": "/introduction/what-is-polyai-jupiter",
       "destination": "/home"

--- a/integrations/api/introduction.mdx
+++ b/integrations/api/introduction.mdx
@@ -19,7 +19,7 @@ This page covers custom API integrations configured in the **APIs** tab in Agent
 
 ![api-tab](/images/api/api-tab-create.png)
 
-The **APIs** tab (under **Configure** in the Agent Studio sidebar) provides:
+The **APIs** tab (in the **Integrations** section of the Agent Studio sidebar) provides:
 - A shared, inspectable API definition
 - [Environment-specific](/environments-and-versions/introduction) base URLs
 - A consistent calling interface inside [`conv.api`](/tools/classes/conv-api)

--- a/integrations/chat/amazon-connect.mdx
+++ b/integrations/chat/amazon-connect.mdx
@@ -6,7 +6,7 @@ description: "Hand off a webchat or SMS conversation from PolyAI to an Amazon Co
 
 Hand off a live webchat or SMS conversation from your PolyAI agent to an Amazon Connect chat agent. PolyAI calls the Connect [`StartChatContact`](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) API and then proxies messages between the end user and the Connect agent for the rest of the session.
 
-<Note>This integration is available from **Configure > Integrations > Amazon Connect** in Agent Studio. For voice routing into the same Connect instance, see the [Amazon Connect voice integration](/integrations/voice/amazon-connect/amazon-connect).</Note>
+<Note>This integration is available from **Integrations > Amazon Connect** in Agent Studio. For voice routing into the same Connect instance, see the [Amazon Connect voice integration](/integrations/voice/amazon-connect/amazon-connect).</Note>
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ Hand off a live webchat or SMS conversation from your PolyAI agent to an Amazon 
 
 ## 2. Connect from Studio
 
-In Agent Studio, open **Configure > Integrations** and click **Connect** on the **Amazon Connect** tile. Paste:
+In Agent Studio, open **Integrations** and click **Connect** on the **Amazon Connect** tile. Paste:
 
 | Field | Required | Description |
 |---|---|---|

--- a/integrations/chat/introduction.mdx
+++ b/integrations/chat/introduction.mdx
@@ -6,7 +6,7 @@ description: "Hand off webchat and SMS conversations from your PolyAI agent to a
 
 Use a chat handoff integration to escalate a webchat or SMS conversation from your PolyAI agent to a live agent in your existing CCaaS or CRM. PolyAI continues to proxy messages between the end user and the live agent, so the conversation stays in the same widget the user started in.
 
-<Note>All chat handoff integrations are configured from **Configure > Integrations** in Agent Studio. The handoff is triggered from a Python tool returning a `handoff` payload, then assigned to the Knowledge topic (or flow step) that should escalate.</Note>
+<Note>All chat handoff integrations are configured from **Integrations** in Agent Studio. The handoff is triggered from a Python tool returning a `handoff` payload, then assigned to the Knowledge topic (or flow step) that should escalate.</Note>
 
 ## Available integrations
 
@@ -34,7 +34,7 @@ Use a chat handoff integration to escalate a webchat or SMS conversation from yo
 ## How it works
 
 1. **Set up the integration on the CCaaS or CRM side.** Each platform expects a webhook, channel, or messaging app to be created so PolyAI has a place to deliver the conversation.
-2. **Connect from Studio.** Go to **Configure > Integrations**, click **Connect** on the relevant tile, and paste the IDs and secrets generated in step 1.
+2. **Connect from Studio.** Go to **Integrations**, click **Connect** on the relevant tile, and paste the IDs and secrets generated in step 1.
 3. **Write a handoff function.** Return a structured `handoff` payload from a Python tool – the payload tells PolyAI which integration to hand off to.
 4. **Assign the function to a topic.** Add the tool to the Knowledge topic (or flow step) that should trigger the handoff. When that topic fires, PolyAI announces the transfer, sends the conversation to the live agent, and continues to proxy turns.
 

--- a/integrations/chat/nice-cxone.mdx
+++ b/integrations/chat/nice-cxone.mdx
@@ -6,7 +6,7 @@ description: "Hand off a webchat or SMS conversation from PolyAI to a NICE CXone
 
 Hand off a live webchat or SMS conversation from your PolyAI agent to a NICE CXone agent through a Digital messaging channel. PolyAI continues to proxy messages between the end user and the CXone agent.
 
-<Note>This integration is available from **Configure > Integrations > NICE CXone Messaging** in Agent Studio.</Note>
+<Note>This integration is available from **Integrations > NICE CXone Messaging** in Agent Studio.</Note>
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ Configure routing on the CXone side (queues, skills, agent assignments) the way 
 
 ## 2. Connect from Studio
 
-In Agent Studio, open **Configure > Integrations** and click **Connect** on the **NICE CXone Messaging** tile. Paste the values from the CXone channel configuration.
+In Agent Studio, open **Integrations** and click **Connect** on the **NICE CXone Messaging** tile. Paste the values from the CXone channel configuration.
 
 ## 3. Write the handoff function
 
@@ -51,7 +51,7 @@ The same function can be called from any flow step or directly via `conv.call_ha
 3. Reply from CXone and confirm the message is delivered back to the user inside the same widget.
 4. End the session from CXone and confirm the widget shows the conversation as closed.
 
-If the conversation never reaches CXone, double-check **Configure > Integrations > NICE CXone Messaging** for connection errors, and verify the Brand ID, Channel ID, and Environment match the channel you opened in step 1.
+If the conversation never reaches CXone, double-check **Integrations > NICE CXone Messaging** for connection errors, and verify the Brand ID, Channel ID, and Environment match the channel you opened in step 1.
 
 ## Related pages
 

--- a/integrations/chat/salesforce.mdx
+++ b/integrations/chat/salesforce.mdx
@@ -6,7 +6,7 @@ description: "Hand off a webchat or SMS conversation from PolyAI to a Salesforce
 
 Hand off a live webchat or SMS conversation from your PolyAI agent to a Salesforce Service Cloud Messaging agent. PolyAI continues to proxy messages between the end user and the Salesforce agent for the rest of the session, so the user stays in the same widget.
 
-<Note>This integration is available from **Configure > Integrations > Salesforce Messaging** in Agent Studio.</Note>
+<Note>This integration is available from **Integrations > Salesforce Messaging** in Agent Studio.</Note>
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ For broader Salesforce CRM access (case lookup, account data), see the [Salesfor
 
 ## 2. Connect from Studio
 
-In Agent Studio, open **Configure > Integrations** and click **Connect** on the **Salesforce Messaging** tile. Paste the credentials and IDs from your Connected App and Messaging channel setup.
+In Agent Studio, open **Integrations** and click **Connect** on the **Salesforce Messaging** tile. Paste the credentials and IDs from your Connected App and Messaging channel setup.
 
 ## 3. Write the handoff function
 
@@ -59,7 +59,7 @@ You can call the same function from a flow step or directly via `conv.call_hando
 3. Reply from Salesforce and confirm the message is delivered back to the user inside the original widget.
 4. End the session from the Salesforce side and confirm the widget shows the conversation as closed.
 
-If nothing arrives in Salesforce, check **Configure > Integrations > Salesforce Messaging** for connection errors, and confirm the Connected App is approved for the user PolyAI is authenticating as.
+If nothing arrives in Salesforce, check **Integrations > Salesforce Messaging** for connection errors, and confirm the Connected App is approved for the user PolyAI is authenticating as.
 
 ## Related pages
 

--- a/integrations/chat/webex.mdx
+++ b/integrations/chat/webex.mdx
@@ -22,7 +22,7 @@ PolyAI connects to Webex Contact Center through the [Bring Your Own Channel](htt
 
 ## 2. Connect from Studio
 
-In Agent Studio, open **Configure > Integrations** and click **Connect** on the **Webex Messaging** tile. Paste the values you recorded in step 1.
+In Agent Studio, open **Integrations** and click **Connect** on the **Webex Messaging** tile. Paste the values you recorded in step 1.
 
 ## 3. Write the handoff function
 

--- a/integrations/chat/zendesk.mdx
+++ b/integrations/chat/zendesk.mdx
@@ -6,7 +6,7 @@ description: "Hand off a webchat or SMS conversation from PolyAI to a Zendesk Me
 
 Hand off a live webchat or SMS conversation from your PolyAI agent to a Zendesk Messaging agent. PolyAI continues to proxy messages between the end user and the Zendesk agent for the rest of the session.
 
-<Note>This integration is available from **Configure > Integrations > Zendesk Messaging** in Agent Studio. For ticketing-only flows (no live messaging), see [Zendesk Ticketing](/integrations/zendesk-ticketing-solutions).</Note>
+<Note>This integration is available from **Integrations > Zendesk Messaging** in Agent Studio. For ticketing-only flows (no live messaging), see [Zendesk Ticketing](/integrations/zendesk-ticketing-solutions).</Note>
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ This standalone webhook lets PolyAI react to ticket status changes (e.g. when a 
 
 ## 3. Connect from Studio
 
-In Agent Studio, open **Configure > Integrations** and click **Connect** on the **Zendesk Messaging** tile. Paste:
+In Agent Studio, open **Integrations** and click **Connect** on the **Zendesk Messaging** tile. Paste:
 
 - **App ID**, **Integration ID**, **Webhook ID**, **Shared secret** (from the Conversations Integration).
 - **Webhook secret key** (from the Ticket Status Webhook).

--- a/integrations/gladly.mdx
+++ b/integrations/gladly.mdx
@@ -5,7 +5,7 @@ description: "Connect your PolyAI agent to Gladly for real-time knowledge access
 
 Connect PolyAI to your **Gladly Knowledge Base** so your agent uses the same content as your human agents. Updates in Gladly automatically sync to PolyAI conversations.
 
-<Note>This integration is available from **Configure > Integrations** in Agent Studio under **Knowledge**.</Note>
+<Note>This integration is available from **Integrations** in Agent Studio under **Knowledge**.</Note>
 
 ## Obtaining your Gladly credentials
 

--- a/integrations/hotSOS.mdx
+++ b/integrations/hotSOS.mdx
@@ -7,7 +7,7 @@ description: "Automate room service and maintenance requests with HotSOS and Pol
 
 PolyAI's integration logs guest service requests directly into HotSOS with predefined issue codes, routing them to the correct team automatically.
 
-<Note>This integration is available from **Configure > Integrations** in Agent Studio under **Hospitality**.</Note>
+<Note>This integration is available from **Integrations** in Agent Studio under **Hospitality**.</Note>
 
 ## Prerequisites
 

--- a/integrations/introduction.mdx
+++ b/integrations/introduction.mdx
@@ -7,13 +7,13 @@ mode: wide
 
 Connect PolyAI to telephony, CRM, payments, and knowledge platforms. Your agent can hand off to live agents, look up reservations, create tickets, and retrieve knowledge articles during calls.
 
-All integrations listed here are available from **Configure > Integrations** in Agent Studio.
+All integrations listed here are available from **Integrations** in Agent Studio.
 
 <div className="simplified-only">
 
 ## Self-serve integrations
 
-A self-serve integration set powered by Paragon, plus any [MCP server](/integrations/mcp) you bring. Connect them from **Configure > Integrations** in Agent Studio and call them from a [tool](/tools/introduction) or [flow step](/flows/introduction).
+A self-serve integration set powered by Paragon, plus any [MCP server](/integrations/mcp) you bring. Connect them from **Integrations** in Agent Studio and call them from a [tool](/tools/introduction) or [flow step](/flows/introduction).
 
 <CardGroup cols={3}>
   <Card title="Microsoft 365" icon="microsoft">
@@ -52,7 +52,7 @@ Call routing, transfers, and live agent handoffs.
   <Card title="Twilio" href="/integrations/voice/twilio" icon="phone">
     Flex contact center integration with handoffs
   </Card>
-  <Card title="Amazon Connect" href="/integrations/voice/amazon-connect" icon="aws">
+  <Card title="Amazon Connect" href="/integrations/voice/amazon-connect/amazon-connect" icon="aws">
     Voice agent integration with Amazon Connect
   </Card>
   <Card title="Genesys" href="/integrations/voice/sip/genesys" icon="headset">
@@ -73,7 +73,7 @@ Call routing, transfers, and live agent handoffs.
 Text-based messaging channels and CCaaS handoff.
 
 <CardGroup cols={3}>
-  <Card title="SMS" href="/sms/introduction" icon="message">
+  <Card title="SMS" href="/voice-channel/message-templates" icon="message">
     Send and receive text messages
   </Card>
   <Card title="Chat handoff" href="/integrations/chat/introduction" icon="comments">
@@ -153,7 +153,7 @@ Any external tool that exposes an MCP server. Agent Studio discovers available f
 
 ## Don't see your platform?
 
-Build a custom integration using the [APIs tab](/api/introduction). Define HTTP endpoints, configure per-environment base URLs and authentication, and call them from Python functions using `conv.api`.
+Build a custom integration using the [APIs tab](/integrations/api/introduction). Define HTTP endpoints, configure per-environment base URLs and authentication, and call them from Python functions using `conv.api`.
 
 For integrations not available in the Studio UI (Custom SIP, PCI Pal, Stripe, and others), see the [Managed services](/integrations/managed-services) section.
 
@@ -162,7 +162,7 @@ For integrations not available in the Studio UI (Custom SIP, PCI Pal, Stripe, an
 ## Related pages
 
 <CardGroup cols={3}>
-  <Card title="APIs" icon="code" href="/api/introduction">
+  <Card title="APIs" icon="code" href="/integrations/api/introduction">
     Define custom HTTP APIs for any platform
   </Card>
   <Card title="MCP" icon="plug" href="/integrations/mcp">

--- a/integrations/mcp.mdx
+++ b/integrations/mcp.mdx
@@ -9,7 +9,7 @@ Connect your agent to external [Model Context Protocol](https://modelcontextprot
 
 ![mcp-integrations](/images/integrations/mcp-homepage.png)
 
-<Note>This feature is available from **Configure > Integrations** in Agent Studio under the **MCP** tab.</Note>
+<Note>This feature is available from **Integrations** in Agent Studio under the **MCP** tab.</Note>
 
 ## How it works
 
@@ -26,7 +26,7 @@ The MCP server controls *what* tools are available, and you control *which* of t
 
 ## When to use MCP
 
-MCP integrations let your agent act as an MCP **client** that connects to external MCP servers. Instead of writing custom [functions](/tools/introduction) and [API configurations](/api/introduction), you point Agent Studio at an MCP server URL and the platform discovers the available tools automatically.
+MCP integrations let your agent act as an MCP **client** that connects to external MCP servers. Instead of writing custom [functions](/tools/introduction) and [API configurations](/integrations/api/introduction), you point Agent Studio at an MCP server URL and the platform discovers the available tools automatically.
 
 Common use cases include:
 
@@ -44,7 +44,7 @@ Common use cases include:
 
 <Steps>
   <Step title="Open the integrations page">
-    Go to **Configure > Integrations** and select the **MCP** tab.
+    Go to **Integrations** and select the **MCP** tab.
   </Step>
   <Step title="Add a new MCP server">
     Click **Add MCP integration**. In the modal, configure:

--- a/integrations/messaging/genesys.mdx
+++ b/integrations/messaging/genesys.mdx
@@ -6,7 +6,7 @@ description: 'Connect a Genesys Cloud org to PolyAI Agent Studio via Open Messag
 
 Connect a Genesys Cloud org to PolyAI Agent Studio over [Open Messaging](https://help.mypurecloud.com/articles/open-messaging-overview/). Genesys forwards inbound conversation events to PolyAI, PolyAI replies through the same channel, and an [Architect inbound message flow](https://help.mypurecloud.com/articles/about-message-flows/) routes any agent handoff to an ACD queue.
 
-<Note>This integration is available from **Configure > Integrations > Genesys Messaging** in Agent Studio. For voice routing into the same Genesys tenant, see the [Genesys Cloud voice integration](/integrations/voice/sip/genesys).</Note>
+<Note>This integration is available from **Integrations > Genesys Messaging** in Agent Studio. For voice routing into the same Genesys tenant, see the [Genesys Cloud voice integration](/integrations/voice/sip/genesys).</Note>
 
 ## Prerequisites
 
@@ -153,7 +153,7 @@ Quick reference for the Genesys Admin paths used in this guide.
   <Card title="Genesys Cloud (voice)" href="/integrations/voice/sip/genesys" icon="headset">
     BYOC voice setup and SIP routing.
   </Card>
-  <Card title="Webchat" href="/webchat/introduction" icon="message">
+  <Card title="Webchat" href="/messaging-channel/introduction" icon="message">
     Configure and embed the PolyAI webchat widget.
   </Card>
   <Card title="Integrations overview" href="/integrations/introduction" icon="puzzle-piece">

--- a/integrations/salesforce.mdx
+++ b/integrations/salesforce.mdx
@@ -5,7 +5,7 @@ description: Connect your PolyAI agent to Salesforce for customer data lookup an
 
 Connect PolyAI to Salesforce to retrieve customer records, create cases, and manage data during calls. Your agent can access account information, update records, and send follow-up messages.
 
-<Note>This integration is available from **Configure > Integrations** in Agent Studio under **CRM**.</Note>
+<Note>This integration is available from **Integrations** in Agent Studio under **CRM**.</Note>
 
 ## Prerequisites
 

--- a/integrations/voice/amazon-connect/amazon-connect.mdx
+++ b/integrations/voice/amazon-connect/amazon-connect.mdx
@@ -174,7 +174,7 @@ def lambda_handler(event, context):
 
 ## Chat and messaging handoff
 
-For webchat and SMS conversations, PolyAI escalates to a live agent through the Amazon Connect [Chat API](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) instead of SIP. Configure this under **Configure > Integrations > Amazon Connect** in Agent Studio.
+For webchat and SMS conversations, PolyAI escalates to a live agent through the Amazon Connect [Chat API](https://docs.aws.amazon.com/connect/latest/APIReference/API_StartChatContact.html) instead of SIP. Configure this under **Integrations > Amazon Connect** in Agent Studio.
 
 | Field | Required | Description |
 |-------|----------|-------------|

--- a/integrations/voice/dialpad.mdx
+++ b/integrations/voice/dialpad.mdx
@@ -6,14 +6,14 @@ description: "Connect your PolyAI agent to Dialpad for voice automation and hand
 Connect PolyAI to Dialpad to automate voice interactions through Dialpad's cloud communications platform. Handle inbound calls and route complex issues to live agents.
 
 <Note>
-Dialpad integration is available through the quick setup flow in Agent Studio. Go to **Configure > Integrations** and click **Dialpad** to get started.
+Dialpad integration is available through the quick setup flow in Agent Studio. Go to **Integrations** and click **Dialpad** to get started.
 </Note>
 
 ## Quick setup
 
 Agent Studio provides click-based integration with Dialpad:
 
-1. Go to **Configure > Integrations** in the sidebar.
+1. Go to **Integrations** in the sidebar.
 2. Click the **Dialpad** card.
 3. Follow the guided setup flow to connect your Dialpad account.
 4. After setup, you're routed to the **Handoffs** page to configure call routing.
@@ -43,7 +43,7 @@ When integrated, PolyAI handles incoming calls routed from Dialpad:
 
 After integration, configure how calls transfer back to human agents:
 
-1. Go to **Build > Call handoffs**.
+1. Go to **Voice > Handoffs**.
 2. Create handoff destinations for different scenarios.
 3. Map destinations to Dialpad queues or agents.
 

--- a/integrations/voice/dnis-pool.mdx
+++ b/integrations/voice/dnis-pool.mdx
@@ -98,7 +98,7 @@ print(f"shared_id: {shared_id}, ani: {ani}")  # you can optionally print the att
 conv.state.shared_id = shared_id
 conv.state.ani = ani
 ```
-You can then use those attributes in other functions, in the Managed Topics or elsewhere
+You can then use those attributes in other functions, in the FAQs or elsewhere
 in your Agent. This will be useful to customize your Agent behavior, or use those attributes
 in other API calls to your infrastructure for example.
 

--- a/integrations/voice/introduction.mdx
+++ b/integrations/voice/introduction.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "Connect PolyAI to voice platforms for call routing and SIP-based handoffs."
 ---
 
-PolyAI integrates with voice platforms for call routing, SIP data exchange, and live-agent handoffs. Most telephony integrations can be connected from **Configure > Integrations** in Agent Studio.
+PolyAI integrates with voice platforms for call routing, SIP data exchange, and live-agent handoffs. Most telephony integrations can be connected from **Integrations** in Agent Studio.
 
 ## Available integrations
 
@@ -13,7 +13,7 @@ PolyAI integrates with voice platforms for call routing, SIP data exchange, and 
 | **[Five9](/integrations/voice/sip/five9)** | Studio UI | SIP trunking, auth tokens, metadata exchange |
 | **[NICE CXone](/integrations/voice/sip/NICECXone)** | Studio UI | Signal API handoffs, pseudo-number routing |
 | **[Twilio](/integrations/voice/twilio)** | Studio UI | Marketplace connector, TwiML/Studio routing, Flex handoff |
-| **[Amazon Connect](/integrations/voice/amazon-connect)** | Studio UI | DynamoDB contact flows, Connect analytics |
+| **[Amazon Connect](/integrations/voice/amazon-connect/amazon-connect)** | Studio UI | DynamoDB contact flows, Connect analytics |
 | **[Genesys](/integrations/voice/sip/genesys)** | Studio UI | BYOC trunks, sequential failover, custom SIP headers |
 | **[Dialpad](/integrations/voice/dialpad)** | Studio UI | Cloud contact center, call management |
 | **[Custom SIP](/integrations/voice/sip/custom-sip)** | Managed | SIP header access, SIP INVITE/REFER transfers |

--- a/integrations/voice/twilio.mdx
+++ b/integrations/voice/twilio.mdx
@@ -4,7 +4,7 @@ description: 'Connect your PolyAI agent to Twilio for voice automation and hando
 ---
 
 <Note>
-For basic Twilio number and SMS setup, see [Configure > Numbers > Twilio](/telephony/twilio/introduction).
+For basic Twilio number and SMS setup, see [Voice > Numbers > Twilio](/telephony/twilio/introduction).
 </Note>
 
 Connect Twilio to your PolyAI project from Agent Studio. PolyAI uses your Twilio API credentials to automatically provision the SIP trunk(s) needed to route calls to your agent — you just bring your API keys and your own phone numbers.
@@ -12,8 +12,8 @@ Connect Twilio to your PolyAI project from Agent Studio. PolyAI uses your Twilio
 ## Quick setup
 
 <Steps>
-  <Step title="Open Configure > Integrations">
-    In Agent Studio, go to **Configure > Integrations** and click **Connect** on the Twilio card.
+  <Step title="Open Integrations">
+    In Agent Studio, go to **Integrations** and click **Connect** on the Twilio card.
 
     <Frame>
       <img src="/images/integrations/twilio/integrations-page.png" alt="The Integrations page in Agent Studio showing available telephony providers including Twilio." />
@@ -36,7 +36,7 @@ Connect Twilio to your PolyAI project from Agent Studio. PolyAI uses your Twilio
     Add the Twilio numbers you want to route to PolyAI for **Sandbox**, **Pre-release**, and **Live**. Numbers must be in E.164 format with a country code (e.g. `+441234567890`).
   </Step>
   <Step title="Submit">
-    PolyAI provisions the SIP trunk on your Twilio account and wires up routing per environment. You're then taken to **Build > Call handoffs** to configure transfers back to a human agent.
+    PolyAI provisions the SIP trunk on your Twilio account and wires up routing per environment. You're then taken to **Voice > Handoffs** to configure transfers back to a human agent.
   </Step>
 </Steps>
 
@@ -53,15 +53,15 @@ Use a Standard API key with permissions to manage SIP trunks on the account.
 
 ## Editing or removing the integration
 
-- **Update routing** — re-open the Twilio card in **Configure > Integrations** to add or remove numbers per environment.
+- **Update routing** — re-open the Twilio card in **Integrations** to add or remove numbers per environment.
 - **Disconnect** — use the **Disconnect** action on the integration. PolyAI removes the routing on its side and tears down the SIP trunk it provisioned.
 
 ## Configuring handoffs
 
-After the integration is connected, configure how calls transfer back to human agents in **Build > Call handoffs**. See [Call handoffs](/call-handoff/introduction) for the full reference.
+After the integration is connected, configure how calls transfer back to human agents in **Voice > Handoffs**. See [Call handoffs](/call-handoff/introduction) for the full reference.
 
 ## Related pages
 
-- [Configure > Numbers > Twilio](/telephony/twilio/introduction) — basic Twilio number and SMS setup
+- [Voice > Numbers > Twilio](/telephony/twilio/introduction) — basic Twilio number and SMS setup
 - [Call handoffs](/call-handoff/introduction) — configure transfer destinations
 - [Voice integrations](/integrations/voice/introduction) — other voice platforms

--- a/integrations/zendesk.mdx
+++ b/integrations/zendesk.mdx
@@ -5,7 +5,7 @@ description: 'Connect to Zendesk Talk to route inbound calls and hand off calls 
 
 Route calls through Zendesk Talk and hand off to Zendesk agents through SIP. This integration handles inbound calls with agent escalation.
 
-<Note>Zendesk Talk is available from **Configure > Integrations** in Agent Studio under **Telephony**. For Zendesk CRM integration, see the CRM section in Agent Studio.</Note>
+<Note>Zendesk Talk is available from **Integrations** in Agent Studio under **Telephony**. For Zendesk CRM integration, see the CRM section in Agent Studio.</Note>
 
 ## Call flow
 

--- a/messaging-channel/advanced/chat-configuration.mdx
+++ b/messaging-channel/advanced/chat-configuration.mdx
@@ -11,7 +11,7 @@ keywords:
 
 ![chat-configuration](/images/webchat/config.png)
 
-Configure chat settings in **Channels > Chat**. Create widgets at **[Widget](/widgets/configure)**.
+Configure chat settings in **Messaging**. Create widgets at **[Widget](/widgets/configure)**.
 
 ## General
 
@@ -52,7 +52,7 @@ Keep your greeting short and welcoming. Avoid long introductions that push the c
 Safety filters are configured on a **per-channel basis**. The chat channel has its own safety filter settings, separate from the voice channel and the project-wide defaults. See [Safety filters](/agent-settings/safety-filters) for the full reference on categories, severity levels, and how filters interact with [Guardrails](/agent-settings/guardrails).
 
 <ParamField path="Enable safety filters" type="boolean">
-  When enabled, applies content filtering to chat responses. These filters apply to the chat channel only. Default settings can be managed on the **Configure > General** page.
+  When enabled, applies content filtering to chat responses. These filters apply to the chat channel only. Default settings can be managed on the **Behavior** page.
 </ParamField>
 
 When safety filters are enabled, adjust the strictness for each category using the sliders:

--- a/messaging-channel/introduction.mdx
+++ b/messaging-channel/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chat"
+title: "Messaging"
 sidebarTitle: "Overview"
 description: "Deploy a webchat version of your agent alongside voice."
 mode: wide
@@ -13,12 +13,12 @@ keywords:
 
 Use webchat to deploy your agent on your website alongside voice. Webchat lets customers interact with the same agent logic through text, with channel-specific styling, safety filters, and widget configuration.
 
-Configure the chat experience from **Channels > Chat** in the sidebar.
+Configure the chat experience from **Messaging** in the sidebar.
 
 ## Chat channel pages
 
 <CardGroup cols={2}>
-  <Card title="Chat configuration" icon="message" href="./chat-configuration">
+  <Card title="Chat configuration" icon="message" href="/messaging-channel/advanced/chat-configuration">
     Configure LLM, style prompt, greeting, and safety filters
   </Card>
   <Card title="Widget" icon="window-maximize" href="/widgets/configure">
@@ -37,7 +37,7 @@ Setting up webchat involves two main steps:
 <Steps>
 
 <Step title="Configure chat settings">
-Go to **Channels > Chat > Chat Configuration** to:
+Go to **Messaging > Chat Configuration** to:
 - Select your language model
 - Add an optional style prompt for chat-specific tone
 - Set your greeting message
@@ -45,7 +45,7 @@ Go to **Channels > Chat > Chat Configuration** to:
 </Step>
 
 <Step title="Create and deploy a widget">
-Go to **Configure > Web Calling** to:
+Go to **Widgets** to:
 - Create a new widget for your website
 - Style the appearance (header, colors, agent avatar)
 - Configure disclaimers and consent
@@ -70,7 +70,7 @@ Configure channel-specific content filtering with adjustable strictness levels f
 
 ### Markdown support
 
-Chat messages support formatted markdown including bold, italics, lists, links, and code blocks. See [chat configuration](/webchat/chat-configuration#markdown-support) for details.
+Chat messages support formatted markdown including bold, italics, lists, links, and code blocks. See [chat configuration](/messaging-channel/advanced/chat-configuration#markdown-support) for details.
 
 ### Variant support
 
@@ -83,7 +83,7 @@ Chat configuration changes take effect immediately when saved. Unlike other proj
 ## Related pages
 
 <CardGroup cols={2}>
-  <Card title="Chat configuration" icon="message" href="/webchat/chat-configuration">
+  <Card title="Chat configuration" icon="message" href="/messaging-channel/advanced/chat-configuration">
     Configure LLM, greeting, and safety filters
   </Card>
   <Card title="Widget" icon="window-maximize" href="/widgets/configure">
@@ -92,7 +92,7 @@ Chat configuration changes take effect immediately when saved. Unlike other proj
   <Card title="Widget installation" icon="code" href="/widgets/install">
     Embed the widget on your website
   </Card>
-  <Card title="Variant management" icon="code-branch" href="/variant-management/introduction">
+  <Card title="Variants" icon="code-branch" href="/variant-management/introduction">
     Configure multi-site setups
   </Card>
 </CardGroup>

--- a/messaging-channel/ios-sdk.mdx
+++ b/messaging-channel/ios-sdk.mdx
@@ -1,0 +1,162 @@
+---
+title: "iOS SDK"
+sidebarTitle: "iOS SDK"
+description: "Embed a PolyAI messaging agent natively in your iOS app with a headless Swift library."
+mode: wide
+keywords:
+  - iOS
+  - SDK
+  - Swift
+  - mobile
+  - in-app messaging
+  - native
+  - CocoaPods
+  - Swift Package Manager
+---
+
+The iOS SDK is a native Swift library that embeds PolyAI's messaging agent directly inside your iOS app. It's **headless by design** — you own the UI, PolyAI provides the AI layer underneath. Your app connects to the same agent logic used across voice, webchat, and other channels.
+
+<Info>
+The iOS SDK uses the [Messaging API](/api-reference/messaging/introduction) under the hood. All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
+</Info>
+
+## How it works
+
+The SDK handles authentication, session management, WebSocket connections, and reconnection logic. Your app sends and receives messages through the SDK and renders them however you choose.
+
+<Steps>
+  <Step title="Install the SDK">
+    Add the SDK to your project via **Swift Package Manager** or **CocoaPods**.
+  </Step>
+  <Step title="Configure authentication">
+    Add your API key (from Agent Studio) and register your app's **bundle identifier** in Agent Studio. The backend rejects connections from unregistered bundle identifiers.
+  </Step>
+  <Step title="Start a session">
+    Initialize the SDK and start a messaging session. The SDK handles access token exchange and WebSocket connection automatically.
+  </Step>
+  <Step title="Build your UI">
+    Listen for incoming messages and events from the SDK, and send user messages through it. Render the conversation in your own UI components.
+  </Step>
+</Steps>
+
+## Installation
+
+The SDK is distributed as a native Swift package. Choose either method:
+
+<Tabs>
+  <Tab title="Swift Package Manager">
+    In Xcode, go to **File > Add Package Dependencies** and enter the repository URL:
+
+    ```
+    https://github.com/PolyAI-LDN/poly_messaging_ios
+    ```
+
+    Select the latest version and add the package to your target.
+  </Tab>
+  <Tab title="CocoaPods">
+    Add the pod to your `Podfile`:
+
+    ```ruby
+    pod 'PolyMessaging'
+    ```
+
+    Then run:
+
+    ```bash
+    pod install
+    ```
+  </Tab>
+</Tabs>
+
+## Authentication setup
+
+The iOS SDK authenticates using a connector token and your app's bundle identifier.
+
+<Steps>
+  <Step title="Generate a connector token">
+    In Agent Studio, go to **Messaging > API Configuration** and generate a new Messaging API key.
+  </Step>
+  <Step title="Register your bundle identifier">
+    When generating the token, set the **host identifier** to your app's bundle identifier (e.g. `com.yourcompany.app`). This must match the `CFBundleIdentifier` in your app's `Info.plist`. The backend rejects connections from apps with a mismatched bundle identifier.
+  </Step>
+</Steps>
+
+<Warning>
+Never embed the connector token directly in your app binary. Use a backend service to mint short-lived access tokens and pass them to the SDK. See [security best practices](/api-reference/messaging/best-practices#security).
+</Warning>
+
+## Key features
+
+### Session persistence
+
+Sessions persist across app launches. If the user leaves and returns, the SDK reconnects to the existing session and replays the conversation history automatically. Network changes (Wi-Fi to cellular, brief drops) are handled with automatic reconnection and retry.
+
+### Streaming responses
+
+Enable streaming when creating a session to show agent responses as they're generated, word by word. The SDK surfaces streaming chunks as they arrive — your UI can render them incrementally.
+
+### Handoff to live agents
+
+The full [handoff flow](/api-reference/messaging/handoff) is supported. When the PolyAI agent triggers a handoff, the SDK delivers the same handoff events (`HANDOFF_ACCEPTED`, `HANDOFF_QUEUE_STATUS`, `LIVE_AGENT_JOINED`, etc.) so your app can show queue status and live agent messages.
+
+### Response suggestions
+
+Agent messages can include `response_suggestions` — pre-written reply options. Render these as tappable buttons in your UI. When the user taps one, send its text as a message through the SDK.
+
+### Attachments
+
+Agent messages may include rich content like links and images via the `attachments` field. Render these inline in your chat UI.
+
+## Platform values
+
+When the SDK creates a session, it sets `platform` to `ios` automatically. This is visible in Agent Studio analytics and can be used in your agent logic to tailor behavior for mobile users.
+
+| Platform value | Source |
+|---|---|
+| `ios` | iOS SDK (native) |
+| `android` | Android SDK (native) |
+| `ios-web` | Webchat widget on iOS Safari |
+| `web` | Webchat widget on desktop |
+
+## Limitations
+
+<Note>
+These limitations apply to the initial release. Check the [release notes](/releases/overview) for updates.
+</Note>
+
+| Limitation | Details |
+|---|---|
+| **Text only** | Voice input is not supported in V1. WebRTC voice support is planned for a future release and will require declaring microphone permissions (`NSMicrophoneUsageDescription`) in your `Info.plist`. |
+| **No push notifications** | While the app is active, the SDK delivers messages in real time. When the app is backgrounded, the SDK cannot receive messages. You can listen for incoming messages and trigger your own local notifications while the app is in the foreground, but true remote push notifications (APNs) are not yet supported. |
+| **iOS only** | The SDK is native Swift. There is no React Native or Flutter wrapper. Cross-platform frameworks would require a separate SDK. |
+
+## Multichannel
+
+The iOS SDK connects to the same agent project as your voice and webchat channels. Agent behavior, knowledge, and flows are shared — only channel-specific settings (greetings, formatting) differ. See [multichannel agents](/messaging-channel/multichannel) for how to tailor behavior per channel.
+
+In your agent's start function, detect the mobile channel using `conv.channel_type`:
+
+```python
+def start(conv):
+    if conv.channel_type == "ios":
+        conv.state.greet_message = "Hi! How can I help you today?"
+    elif conv.channel_type.startswith("webchat"):
+        conv.state.greet_message = "Hi there! 👋 How can I help?"
+```
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Messaging API reference" icon="plug" href="/api-reference/messaging/introduction">
+    Full WebSocket protocol, events, streaming, and handoff
+  </Card>
+  <Card title="Sessions and authentication" icon="key" href="/api-reference/messaging/sessions">
+    Access tokens, session creation, and platform values
+  </Card>
+  <Card title="Multichannel agents" icon="layer-group" href="/messaging-channel/multichannel">
+    Build agents that work across voice, webchat, and mobile
+  </Card>
+  <Card title="Best practices" icon="star" href="/api-reference/messaging/best-practices">
+    Connection management, UX, and security recommendations
+  </Card>
+</CardGroup>

--- a/messaging-channel/multichannel.mdx
+++ b/messaging-channel/multichannel.mdx
@@ -73,7 +73,7 @@ Channel-specific greetings are set in your agent's start function. Switch to **F
 
 You don't need to manually add style guidelines to your behavior prompt for voice. A **prompt decorator** is automatically applied per channel – for example, the Raven voice model includes built-in style guidelines.
 
-Configure which LLM powers each channel in **Channels > [Voice configuration](/voice/voice-configuration)** or **Channels > [Chat configuration](/webchat/chat-configuration)**. For multichannel agents, **[Raven 3.5](/agent-settings/raven)** is the recommended model – it is the only Raven model tuned for both voice and chat, providing a consistent experience across channels.
+Configure which LLM powers each channel in **Voice > Advanced > [Call settings](/voice/voice-configuration)** or **Messaging > Advanced > [Chat configuration](/messaging-channel/advanced/chat-configuration)**. For multichannel agents, **[Raven 3.5](/agent-settings/raven)** is the recommended model – it is the only Raven model tuned for both voice and chat, providing a consistent experience across channels.
 
 ## Knowledge and links
 
@@ -94,11 +94,11 @@ The same metrics system applies across all channels. Metrics designed for voice 
 <Steps>
 
 <Step title="Configure chat settings">
-From **Channels > Chat**, configure your greeting, LLM, and style prompt for the chat channel.
+From **Messaging**, configure your greeting, LLM, and style prompt for the chat channel.
 </Step>
 
 <Step title="Deploy the widget">
-From **Configure > Web Calling**, generate a script tag and embed it in your website's HTML headers. See the [widget deployment guide](/widgets/install) for details.
+From **Widgets**, generate a script tag and embed it in your website's HTML headers. See the [widget deployment guide](/widgets/install) for details.
 </Step>
 
 <Step title="Test with preview">
@@ -121,7 +121,7 @@ Use the **Preview** button to test your webchat agent. Verify that formatting di
 ## Related pages
 
 <CardGroup cols={3}>
-  <Card title="Chat configuration" icon="gear" href="/webchat/chat-configuration">
+  <Card title="Chat configuration" icon="gear" href="/messaging-channel/advanced/chat-configuration">
     Configure greetings, LLM, and style for the chat channel
   </Card>
   <Card title="Widget deployment" icon="code" href="/widgets/install">

--- a/voice-channel/message-templates.mdx
+++ b/voice-channel/message-templates.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Overview"
+title: "Message templates"
+sidebarTitle: "Message templates"
 description: "Send SMS messages from your agent using Twilio for confirmations, links, and follow-ups"
 keywords:
   - SMS
@@ -13,12 +14,12 @@ keywords:
 
 Use SMS to send confirmation codes, appointment details, links, or follow-up information that callers can reference after the call ends.
 
-Create and manage SMS templates in **Build > SMS**.
+Create and manage SMS templates in **Messaging**.
 
 ## Setting up messaging
 
 ### Connect your Twilio account
-1. Go to **Build > SMS** in the sidebar.
+1. Go to **Messaging** in the sidebar.
 2. Click **Connect Twilio Account**.
 3. In the pop-up form, fill in the following fields:
    - [**Account SID**](https://help.twilio.com/articles/14726256820123-What-is-a-Twilio-Account-SID-and-where-can-I-find-it-): Find this in the "Account Info" section of your Twilio dashboard.
@@ -45,7 +46,7 @@ A2P 10DLC registration can take **several weeks** and campaigns are frequently r
 
 Campaigns are often rejected for vague opt-in descriptions. Include detailed example conversation transcripts showing how callers consent to receiving SMS — linking a document with full sample transcripts significantly improves approval rates.
 
-A2P 10DLC is specific to US and Canadian numbers. UK and other international numbers have separate regulatory requirements — see [Number availability & compliance](/sms/number-availability) for country-by-country details, throughput limits, lead times, and regulation links.
+A2P 10DLC is specific to US and Canadian numbers. UK and other international numbers have separate regulatory requirements — see [Number availability & compliance](/voice-channel/number-availability) for country-by-country details, throughput limits, lead times, and regulation links.
 
 **Troubleshooting:** If your messages fail to send, check the Twilio logs for these error codes:
 - [**30034** - Unregistered Number](https://www.twilio.com/docs/api/errors/30034)
@@ -53,7 +54,7 @@ A2P 10DLC is specific to US and Canadian numbers. UK and other international num
 
 ### Add SMS templates
 Once connected, follow these steps to create SMS templates:
-1. Click **Add SMS** in **Build > SMS**.
+1. Click **Add SMS** in **Messaging**.
 2. Fill in the form:
    - **Title**: A descriptive name for the SMS template (e.g., `reservation_confirmation`). This is the name you reference when triggering the template in functions. Max 100 characters.
    - **SMS Body**: The content of the message. Max 500 characters. Supports dynamic tokens (see below).
@@ -93,15 +94,15 @@ Hi ${customer_name}, your reservation at ${property_name} is confirmed for {{ent
 For multilingual projects, consider creating separate templates with language suffixes (e.g., `confirmation_en`, `confirmation_es`).
 
 ### Managing templates
-All created SMS templates are listed in **Build > SMS**. You can:
+All created SMS templates are listed in **Messaging**. You can:
 - **Edit**: Modify the title, message content, or associated phone number.
 - **Duplicate**: Quickly create a copy of an existing template for similar use cases.
 - **Delete**: Remove unused or outdated templates.
 
 ### Using an SMS template
 
-1. **Go to [Build > Knowledge > Managed Topics tab](/managed-topics/introduction)**
-    - Ensure you are on the Managed Topics tab.
+1. **Go to [Knowledge > FAQs tab](/managed-topics/introduction)**
+    - Ensure you are on the FAQs tab.
 
 2. **Add an action to a Managed Topic card**
     - In any Managed Topic card, click ["Add Actions."](/managed-topics/how-to-setup-action/send-sms)
@@ -144,7 +145,7 @@ Matching is case-insensitive and ignores leading or trailing whitespace and a si
 
 ### What this means for your agent
 
-- **Inbound `STOP`/`START`/`HELP` replies never reach your flows or Managed Topics.** They are intercepted at the SMS handler, so you do not need to script keyword responses yourself.
+- **Inbound `STOP`/`START`/`HELP` replies never reach your flows or FAQs.** They are intercepted at the SMS handler, so you do not need to script keyword responses yourself.
 - **Outbound SMS to opted-out recipients is silently dropped.** If a function or Managed Topic action calls `conv.send_sms` or `conv.send_sms_template` for an opted-out number, the request returns successfully but no SMS is delivered. Check the [Standard dashboard](/analytics/dashboards/standard) SMS widget to monitor delivery.
 - **Any other inbound message from an opted-out sender is also dropped** until they reply `START`.
 - The opt-out record persists indefinitely until the user opts back in, satisfying TCPA record-keeping requirements.
@@ -190,14 +191,14 @@ conv.send_sms(
 
 ### `conv.send_sms_template`
 
-Sends a pre-configured SMS template by **template name** (the title you defined in **Build > SMS**).
+Sends a pre-configured SMS template by **template name** (the title you defined in **Messaging**).
 
 ```python
 # Send a template to the current caller
 conv.send_sms_template(to_number=conv.caller_number, template="reservation_confirmation")
 ```
 
-The second argument is the template **name** (the title from Build > SMS), not an ID. For example, if your template is titled `prescription_refill`, use `conv.send_sms_template(conv.caller_number, 'prescription_refill')`.
+The second argument is the template **name** (the title from Messaging), not an ID. For example, if your template is titled `prescription_refill`, use `conv.send_sms_template(conv.caller_number, 'prescription_refill')`.
 
 <Warning>
 `conv.send_sms_template` queues the SMS for delivery rather than sending it synchronously. This means `try/except` blocks will **not** catch delivery failures – the call returns successfully even if the SMS later fails to send. To verify delivery, check conversation metadata or the [Standard dashboard](/analytics/dashboards/standard) SMS widget.
@@ -233,15 +234,18 @@ The notification is sent automatically and does not require configuration. It us
 
 ## Related pages
 
-<CardGroup cols={2}>
-  <Card title="Number availability & compliance" icon="globe" href="/sms/number-availability">
+<CardGroup cols={3}>
+  <Card title="Number availability & compliance" icon="globe" href="/voice-channel/number-availability">
     Country-by-country Twilio number availability, throughput, lead times, and regulatory links.
   </Card>
-  <Card title="Managed Topics actions" icon="bolt" href="/managed-topics/how-to-setup-action/send-sms">
+  <Card title="FAQs actions" icon="bolt" href="/managed-topics/how-to-setup-action/send-sms">
     Trigger SMS sends from Knowledge topic actions.
   </Card>
   <Card title="Twilio integration" icon="phone" href="/telephony/twilio/introduction">
     Connect your Twilio account to enable SMS.
+  </Card>
+  <Card title="Outbound SMS API" icon="paper-plane" href="/api-reference/outbound-sms/introduction">
+    Send SMS programmatically and open reply-enabled sessions.
   </Card>
   <Card title="Standard dashboard" icon="chart-line" href="/analytics/dashboards/standard">
     Monitor SMS delivery rates with the SMS widget.

--- a/voice-channel/number-availability.mdx
+++ b/voice-channel/number-availability.mdx
@@ -76,7 +76,7 @@ Carrier regulations vary by country and must be met **before** you send any mess
 
 ### US and Canada — A2P 10DLC
 
-US and Canadian long code SMS requires [A2P 10DLC registration](/sms/introduction#a2p-10dlc-registration-us-and-canada). Without it, carriers block messages entirely. See the [SMS overview](/sms/introduction) for the full registration walkthrough.
+US and Canadian long code SMS requires [A2P 10DLC registration](/voice-channel/message-templates#a2p-10dlc-registration-us-and-canada). Without it, carriers block messages entirely. See the [SMS overview](/voice-channel/message-templates) for the full registration walkthrough.
 
 For short code campaigns:
 - **US**: Follow the [CTIA Short Code Monitoring Handbook](https://api.ctia.org/wp-content/uploads/2024/01/CTIA-Short-Code-Monitoring-Handbook-v1.9-FINAL.pdf) and [Messaging Principles and Best Practices](https://api.ctia.org/wp-content/uploads/2023/05/230523-CTIA-Messaging-Principles-and-Best-Practices-FINAL.pdf).
@@ -101,9 +101,9 @@ Before going live with 2-way SMS in any country:
 
 1. **Confirm number availability** — check the tables above to verify your target country supports 2-way SMS and that the number type you need is available.
 2. **Provision your number** — long codes can often be provisioned immediately through the Twilio Console; short codes require a carrier application.
-3. **Complete registration** — for US/CA, complete [A2P 10DLC registration](/sms/introduction#a2p-10dlc-registration-us-and-canada). For other countries, follow the linked regulatory guidelines.
+3. **Complete registration** — for US/CA, complete [A2P 10DLC registration](/voice-channel/message-templates#a2p-10dlc-registration-us-and-canada). For other countries, follow the linked regulatory guidelines.
 4. **Validate your campaign** — use the [A2P Campaign Pre-Scanner](https://www.a2pcheck.com/) to check your setup against carrier requirements before sending.
-5. **Connect to PolyAI** — follow the [SMS setup guide](/sms/introduction#connect-your-twilio-account) to link your Twilio number to your PolyAI project.
+5. **Connect to PolyAI** — follow the [SMS setup guide](/voice-channel/message-templates#connect-your-twilio-account) to link your Twilio number to your PolyAI project.
 
 ## Industry resources
 
@@ -137,10 +137,13 @@ Before going live with 2-way SMS in any country:
 ## Related pages
 
 <CardGroup cols={3}>
-  <Card title="SMS overview" icon="message" href="/sms/introduction">
+  <Card title="Message templates" icon="message" href="/voice-channel/message-templates">
     Set up Twilio, create templates, and send SMS from your agent.
   </Card>
-  <Card title="Twilio integration" icon="phone" href="/telephony/twilio/introduction">
+  <Card title="Outbound SMS API" icon="paper-plane" href="/api-reference/outbound-sms/introduction">
+    Send SMS programmatically and open reply-enabled sessions.
+  </Card>
+  <Card title="Twilio integration" icon="phone" href="/voice-channel/numbers/twilio/introduction">
     Connect your Twilio account for voice and SMS.
   </Card>
   <Card title="Buy a number from PolyAI" icon="phone-plus" href="/telephony/how-to-buy-number">


### PR DESCRIPTION
## Summary

- **Outbound SMS API reference** — new introduction and send-sms endpoint pages under `api-reference/outbound-sms/`
- **Messaging channel rename** — `webchat/` → `messaging-channel/` with a new iOS SDK page
- **SMS docs moved under Voice** — `sms/` → `voice-channel/message-templates` and `voice-channel/number-availability`
- **API integrations path** — `api/introduction` → `integrations/api/introduction`
- **Integrations prose updates** — consistent navigation references and link fixes across all integration pages
- **Redirects** — old paths (`/webchat/*`, `/sms/*`, `/api/introduction`) redirect to their new locations

Extracted from the main IA PR (`fix/regex-examples-formatting`) so it can be merged independently.

## Test plan

- [ ] Verify sidebar entries render correctly for SMS, Chat, APIs, and Outbound SMS API sections
- [ ] Confirm redirects work for `/webchat/introduction`, `/sms/introduction`, `/sms/number-availability`, `/api/introduction`
- [ ] Check Outbound SMS API pages render with correct endpoint docs
- [ ] Verify iOS SDK page appears under Chat in sidebar
- [ ] Spot-check internal links from integrations pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)