### PR TITLE
Restructure voice docs for new Agent Studio Voice UI

### DIFF
--- a/analytics/conversations/annotations.mdx
+++ b/analytics/conversations/annotations.mdx
@@ -53,7 +53,7 @@ You can apply **Wrong information** in combination with **Bad response** — the
 
 For voice conversations, caller turns can also be annotated to capture ASR and Knowledge issues:
 
-- **Wrong transcription** — the ASR (automatic speech recognition) produced an incorrect transcript. Use this when the agent misheard the caller. Feeds back into ASR tuning and [keyphrase boosting](/voice-channel/advanced/speech-recognition).
+- **Wrong transcription** — the ASR (automatic speech recognition) produced an incorrect transcript. Use this when the agent misheard the caller. Feeds back into ASR tuning and [keyphrase boosting](/voice-channel/advanced/call-settings#keyphrases).
 - **Missing topic** — the caller asked something the agent could not answer because no matching topic exists in the [Knowledge](/knowledge/faqs/introduction) area. Feeds the prioritization of new topics.
 
 These annotations are available on the caller side of voice transcripts. Webchat sessions don't have ASR or audio, so they don't surface these types.
@@ -71,7 +71,7 @@ These annotations are available on the caller side of voice transcripts. Webchat
 - **Annotate consistently** — Review a sample of conversations regularly and annotate issues as you find them.
 - **Pick the most specific reason** — "Hallucination" is more actionable than a generic Bad response without a reason.
 - **Combine when useful** — A turn can be both **Bad response: Response too general** and **Wrong information** if both apply.
-- **Act on annotations** — Use them as input when updating your Knowledge area, [ASR keyphrase boosting](/voice-channel/advanced/speech-recognition), [transcript corrections](/voice-channel/advanced/speech-recognition), or agent behavior configuration.
+- **Act on annotations** — Use them as input when updating your Knowledge area, [ASR keyphrase boosting](/voice-channel/advanced/call-settings#keyphrases), [transcript corrections](/voice-channel/advanced/call-settings#keyphrases), or agent behavior configuration.
 
 ## Related pages
 

--- a/behavior/general/agent.mdx
+++ b/behavior/general/agent.mdx
@@ -19,7 +19,7 @@ Use the Agent page to control your agent's character – its **personality** and
 Configure personality and role in **Behavior > General**. The same page also contains the [Behavior](/behavior/general/rules) section for hard rules and constraints.
 
 <Note>
-  **Where is the greeting?** Configured per channel — **Voice > Advanced > Call settings** or **Messaging > Advanced > Chat configuration**. Legacy projects without channel-specific settings still configure it on this page.
+  **Where is the greeting?** Configured per channel — **Voice > Advanced settings** or **Messaging > Advanced > Chat configuration**. Legacy projects without channel-specific settings still configure it on this page.
 </Note>
 
 ## Greeting

--- a/behavior/guardrails/safety-filters.mdx
+++ b/behavior/guardrails/safety-filters.mdx
@@ -16,7 +16,7 @@ keywords:
 
 Safety filters are PolyAI's content classifiers. They inspect every user input and every agent output in real time and block anything that exceeds the severity threshold you set for each category. Filters combine PolyAI's models with third-party services such as [Azure OpenAI content safety](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/).
 
-Configure project-wide defaults in **Behavior**, then override them per channel in **Voice > Advanced > Call settings** and **Messaging > Advanced > Chat configuration**.
+Configure project-wide defaults in **Behavior**, then override them per channel in **Voice > Advanced settings** and **Messaging > Advanced > Chat configuration**.
 
 <Frame caption="Safety filter sliders on the voice channel">
   <img src="/images/voice/safety-filters-voice.png" alt="Safety filter settings showing severity sliders for hate, sexual, violence, and self-harm on the voice channel" />
@@ -66,7 +66,7 @@ Each category has four severity levels. Pick the level per category that matches
 Safety filters are configured on a **per-channel basis** with project-wide defaults as a fallback.
 
 - **Project defaults** – set in **Behavior**. Apply to any channel that does not have its own overrides enabled.
-- **Voice channel** – override in **Voice > Advanced > Call settings**. See [Voice configuration → Safety filters](/voice-channel/advanced/call-settings#safety-filters).
+- **Voice channel** – override in **Voice > Advanced settings**. See [Voice configuration → Safety filters](/voice-channel/advanced/call-settings#safety-filters).
 - **Chat channel** – override in **Messaging > Advanced > Chat configuration**. See [Chat configuration → Safety filters](/messaging-channel/advanced/chat-configuration#safety-filters).
 
 When a channel has its own filters enabled, the channel values win for that channel. When a channel has filters disabled, the project defaults apply.

--- a/behavior/language/language-coverage.mdx
+++ b/behavior/language/language-coverage.mdx
@@ -166,7 +166,7 @@ ASR providers wired into the platform today:
 - Fano
 - NVIDIA NeMo
 
-The platform routes requests to the best-fit provider per language and use case, with automatic fallback. See [Speech recognition](/voice-channel/advanced/speech-recognition).
+The platform routes requests to the best-fit provider per language and use case, with automatic fallback. See [Keyphrases](/voice-channel/advanced/call-settings#keyphrases).
 
 ### TTS providers
 
@@ -192,7 +192,7 @@ TTS voice availability varies by provider and language. Browse what's available 
 3. **If Raven does not cover it** (for example Danish), select a third-party LLM in [Voice configuration](/voice-channel/advanced/call-settings) or [Chat configuration](/messaging-channel/advanced/chat-configuration). Verify the chosen model officially supports the language.
 4. **Confirm regional availability** for Bedrock models if you are deploying outside US-1.
 5. **Confirm a voice exists** for the language in the [Voice library](/voice-channel/voice-library). Prefer native voices over multilingual fallbacks.
-6. **Configure ASR** – defaults usually work; for domain terms see [Speech recognition](/voice-channel/advanced/speech-recognition) and ASR biasing.
+6. **Configure ASR** – defaults usually work; for domain terms see [Keyphrases](/voice-channel/advanced/call-settings#keyphrases) and ASR biasing.
 
 ## Related pages
 
@@ -200,5 +200,5 @@ TTS voice availability varies by provider and language. Browse what's available 
 - [Model](/behavior/models/model-use) – compare LLM options and configure per channel.
 - [Raven](/behavior/models/raven) – PolyAI's proprietary LLM family.
 - [Bring your own model](/behavior/models/byom) – connect a custom LLM endpoint.
-- [Speech recognition](/voice-channel/advanced/speech-recognition) – ASR settings and biasing.
+- [Keyphrases](/voice-channel/advanced/call-settings#keyphrases) – ASR settings and biasing.
 - [Voice library](/voice-channel/voice-library) – browse voices per language and provider.

--- a/behavior/language/multilingual.mdx
+++ b/behavior/language/multilingual.mdx
@@ -27,7 +27,7 @@ Languages are now managed directly in Agent Studio. This replaces the older `sta
     Go to **Behavior** and find the **Additional languages** field. Select up to 10 additional languages from the dropdown. The **Response language** set during project creation becomes the **main language**.
   </Step>
   <Step title="Configure voices per language">
-    Each language has its own voice configuration. Go to **Voice > Agent** where you'll see a voice card for each configured language. The main language card is tagged as "Main language".
+    Each language has its own voice configuration. Go to **Voice > Settings** where you'll see a voice card for each configured language. The main language card is tagged as "Main language".
 
     - Select a voice for each language from the [Voice Library](/voice-channel/voice-library)
     - You can configure separate voices for **Agent voice** and **Disclaimer** per language
@@ -176,7 +176,7 @@ When multilingual support is enabled, the **Agent Voice** page shows separate vo
 
 ![Agent voice set language by voice](/images/agent-settings/agent-voice-set-language-by-voice.png)
 
-1. Go to **Voice > Agent**
+1. Go to **Voice > Settings**
 2. You'll see an **Agent** tab and a **Disclaimer** tab
 3. On the **Agent** tab, each language has its own voice card
 4. Click into a language card to select or change the voice
@@ -229,7 +229,7 @@ Sample questions must be in the same language as caller inputs – they are comp
 
 ## Language-specific pronunciation rules
 
-Pronunciation rules in [Response Control](/voice-channel/advanced/pronunciations) are organized by language. Each language has its own set of rules, displayed as separate collapsible cards. Rules within a language card only apply to responses in that language. Rules with no language specified apply globally.
+Pronunciation rules in [Advanced voice settings](/voice-channel/advanced/call-settings#pronunciation) are organized by language. Each language has its own set of rules, displayed as separate collapsible cards. Rules within a language card only apply to responses in that language. Rules with no language specified apply globally.
 
 ## What to translate
 
@@ -338,7 +338,7 @@ Language information surfaces across Agent Studio so you can review and filter m
   <Card title="Voice Library" icon="music" href="/voice-channel/voice-library">
     Browse and select voices per language for your agent.
   </Card>
-  <Card title="Pronunciations" icon="sound" href="/voice-channel/advanced/pronunciations">
+  <Card title="Pronunciations" icon="sound" href="/voice-channel/advanced/call-settings#pronunciation">
     Configure language-specific pronunciation rules for natural speech.
   </Card>
 </CardGroup>

--- a/behavior/language/translations.mdx
+++ b/behavior/language/translations.mdx
@@ -106,10 +106,10 @@ Use `<language:xx>` tags in behavior rules to scope style guides to specific lan
 ## Related pages
 
 <CardGroup cols={2}>
-  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/pronunciations">
+  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/call-settings#pronunciation">
     Control how your agent pronounces specific terms.
   </Card>
-  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/stop-keywords">
+  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/call-settings#stop-keywords">
     Block or log specific phrases in agent responses.
   </Card>
   <Card title="Multilingual setup" icon="language" href="/behavior/language/multilingual">

--- a/docs.json
+++ b/docs.json
@@ -259,16 +259,7 @@
                   }
                 ]
               },
-              {
-                "group": "Advanced",
-                "pages": [
-                  "voice-channel/advanced/call-settings",
-                  "voice-channel/advanced/speech-recognition",
-                  "voice-channel/advanced/response-control",
-                  "voice-channel/advanced/stop-keywords",
-                  "voice-channel/advanced/pronunciations"
-                ]
-              }
+              "voice-channel/advanced/call-settings"
             ]
           },
           {
@@ -1285,19 +1276,19 @@
     },
     {
       "source": "/response-control/introduction",
-      "destination": "/voice-channel/advanced/response-control"
+      "destination": "/voice-channel/advanced/call-settings"
     },
     {
       "source": "/response-control/stop-keywords",
-      "destination": "/voice-channel/advanced/stop-keywords"
+      "destination": "/voice-channel/advanced/call-settings#stop-keywords"
     },
     {
       "source": "/response-control/pronunciations",
-      "destination": "/voice-channel/advanced/pronunciations"
+      "destination": "/voice-channel/advanced/call-settings#pronunciation"
     },
     {
       "source": "/speech-recognition/introduction",
-      "destination": "/voice-channel/advanced/speech-recognition"
+      "destination": "/voice-channel/advanced/call-settings#keyphrases"
     },
     {
       "source": "/audio-management/introduction",
@@ -1445,11 +1436,11 @@
     },
     {
       "source": "/speech-recognition",
-      "destination": "/voice-channel/advanced/speech-recognition"
+      "destination": "/voice-channel/advanced/call-settings#keyphrases"
     },
     {
       "source": "/response-control",
-      "destination": "/voice-channel/advanced/response-control"
+      "destination": "/voice-channel/advanced/call-settings"
     },
     {
       "source": "/polyphone",
@@ -1478,6 +1469,22 @@
     {
       "source": "/environments-and-versions/project-history",
       "destination": "/environments-and-versions/introduction"
+    },
+    {
+      "source": "/voice-channel/advanced/speech-recognition",
+      "destination": "/voice-channel/advanced/call-settings#keyphrases"
+    },
+    {
+      "source": "/voice-channel/advanced/response-control",
+      "destination": "/voice-channel/advanced/call-settings#stop-keywords"
+    },
+    {
+      "source": "/voice-channel/advanced/stop-keywords",
+      "destination": "/voice-channel/advanced/call-settings#stop-keywords"
+    },
+    {
+      "source": "/voice-channel/advanced/pronunciations",
+      "destination": "/voice-channel/advanced/call-settings#pronunciation"
     }
   ],
   "background": {

--- a/essentials/order.mdx
+++ b/essentials/order.mdx
@@ -19,7 +19,7 @@ A conversation moves through the following stages:
   - **User**: The user provides input–speech (voice) or text (webchat/SMS).
   - **Input capture**: For voice, the audio stream is captured and sent for transcription. For webchat/SMS, text is received directly.
   - **ASR Provider** (voice only): The system receives the raw audio.
-  - **[ASR Service](/voice-channel/advanced/speech-recognition)** (voice only): Converts the audio into text using [automatic speech recognition](https://en.wikipedia.org/wiki/Speech_recognition).
+  - **[ASR Service](/voice-channel/advanced/call-settings#keyphrases)** (voice only): Converts the audio into text using [automatic speech recognition](https://en.wikipedia.org/wiki/Speech_recognition).
   - **ASR Processing** (voice only): Searches for transcription issues and applies any relevant corrections.
   - **Transcript/Text → Processed Input**: The processed input is passed to [Retrieval](/knowledge/faqs/RAG/introduction).
   - **Retrieval**: Pulls relevant **topics retrieved** from the [Knowledge area](/knowledge/faqs/introduction) using [RAG (retrieval-augmented generation)](https://en.wikipedia.org/wiki/Retrieval-augmented_generation) to provide context for the response.
@@ -40,7 +40,7 @@ A conversation moves through the following stages:
   <Accordion title="3. Streaming and chunking">
 
   - **Chunk LLM Output**: The response is broken into chunks for delivery.
-  - **Postprocess Chunks**: Applies rules such as [stop keywords](/voice-channel/advanced/stop-keywords) to remove unnecessary phrases.
+  - **Postprocess Chunks**: Applies rules such as [stop keywords](/voice-channel/advanced/call-settings#stop-keywords) to remove unnecessary phrases.
   - **Stream Partial Responses**: The system sends chunks as soon as they are ready, rather than waiting for the full response.
   - **TTS Service** (voice only): Converts text chunks into speech using [text-to-speech synthesis](https://en.wikipedia.org/wiki/Speech_synthesis). Configure voices in [voice settings](/voice-channel/introduction).
   - **Response delivery**: For voice, synthesized speech is streamed to the user. For webchat/SMS, text responses are sent directly.
@@ -64,7 +64,7 @@ PolyAI agents don't wait for the full response before speaking. Instead, respons
 
 - **LLM Streaming**: Words are generated and sent continuously.
 - **Chunking**: Responses are broken into chunks for controlled delivery.
-- **Postprocessing**: [Stop keywords](/voice-channel/advanced/stop-keywords) remove unnecessary phrases before delivery.
+- **Postprocessing**: [Stop keywords](/voice-channel/advanced/call-settings#stop-keywords) remove unnecessary phrases before delivery.
 - **Response Streaming**: For voice, users hear speech as soon as it's processed via TTS. For webchat, text appears progressively as it's generated.
 
 </div>
@@ -96,7 +96,7 @@ This video visualizes the conversation flow, showing how responses are processed
   <Card title="Knowledge setup" icon="brain" href="/knowledge/faqs/introduction">
     Add FAQs and knowledge sources
   </Card>
-  <Card title="Speech recognition" icon="ear" href="/voice-channel/advanced/speech-recognition">
+  <Card title="Keyphrases" icon="ear" href="/voice-channel/advanced/call-settings#keyphrases">
     Tune ASR and input processing
   </Card>
 </CardGroup>

--- a/glossary/introduction.mdx
+++ b/glossary/introduction.mdx
@@ -42,11 +42,11 @@ A manual tag applied during [Conversation Review](/analytics/conversations/revie
 
 ## ASR (Automatic Speech Recognition)
 
-Converts spoken language into text. PolyAI uses ASR models optimized for conversational accuracy with support for multiple languages, accents, and industry-specific vocabulary. See [Speech recognition](/voice-channel/advanced/speech-recognition).
+Converts spoken language into text. PolyAI uses ASR models optimized for conversational accuracy with support for multiple languages, accents, and industry-specific vocabulary. See [Advanced voice settings](/voice-channel/advanced/call-settings#keyphrases).
 
 ## ASR biasing
 
-A technique to improve speech recognition by instructing the ASR model to prioritize specific words or phrases. Available at three levels: **global** (also called [keyphrase boosting](#keyphrase-boosting), configured on the Speech Recognition page), **per-step** (configured on individual flow steps), and **dynamic** (set at runtime via `conv.set_asr_biasing()`). See [ASR biasing in flows](/flows/asr-biasing) and [Speech recognition](/voice-channel/advanced/speech-recognition).
+A technique to improve speech recognition by instructing the ASR model to prioritize specific words or phrases. Available at three levels: **global** (also called [keyphrase boosting](#keyphrase-boosting), configured in Advanced voice settings), **per-step** (configured on individual flow steps), and **dynamic** (set at runtime via `conv.set_asr_biasing()`). See [ASR biasing in flows](/flows/asr-biasing) and [Advanced voice settings](/voice-channel/advanced/call-settings#keyphrases).
 
 ## Barge-in
 
@@ -164,7 +164,7 @@ A standardized pronunciation system used in the Pronunciations feature to define
 
 ## Keyphrase boosting
 
-The global level of [ASR biasing](#asr-biasing), configured on the Speech Recognition page. Biases the ASR model toward recognizing specific words and phrases on every turn of the conversation for better domain-specific transcription accuracy. See [Keyphrase boosting](/voice-channel/advanced/speech-recognition).
+The global level of [ASR biasing](#asr-biasing), configured in Advanced voice settings. Biases the ASR model toward recognizing specific words and phrases on every turn of the conversation for better domain-specific transcription accuracy. See [Keyphrases](/voice-channel/advanced/call-settings#keyphrases).
 
 ## LLM (Large Language Model)
 
@@ -240,7 +240,7 @@ PolyAI's proprietary model family for conversational AI, specialized for custome
 
 ## Response control
 
-Modifies how agents respond: rate-limiting, interruption handling, compliance filtering. See [Response control](/voice-channel/advanced/response-control).
+Modifies how agents respond: rate-limiting, interruption handling, compliance filtering. See [Advanced voice settings](/voice-channel/advanced/call-settings).
 
 ## Safety dashboard
 
@@ -280,7 +280,7 @@ A self-contained conversation state within a flow, consisting of text prompts an
 
 ## Stop keyword
 
-A regex pattern that halts or logs agent responses containing specific phrases. See [Stop keywords](/voice-channel/advanced/stop-keywords).
+A regex pattern that halts or logs agent responses containing specific phrases. See [Stop keywords](/voice-channel/advanced/call-settings#stop-keywords).
 
 ## Start function
 
@@ -288,7 +288,7 @@ A function triggered at the beginning of an interaction for state initialization
 
 ## Transcript correction
 
-Editing AI-generated conversation transcripts to improve ASR accuracy and training data quality. See [Speech recognition](/voice-channel/advanced/speech-recognition#transcript-corrections).
+Editing AI-generated conversation transcripts to improve ASR accuracy and training data quality. See [Speech recognition](/voice-channel/advanced/call-settings#transcript-corrections).
 
 ## TTS (Text-to-Speech)
 

--- a/learn/guides/advanced/audio-management.mdx
+++ b/learn/guides/advanced/audio-management.mdx
@@ -14,7 +14,7 @@ import { LessonMeta } from '/snippets/lesson-meta.jsx'
 
 <LessonMeta level={2} difficulty="Intermediate" time="15 min" />
 
-[Audio Management](/voice-channel/audio-library) controls how TTS output is generated, cached, and replayed. Without understanding caching, teams often think changes "didn't apply" when they're hearing old audio.
+[Audio library](/voice-channel/audio-library) controls how TTS output is generated, cached, and replayed. Without understanding caching, teams often think changes "didn't apply" when they're hearing old audio.
 
 ## Understanding the audio cache
 
@@ -121,7 +121,7 @@ Interaction style controls how quickly the agent responds after detecting user s
 
 Ensure domain-specific terms are spoken clearly and correctly in Call.
 
-Pronunciations are defined in the **Pronunciations** tab under **Voice > [Response Control](/voice-channel/advanced/pronunciations)** and applied globally. They modify how text is converted to speech, without changing the underlying text.
+Pronunciations are defined in the **Pronunciations** tab under **Voice > [Advanced settings](/voice-channel/advanced/call-settings#pronunciation)** and applied globally. They modify how text is converted to speech, without changing the underlying text.
 
 ### When to use pronunciations
 
@@ -268,7 +268,7 @@ Matching is done using **regular expressions**. Replacements can be:
 
 
 <CardGroup cols={2}>
-  <Card title="← Previous: Response Control" icon="arrow-left" href="/learn/guides/advanced/response-control">
+  <Card title="← Previous: Advanced settings" icon="arrow-left" href="/learn/guides/advanced/response-control">
     Lesson 4 of 8
   </Card>
   <Card title="Next: Global ASR →" icon="arrow-right" href="/learn/guides/advanced/global-asr">

--- a/learn/guides/advanced/finished.mdx
+++ b/learn/guides/advanced/finished.mdx
@@ -15,8 +15,8 @@ import { Quiz } from '/snippets/quiz.jsx'
 You covered:
 - Complex [FAQs](/knowledge/faqs/introduction) with actions and multi-turn logic
 - [Functions](/tools/introduction): two-request pattern, [return values](/tools/return-values), what the LLM sees
-- Global [ASR](/voice-channel/advanced/speech-recognition) biasing and corrections
-- [Response Controls](/voice-channel/advanced/response-control) for regulating agent output
+- Global [ASR](/voice-channel/advanced/call-settings#keyphrases) biasing and corrections
+- [Advanced voice settings](/voice-channel/advanced/call-settings) for speech, pronunciation, and stop keywords
 - [Audio and voice](/voice-channel/audio-library) tuning
 - [Conversation Review](/analytics/conversations/review) diagnostics and metrics
 - Safe testing across [environments](/environments-and-versions/introduction)

--- a/learn/guides/advanced/global-asr.mdx
+++ b/learn/guides/advanced/global-asr.mdx
@@ -16,7 +16,7 @@ import { LessonMeta } from '/snippets/lesson-meta.jsx'
 
 <LessonMeta level={2} difficulty="Intermediate" time="20 min" />
 
-[ASR](/voice-channel/advanced/speech-recognition) determines what the agent *hears*. Every downstream system depends on it: retrieval, routing, response control, handoff logic. Small transcription errors here silently break otherwise well-designed agents. Global ASR is where you correct systematic listening problems at the source.
+[ASR](/voice-channel/advanced/call-settings#keyphrases) determines what the agent *hears*. Every downstream system depends on it: retrieval, routing, response control, handoff logic. Small transcription errors here silently break otherwise well-designed agents. Global ASR is where you correct systematic listening problems at the source.
 
 ## What global ASR is for
 

--- a/learn/guides/advanced/response-control.mdx
+++ b/learn/guides/advanced/response-control.mdx
@@ -14,7 +14,7 @@ import { LessonMeta } from '/snippets/lesson-meta.jsx'
 
 <LessonMeta level={2} difficulty="Intermediate" time="15 min" />
 
-[Response Controls](/voice-channel/advanced/response-control) regulate the agent's *own output*. They run **after** the model generates text and **before** anything is spoken or sent. Useful for tone, safety, and flow – easy to misuse if patterns are too broad.
+[Advanced voice settings](/voice-channel/advanced/call-settings) regulate the agent's *own output*. They run **after** the model generates text and **before** anything is spoken or sent. Useful for tone, safety, and flow – easy to misuse if patterns are too broad.
 
 ## What response controls are
 

--- a/learn/guides/get-started/create-a-project.mdx
+++ b/learn/guides/get-started/create-a-project.mdx
@@ -155,7 +155,7 @@ The right sidebar toggles open/closed for quick access to testing tools.
     - **Behavior > General** (personality, role, Behavior)
     - **Knowledge**
     - **Knowledge > Variants**
-    - **Voice > Agent**
+    - **Voice > Settings**
     - **Deployments**
   - The Knowledge page shows an empty state with a clear call to action (for example, **Add topic**), indicating you're ready for the next steps in the checklist.
 </Check>

--- a/learn/guides/get-started/edit-voice-settings.mdx
+++ b/learn/guides/get-started/edit-voice-settings.mdx
@@ -18,7 +18,7 @@ Complete this after behavior is stable but before call testing. The voice is wha
 
 ## Where this lives
 
-Navigate to **Voice > Agent**
+Navigate to **Voice > Settings**
 
 ![set-up-project](/images/academy/voice-agentvoice.png)
 

--- a/learn/iterate-open-platform.mdx
+++ b/learn/iterate-open-platform.mdx
@@ -25,7 +25,7 @@ Real callers say things your prompts did not anticipate, mispronounce reference 
 | Agent went off-topic | Conversations → transcript | Add a behavior rule in **Behavior > General > Behavior**, or tighten the topic content. |
 | Agent collected info but didn't act on it | Conversations → Diagnosis tab | Wire up the action on the topic, or add a handoff step. |
 | Welcome message is wrong | Studio Assistant | *"Rewrite the welcome message to be warmer and mention reservations specifically."* |
-| Voice sounds wrong | **Voice > Agent** | Pick another voice. Test on the next call. |
+| Voice sounds wrong | **Voice > Settings** | Pick another voice. Test on the next call. |
 
 ## The loop
 

--- a/learn/maintain/common-issues.mdx
+++ b/learn/maintain/common-issues.mdx
@@ -19,7 +19,7 @@ Most issues fall into a handful of patterns. Before you open a support ticket, r
 | **Analytics show zero calls** | Dashboard filtered to the wrong environment or date. | Switch environment to **Live** and widen the date range. | [Dashboards overview ↗](/analytics/dashboards/introduction) |
 | **CSV import failed** | Header names or file encoding off. | Re-export a fresh CSV, copy-paste rows, save as UTF-8, re-import. | [CSV imports ↗](/knowledge/variants/csv-imports) |
 | **I can't edit anything** | Read-only permissions. | Ask a project admin to grant you **Editor** in **User management**. | [Invite users ↗](/user-management/invite-users) |
-| **Audio is silent or distorted** | Voice config mismatch or bad network. | Check **Voice > Advanced > [Call settings]oice Configuration** for the correct TTS voice. Test your network or try another device. | [Voice config ↗](/voice-channel/advanced/call-settings) |
+| **Audio is silent or distorted** | Voice config mismatch or bad network. | Check **Voice > Advanced settings** for the correct TTS voice. Test your network or try another device. | [Voice config ↗](/voice-channel/advanced/call-settings) |
 | **Agent answers a totally different question** | Mis-matched topic or ASR error. | Review the conversation, tag **Wrong transcription** or **Missing topic**, and fix accordingly. | [Conversation review ↗](/analytics/conversations/review) |
 
 ## Knowledge base issues
@@ -61,15 +61,15 @@ Most issues fall into a handful of patterns. Before you open a support ticket, r
 
 <AccordionGroup>
   <Accordion title="Voice speed change isn't reflected in calls" icon="gauge-high">
-    The change may be pulling from cached audio. Go to **Audio Management**, find the specific audio clip, update the speed setting, and regenerate the audio.
+    The change may be pulling from cached audio. Go to **Voice > Audio library**, find the specific audio clip, update the speed setting, and regenerate the audio.
   </Accordion>
 
   <Accordion title="Agent mispronounces a word or brand name" icon="volume-xmark">
-    Use the **Pronunciations** feature in Audio Management. You can provide IPA notation, SSML overrides, or regex-based corrections. See [Audio Management](/learn/guides/advanced/audio-management) for details.
+    Use the **Pronunciation** section in **Voice > Advanced settings > Speech**. You can provide IPA notation, SSML overrides, or regex-based corrections. See [Audio Management](/learn/guides/advanced/audio-management) for details.
   </Accordion>
 
   <Accordion title="Disclaimer voice sounds different from the main agent" icon="microphone-lines">
-    The disclaimer uses a separate voice configuration. Check **Voice > Agent** – the **Disclaimer** section has its own voice selection and tuning, independent of the main agent voice.
+    The disclaimer uses a separate voice configuration. Check **Voice > Settings** – the **Disclaimer** section has its own voice selection and tuning, independent of the main agent voice.
   </Accordion>
 </AccordionGroup>
 

--- a/learn/maintain/multi-language-updates.mdx
+++ b/learn/maintain/multi-language-updates.mdx
@@ -11,9 +11,9 @@ Maintain multilingual capabilities by adding languages, updating language-specif
 |---|---|
 | Add a new language | **Behavior** → Additional languages |
 | Update language-specific knowledge | Edit topics with language variants or use `<language:xx>` tags |
-| Change voice for a language | **Voice > Agent** → select language card |
+| Change voice for a language | **Voice > Settings** → select language card |
 | Fix a translation issue | **Behavior > Language > [Translations](/behavior/language/translations)** → edit the card |
-| Add language-specific pronunciations | **Behavior > Language > [Pronunciations](/voice-channel/advanced/pronunciations)** → add rules per language |
+| Add language-specific pronunciations | ****Voice > Advanced settings > Speech** > [Pronunciation](/voice-channel/advanced/call-settings#pronunciation)** → add rules per language |
 | Test language switching | Agent Chat → select language from dropdown |
 
 ## Adding or removing languages
@@ -21,11 +21,11 @@ Maintain multilingual capabilities by adding languages, updating language-specif
 ### Adding a new language
 
 1. Go to **Behavior** and add the language under **Additional languages**
-2. Configure a voice for the new language in **Voice > Agent**
+2. Configure a voice for the new language in **Voice > Settings**
 3. Add language-specific knowledge (see below)
 4. Add any necessary [translation overrides](/behavior/language/translations)
 5. Update [behavior rules](/behavior/general/rules) for the new language – use `<language:xx>` tags to scope rules to specific languages
-6. Add [pronunciation rules](/voice-channel/advanced/pronunciations) for the new language
+6. Add [pronunciation rules](/voice-channel/advanced/call-settings#pronunciation) for the new language
 7. Test in Agent Chat using the language dropdown, then publish
 
 <Tip>Use a multilingual voice model (such as ElevenLabs multilingual or Cartesia sonic) for proper pronunciation across languages. See [Voice](/tools/classes/voice) for available providers including ElevenLabs, Cartesia, Hume, Rime, Minimax, PlayHT, and Google TTS.</Tip>
@@ -150,7 +150,7 @@ Not all project content needs translation. See the full reference table in [Mult
 | Cultural mismatches | Use culturally-appropriate equivalents for idioms |
 | Incorrect terminology | Use domain-specific terms with a glossary |
 | Formatting issues | Localize date/time/number formats per language |
-| Pronunciation issues | Add language-specific rules on the [Pronunciations](/voice-channel/advanced/pronunciations) page |
+| Pronunciation issues | Add language-specific rules in [Advanced voice settings](/voice-channel/advanced/call-settings#pronunciation) |
 
 For content where auto-translation isn't sufficient, use the [Translations](/behavior/language/translations) page to create manual overrides. For bulk updates to FAQs, export as CSV, translate the content, then re-import.
 
@@ -171,7 +171,7 @@ For content where auto-translation isn't sufficient, use the [Translations](/beh
 
 - [Multi-language setup](/behavior/language/multilingual) – configure language support and see the full "what to translate" reference
 - [Translations](/behavior/language/translations) – manage manual translation overrides
-- [Pronunciations](/voice-channel/advanced/pronunciations) – configure language-specific pronunciation rules
+- [Advanced voice settings](/voice-channel/advanced/call-settings#pronunciation) – pronunciation and speech configuration
 - [Voice Library](/voice-channel/voice-library) – browse and select voices per language
 - [FAQs](/knowledge/faqs/introduction) – add language variants
 - [Voice](/tools/classes/voice) – programmatic voice configuration with provider classes

--- a/learn/maintain/voice-audio-updates.mdx
+++ b/learn/maintain/voice-audio-updates.mdx
@@ -3,25 +3,24 @@ title: 'Voice and audio updates'
 description: 'Change voice, fix pronunciations, adjust latency, and manage cached audio for optimal voice quality.'
 ---
 
-Update voice settings, fix mispronunciations, manage cached audio, and tune interaction styles to maintain high-quality voice experiences for your callers.
+Update voice settings, fix mispronunciations, manage cached audio, and tune call behavior to maintain high-quality voice experiences for your callers.
 
 ## Quick reference
 
 | I need to... | Action |
 |---|---|
-| Change the agent's voice | **Voice > Agent** → Change |
-| Adjust voice parameters | **Voice > Agent** → settings gear |
-| Fix a mispronunciation | **Voice > Advanced > [Response control]esponse Control** → Pronunciations |
-| Update cached audio | **Audio Management** → Edit → Sync |
-| Change interaction style | **Voice > Audio Management** → Interaction style |
-| Enable/disable barge-in | **Voice > Audio Management** → toggle |
-| Upload custom audio | **Audio Management** → Upload |
+| Change the agent's voice | **Voice > Settings** → Change |
+| Adjust voice parameters | **Voice > Settings** → settings gear |
+| Fix a mispronunciation | **Voice > Advanced settings > Speech** → Pronunciation |
+| Update cached audio | **Voice > Audio library** → Edit → Sync |
+| Enable/disable barge-in | **Voice > Advanced settings > Call** → toggle |
+| Upload custom audio | **Voice > Audio library** → Upload |
 
 ## Changing your agent's voice
 
 Consider updating when your brand refreshes, customers report clarity issues, you're expanding to new languages, or newer voice models become available.
 
-1. Go to **Voice > Agent**
+1. Go to **Voice > Settings**
 2. Click **Change** to open the [Voice Library](/voice-channel/voice-library)
 3. Filter by **Language**, **Region**, and **Gender**
 4. Preview voices with custom text
@@ -32,33 +31,20 @@ Consider updating when your brand refreshes, customers report clarity issues, yo
 
 For programmatic voice configuration, see [voice classes](/tools/classes/voice) and [Add a voice](/voice-channel/add-a-new-voice).
 
-## Interaction style and barge-in
+## Barge-in
 
-### Interaction style (response latency)
+Toggle in **Voice > Advanced settings > Call**. Lets callers interrupt the agent mid-sentence.
 
-Control how quickly your agent responds in **Voice > Audio Management**:
-
-| Mode | Delay | Best for |
-|---|---|---|
-| **Turbo** | 400ms | Ultra-fast, may interrupt more |
-| **Swift** | 1200ms | Simple queries |
-| **Balanced** | 1600ms | Most use cases (default) |
-| **Precise** | 2000ms | Complex queries needing accuracy |
-
-### Barge-in
-
-Toggle in **Voice > Audio Management**. Lets callers interrupt the agent mid-sentence.
-
-**Enable when:** using Turbo mode, callers frequently interrupt, or you want more natural conversations.
+**Enable when:** callers frequently interrupt, or you want more natural conversations.
 **Disable when:** delivering complete information (legal disclaimers), background noise causes false interruptions.
 
 ## Managing audio quality
 
 ### Cached audio
 
-The Audio Management tab lets you cache and optimize frequently-used audio for reduced latency and consistent quality.
+The Audio library tab lets you cache and optimize frequently-used audio for reduced latency and consistent quality.
 
-- Find utterances in **Voice > Audio Management**
+- Open **Voice > Audio library**
 - Click **Edit** to adjust stability/clarity settings or add IPA pronunciation corrections
 - Click the **sync** icon to regenerate, then preview
 
@@ -72,10 +58,10 @@ Upload pre-recorded audio (WAV or MP3) for maximum control over greetings, legal
 
 When the agent mispronounces words:
 
-1. Go to **Voice > Advanced > [Response control]esponse Control** → **Pronunciations** tab
-2. Click **Add pronunciation**
-3. Enter the word as it appears in text
-4. Provide the IPA pronunciation (e.g., "PolyAI" → `/ˈpɒli eɪ aɪ/`)
+1. Go to **Voice > Advanced settings > Speech** → **Pronunciation** section
+2. Add a pronunciation rule
+3. Enter the regex pattern for the word as it appears in text
+4. Provide the IPA replacement (e.g., "PolyAI" → `/ˈpɒli eɪ aɪ/`)
 5. Test in Agent Chat
 
 You can also use SSML for advanced control:
@@ -90,11 +76,11 @@ You can also use SSML for advanced control:
 | Issue | Likely cause | Fix |
 |---|---|---|
 | Voice sounds robotic | Low-quality TTS | Switch to Cartesia or ElevenLabs |
-| Agent speaks too fast | Rate set too high | Adjust with the settings gear in Agent Voice |
-| Agent interrupts frequently | Turbo mode without barge-in | Enable barge-in or switch to Balanced |
-| Mispronunciations | TTS doesn't recognize word | Add pronunciation in Response Control |
+| Agent speaks too fast | Rate set too high | Adjust with the settings gear in Voice Settings |
+| Agent interrupts frequently | Barge-in too sensitive | Disable barge-in in Advanced settings > Call |
+| Mispronunciations | TTS doesn't recognize word | Add pronunciation rule in Advanced settings > Speech |
 | High latency | Slow TTS provider | Switch to Cartesia or use cached audio |
-| Background noise interruptions | Barge-in too sensitive | Disable barge-in or adjust interaction style |
+| Background noise interruptions | Barge-in too sensitive | Disable barge-in or increase speech end delay |
 
 ## Maintenance routine
 
@@ -104,7 +90,7 @@ You can also use SSML for advanced control:
 
 ## Related pages
 
-- [Audio Management](/voice-channel/audio-library) – audio caching and optimization
-- [Response Control](/voice-channel/advanced/response-control) – pronunciations and output controls
-- [Voice Library](/voice-channel/voice-library) – browse and select voices
-- [Agent Voice](/voice-channel/agent) – voice configuration options
+- [Audio library](/voice-channel/audio-library) – audio caching and optimization
+- [Advanced voice settings](/voice-channel/advanced/call-settings) – model, barge-in, speech recognition, pronunciation
+- [Voice library](/voice-channel/voice-library) – browse and select voices
+- [Voice settings](/voice-channel/agent) – voice configuration options

--- a/releases/notes/24.11.mdx
+++ b/releases/notes/24.11.mdx
@@ -73,7 +73,7 @@ trigger custom functions or prevent unwanted interactions. Use this feature to c
 2. Add Stop Keywords and define their behavior using RegEx patterns.
 3. Optionally, configure the agent to trigger a custom function or workflow when a Stop Keyword is detected.
 
-Visit the [response control](/voice-channel/advanced/stop-keywords) page for more details.
+Visit the [stop keywords](/voice-channel/advanced/call-settings#stop-keywords) section for more details.
 
 </Accordion>
 

--- a/releases/notes/24.12.mdx
+++ b/releases/notes/24.12.mdx
@@ -39,7 +39,7 @@ Use transcript corrections to aid agents in recognizing domain-specific terms, a
 
 ![transcript-corrections](/images/release-notes/2412/transcript-correction.png)
 
-Go to **"Speech Recognition"** > **"Transcript Corrections."** in the studio to use this feature, and visit the full [documentation](/voice-channel/advanced/speech-recognition#configuring-transcript-corrections) page for more details.
+Go to **Voice > Advanced settings > Speech** in the studio to use this feature, and visit the full [documentation](/voice-channel/advanced/call-settings#transcript-corrections) page for more details.
 
 </Accordion>
 

--- a/releases/notes/26.04.mdx
+++ b/releases/notes/26.04.mdx
@@ -17,7 +17,7 @@ Build a single agent that handles multiple languages – no separate projects, n
 
 **What's new:**
 - **Add languages in the UI** – go to **Behavior** and add up to 10 additional languages with a couple of clicks.
-- **Per-language voices** – assign a dedicated Agent voice and Disclaimer voice for each language under **Voice > Agent**, with multi-voice support per language. The agent switches voice automatically when the conversation language changes.
+- **Per-language voices** – assign a dedicated Agent voice and Disclaimer voice for each language under **Voice > Settings**, with multi-voice support per language. The agent switches voice automatically when the conversation language changes.
 - **Test in any language** – a new language dropdown in Agent Chat lets you start conversations in a specific language to verify behavior before going live.
 - **Conditional content tags** – wrap language-specific content in `<language:en>` / `<language:es>` tags to serve the right version from a single prompt.
 - **Test in any language** – a new language dropdown in Agent Chat lets you start conversations in a specific language to verify behavior before going live.

--- a/releases/overview.mdx
+++ b/releases/overview.mdx
@@ -55,7 +55,7 @@ Explore the update cards for release summaries:
   Click the **bolded** titles for a breakdown of what's new, or go to the [notes tab](./notes/26.04) for full details.
 
   - **[Multi-language support](./notes/26.04#multilingual)**: Configure a single agent to handle [multiple languages](/behavior/language/multilingual) from the UI – add languages, assign per-language voices with automatic switching, use conditional content tags, and test in any language from Agent Chat.
-  - **[Translations](./notes/26.04#translations)**: A new [Translations](/behavior/language/translations) page under [Response Control](/voice-channel/advanced/response-control) lets you manage auto-translated content and manually override specific phrases.
+  - **[Translations](./notes/26.04#translations)**: A new [Translations](/behavior/language/translations) page under [Advanced voice settings](/voice-channel/advanced/call-settings) lets you manage auto-translated content and manually override specific phrases.
   - **[MCP integrations](./notes/26.04#mcp-integrations)**: Connect [external tool servers](/integrations/mcp) to your agent from **Integrations > MCP**.
 </Update>
 

--- a/tools/classes/asr-from-conv.mdx
+++ b/tools/classes/asr-from-conv.mdx
@@ -31,7 +31,7 @@ You do not need to re-apply biasing on every turn.
 
 Function-set ASR biasing has the highest priority. It is merged with any ASR configuration defined elsewhere, including:
 
-- global ASR settings (configured on the **Voice > Speech recognition** page)
+- global ASR settings (configured on the **Voice > Advanced settings > Speech** page)
 - step-level ASR settings (configured on individual flow steps)
 - language-specific ASR settings
 

--- a/tools/delay-control.mdx
+++ b/tools/delay-control.mdx
@@ -42,7 +42,7 @@ Delay scripts play on a fixed timer that starts when the function begins executi
 - **Barge-in enabled:** The agent stops playing the current delay response and listens to the caller. The remaining delay scripts in the queue are discarded. When the function completes, the agent responds to whatever the caller said rather than resuming the delay sequence.
 - **Barge-in disabled:** Delay responses continue playing on schedule regardless of caller speech. The caller's input is still captured by ASR but is only processed after the current agent utterance finishes.
 
-Barge-in behavior cannot be fully tested in the chat panel — use a real phone call to verify how your delay responses interact with caller interruptions. See [Audio management](/voice-channel/audio-library#barge-in) for barge-in configuration.
+Barge-in behavior cannot be fully tested in the chat panel — use a real phone call to verify how your delay responses interact with caller interruptions. See [Advanced voice settings](/voice-channel/advanced/call-settings#barge-in) for barge-in configuration.
 
 ### Functions with side effects
 

--- a/troubleshoot/faq-personality.mdx
+++ b/troubleshoot/faq-personality.mdx
@@ -8,7 +8,7 @@ Answers to questions about setting your agent's personality, tone, and role. Thi
 
 <AccordionGroup>
   <Accordion title="How do I set the agent's personality and tone?" icon="face-smile">
-    Personality and role are configured in **Behavior > General**. The greeting is configured per-channel under **Voice > Advanced > Call settings** (or **Messaging > Advanced > Chat configuration**), not on the Agent page.
+    Personality and role are configured in **Behavior > General**. The greeting is configured per-channel under **Voice > Advanced settings** (or **Messaging > Advanced > Chat configuration**), not on the Agent page.
 
     The built-in personality tags (`Polite`, `Kind`, `Funny`, `Energetic`, `Calm`, `Thoughtful`) are simply inserted as adjectives into the system prompt – e.g. _"You are a polite, kind \[role]."_. Selecting **Other** replaces the joined adjectives with your free-form string. There's no hidden behavior tied to specific words – they're literal prompt content.
 

--- a/troubleshoot/faq-technical.mdx
+++ b/troubleshoot/faq-technical.mdx
@@ -11,7 +11,7 @@ Answers to technical questions about automatic speech recognition (ASR), text-to
     No. Prompts do not influence automatic speech recognition (ASR) or text-to-speech (TTS). These systems are independent.
 
     <Note>
-      To customize speech recognition, use [ASR biasing](/flows/asr-biasing) and [keyphrase boosting](/voice-channel/advanced/speech-recognition). To customize voice output, see [voice configuration](/voice-channel/introduction).
+      To customize speech recognition, use [ASR biasing](/flows/asr-biasing) and [keyphrase boosting](/voice-channel/advanced/call-settings#keyphrases). To customize voice output, see [voice settings](/voice-channel/introduction).
     </Note>
   </Accordion>
   <Accordion title="What are token and context limits?" icon="memory">

--- a/voice-channel/add-a-new-voice.mdx
+++ b/voice-channel/add-a-new-voice.mdx
@@ -97,7 +97,7 @@ Prepend the model ID to the voice ID (e.g. `eleven_turbo_v2_5/a1b2c3...`) to iso
   <Card title="Multi-voice" icon="users" href="/voice-channel/multi-voice">
     Use multiple voices in a single agent
   </Card>
-  <Card title="Voice configuration" icon="gear" href="/voice-channel/advanced/call-settings">
+  <Card title="Advanced voice settings" icon="gear" href="/voice-channel/advanced/call-settings">
     Configure model selection and call settings
   </Card>
 </CardGroup>

--- a/voice-channel/advanced/call-settings.mdx
+++ b/voice-channel/advanced/call-settings.mdx
@@ -1,59 +1,163 @@
 ---
-title: "Voice configuration"
-sidebarTitle: "Configuration"
-description: "Configure model selection, greeting, disclaimer, safety filters, and call handling settings."
+title: "Advanced voice settings"
+sidebarTitle: "Advanced settings"
+description: "Configure model selection, barge-in, filler phrases, safety filters, keyphrases, transcript corrections, and pronunciation for voice agents."
 keywords:
   - voice configuration
   - voice settings
-  - greeting
-  - disclaimer
+  - model selection
+  - barge-in
+  - filler phrases
+  - CSAT
   - safety filters
-  - call handling
+  - keyphrase boosting
+  - transcript corrections
+  - pronunciations
+  - speech recognition
+  - ASR
+  - stop keywords
+  - turn-taking
 ---
 
-The **Voice Configuration** page (**Voice > Advanced > Call settings**) controls voice-specific settings including model selection, greeting, and disclaimer behavior.
+The **Advanced settings** page controls voice-specific configuration that goes beyond basic voice selection. Open it from the **Advanced settings** link in the top-right corner of the Voice page.
 
-**Greeting and disclaimer settings are in Voice Configuration**, separate from shared agent configuration in **Behavior > General**.
+The page has three tabs: **Model**, **Call**, and **Speech**.
 
-## Model selection
+## Model
 
-Select the language model that powers your voice agent.
+### Voice mode
 
-<ParamField path="Large language model" type="dropdown">
+Choose between two architectures for your voice agent:
+
+| Mode | Description |
+|------|-------------|
+| **Traditional** | Separate components handle speech recognition, language processing, and speech synthesis. |
+| **End-to-end** | A unified model directly maps input (audio, text, or multimodal signals) to speech output. |
+
+### Language model
+
+Select the LLM that powers your voice agent.
+
+<ParamField path="Model" type="dropdown">
   Choose the LLM for voice conversations. PolyAI's **Raven** models are recommended for voice – they are designed for conversational AI and deliver the most natural, grounded responses.
+</ParamField>
+
+<ParamField path="Temperature" type="slider">
+  Controls response variability. Lower values (toward **Deterministic**) produce more consistent, predictable responses. Higher values (toward **Creative**) produce more varied output. Default is 0.4.
 </ParamField>
 
 **Recommended for voice:** PolyAI's [Raven 3.5](/behavior/models/raven) is designed for conversational AI. It produces concise, natural responses without needing example utterances in your prompts — just add raw information and Raven converts it into conversational speech. Raven 3.5 supports 24+ languages, delivers sub-300ms latency, and includes auto-reasoning, out-of-domain detection, and built-in safety.
 
 For a full list of available models, see the [Model](/behavior/models/model-use) page.
 
-## Voice greeting
+### Speech recognition
 
-Configure what your agent says when a call begins.
+Choose the primary transcription engine and target language for your voice agent.
 
-<ParamField path="Greeting message" type="string">
-  The first thing your agent says when answering a call.
-  
-  **Example:** "Thank you for calling. How can I help you today?"
+<ParamField path="Model" type="dropdown">
+  Select the ASR model used to transcribe caller speech. The model you choose affects transcription accuracy, latency, and language support.
 </ParamField>
 
-Keep your greeting concise. Long greetings can frustrate callers who want to get to the point quickly.
+### Turn-taking
 
-## Voice disclaimer
+Control when the agent starts speaking after the caller stops.
 
-Configure a disclaimer message that plays at the start of calls.
-
-<ParamField path="Disclaimer message" type="string">
-  A message informing callers about call recording or other legal requirements.
-  
-  **Example:** "This call may be recorded for quality and training purposes."
+<ParamField path="Speech end delay" type="slider">
+  How long to wait (in milliseconds) after the caller stops speaking before the agent begins its response. **Fast** (200ms) responds quickly but may cut off pauses. **Tolerant** (1000ms) waits longer through pauses but adds latency.
 </ParamField>
 
-<ParamField path="Disclaimer voice" type="string">
-  You can use a separate voice for the disclaimer to distinguish it from the main agent voice. Configure this in [Agent Voice](/voice-channel/agent).
+### AI-coustics
+
+<ParamField path="AI-coustics" type="boolean">
+  Removes background noise and enhances audio quality. Enable this for callers in noisy environments.
 </ParamField>
 
-## Safety filters
+---
+
+## Call
+
+### Barge-in
+
+Allow callers to interrupt the agent mid-utterance. When enabled, the agent stops speaking as soon as it detects caller speech, shortening [VAD](https://en.wikipedia.org/wiki/Voice_activity_detection) time and reducing response latency.
+
+<ParamField path="Enable barge-in" type="boolean">
+  Toggle on to let callers interrupt the agent mid-sentence.
+</ParamField>
+
+<ParamField path="Enable on first turn" type="boolean">
+  When enabled, barge-in is active from the very first agent utterance (including the greeting). When disabled, barge-in activates after the first turn completes.
+</ParamField>
+
+<ParamField path="Maximum barge-ins per call" type="number">
+  Limit how many times a caller can interrupt per call. Set to 0 for unlimited.
+</ParamField>
+
+#### How barge-in works
+
+When barge-in is enabled:
+1. The agent begins speaking its response.
+2. If the caller starts talking, the agent stops its current utterance and begins listening.
+3. The agent processes the caller's input and responds as a new turn.
+
+This also applies to [delay control](/tools/delay-control) responses – if the caller speaks during a filler phrase, the delay sequence is interrupted.
+
+#### When to use barge-in
+
+Barge-in works well for:
+- FAQ-heavy agents where callers may already know what they need
+- Long agent responses where the caller wants to redirect the conversation
+- Fast interaction styles where responsiveness is a priority
+
+#### When to disable barge-in
+
+Consider disabling barge-in (globally or per flow/step) when:
+- The agent is executing a function with **external side effects** (bookings, payments, form submissions) – the caller may interrupt after the action completes but before hearing the confirmation
+- The agent must deliver a **mandatory disclosure or disclaimer** that cannot be skipped
+- The environment is **noisy**, causing false barge-in triggers from background sounds
+
+#### Per-flow and per-step overrides
+
+You can configure barge-in at a granular level using the experimental JSON config. This lets you enable barge-in globally while disabling it for specific flows or steps where interruption would be problematic.
+
+Overrides follow a precedence order: **step > flow > global**. For example, you can have barge-in off globally, enabled for a specific flow, and disabled again for a sensitive step within that flow.
+
+<Note>
+Barge-in behavior cannot be fully tested in the chat panel. Always verify with a real phone call.
+</Note>
+
+### Filler phrases
+
+Configure brief sounds or words the agent uses while processing the user's input — "One moment...", "Just a second...", etc. These fill the gap between the caller finishing and the agent responding, preventing awkward silence.
+
+<ParamField path="Enable filler phrases" type="boolean">
+  Toggle on to enable filler phrases during processing delays.
+</ParamField>
+
+<ParamField path="Randomize filler phrases" type="boolean">
+  When enabled, the agent picks randomly from the configured phrases instead of cycling in order.
+</ParamField>
+
+<ParamField path="Initial interval (s)" type="number">
+  How many seconds to wait before the first filler phrase plays.
+</ParamField>
+
+<ParamField path="Interval between filler phrases (s)" type="number">
+  How many seconds between subsequent filler phrases if the agent is still processing.
+</ParamField>
+
+### Customer satisfaction survey (CSAT)
+
+<ParamField path="Enable in-call voice survey" type="boolean">
+  Enable to collect customer feedback during voice calls. Additional options appear once enabled.
+</ParamField>
+
+When enabled, the agent can route callers into a CSAT survey flow at the end of the conversation. For full configuration details — survey questions, scoring, and dashboard integration — see [CSAT surveys](/analytics/csat/introduction).
+
+---
+
+## Speech
+
+### Safety filters
 
 Safety filters are configured on a **per-channel basis**. The voice channel has its own safety filter settings, separate from the chat channel and the project-wide defaults. See [Safety filters](/behavior/guardrails/safety-filters) for the full reference on categories, severity levels, and how filters interact with [Guardrails](/behavior/guardrails/introduction).
 
@@ -78,17 +182,286 @@ The jailbreak attack filter is always enabled and cannot be turned off.
 More lenient settings allow a wider range of content through. Review your use case and compliance requirements when adjusting these settings.
 </Warning>
 
-## Call handling settings
+### Keyphrases
 
-Additional settings that affect how calls are handled:
+Keyphrase boosting improves [ASR](https://en.wikipedia.org/wiki/Speech_recognition) recognition of domain-specific terms like product names, locations, or specialized vocabulary. It biases the ASR model toward recognizing specific words during transcription.
 
-- **Silence timeout** - How long to wait during silence before prompting the caller
-- **Max call duration** - Maximum length of a call before automatic termination
-- **End of call behavior** - What happens when a call ends (e.g., trigger CSAT survey)
+<Warning>
+Biasing the ASR can cause unwanted side effects. Adding too many keyphrases or setting bias too high may cause the model to over-correct natural speech. For example, boosting the word `flimsy` at Maximum strength could cause unrelated words like `Lindsay` to be transcribed as `flimsy`. Always test thoroughly in sandbox before deploying changes to production.
+</Warning>
+
+#### Configuring keyphrases
+
+1. Open the **Keyphrases** section on the Speech tab.
+2. Add, edit, or remove keyphrases.
+3. Adjust the **bias strength** for each keyphrase using the slider.
+4. Save your changes. Updated keyphrases are applied immediately.
+
+#### Bias strength levels
+
+| Level | Behavior |
+|-------|----------|
+| **Default** | Light bias. Balances recognition accuracy with overall ASR performance. |
+| **Boosted** | Moderate bias. Increases recognition of the keyphrase without heavily impacting general transcription. |
+| **Maximum** | Strong bias. Prioritizes the keyphrase but may interfere with natural speech patterns. |
+
+Maximum bias does not always produce better results. In some cases it can cause the model to misrecognize unrelated words. Start with Default or Boosted and only escalate to Maximum after testing confirms it is needed.
+
+#### Example keyphrases
+
+| Keyphrase | Use case | Suggested strength |
+|-----------|----------|-------------------|
+| `flexi-access` | Financial product name | Boosted |
+| `BlueStar` | Brand name frequently misheard as "blue star" | Maximum |
+| `hablas español` | Spanish phrase in an English-language agent | Boosted |
+| `isotretinoin` | Medical term | Maximum |
+| `pension` | Domain-specific term | Default |
+
+<Note>
+**Keyphrase boosting and ASR biasing are the same mechanism.** Keyphrase boosting is the *global* level of ASR biasing – it applies to every turn of the conversation. ASR biasing also has *per-step* and *dynamic* levels for more targeted control. See [ASR biasing in flows](/flows/asr-biasing) and [ASR biasing from functions](/tools/classes/asr-from-conv).
+</Note>
+
+#### Global vs. per-step vs. dynamic biasing
+
+The Speech tab configures **global** keyphrase boosting, which applies to every turn of the conversation. Two additional levels of biasing are available for more targeted control:
+
+- **Per-step biasing** – configure ASR biasing on individual flow steps for contextual precision (e.g. biasing for doctor names only during a name-collection step). See [ASR biasing in flows](/flows/asr-biasing).
+- **Dynamic biasing from functions** – set biasing at runtime using `conv.set_asr_biasing()` when you need to bias toward values retrieved from an API or database. See [ASR biasing from functions](/tools/classes/asr-from-conv).
+
+**Precedence rules:** When multiple levels of biasing are active, they are merged with the following priority (highest first):
+
+1. **Dynamic** – biasing set via `conv.set_asr_biasing()` in functions
+2. **Per-step** – biasing configured on individual flow steps
+3. **Global** – biasing configured on the Speech tab
+
+If the same phrase appears at multiple levels, the highest-priority setting takes precedence.
+
+### Transcript corrections
+
+Fix common ASR misinterpretations using string matching and [regex](https://en.wikipedia.org/wiki/Regular_expression) patterns. Unlike keyphrases, transcript corrections run *after* the ASR model has produced a transcript – they replace text in the output rather than influencing what the model hears.
+
+<Warning>
+Transcript corrections can match broadly and introduce errors if the pattern is too wide. A correction like `blue star` → `BlueStar` could also fire on legitimate uses of "blue star" in other contexts. Use specific regex patterns and test corrections against a range of real transcripts before deploying.
+</Warning>
+
+#### Configuring transcript corrections
+
+1. Open the **Transcript corrections** section on the Speech tab.
+2. Click **Correction** to create a new rule.
+3. Give the correction a **name** (must be unique) and optional **description**.
+4. Add one or more regex rules within the correction:
+   - **Replacement type**: **Full transcript** (replaces the entire transcript if matched exactly) or **Partial transcript** (replaces only the matching portion).
+   - **Regex**: the regular expression to match the misinterpreted phrase.
+   - **Replacement**: the correct term or phrase (leave empty to delete the matched text).
+5. Changes auto-save as you edit.
+
+You can group multiple related regex rules under a single correction. For example, create a correction called "Brand names" containing rules for each brand your agent handles.
+
+#### Example configurations
+
+| Regex | Replacement | Type | Use case |
+|-------|-------------|------|----------|
+| `\bI\s?C\s?U\b` | `I see you` | Partial transcript | Medical abbreviation being misheard |
+| `\b(blue star\|bluestar)\b` | `BlueStar` | Partial transcript | Brand name correction |
+| `\bDr\.?\s?Amari\b` | `Dr. Amari` | Partial transcript | Proper noun / doctor name |
+| `\bfull fund is cash\b` | `full fund as cash` | Partial transcript | Financial term correction |
+
+#### Verifying corrections are applied
+
+1. Open a conversation in [Conversation Review](/analytics/conversations/review).
+2. Enable the **Transcript corrections** layer in [Conversation Diagnosis](/analytics/conversations/diagnosis).
+3. Check each turn to see whether your correction was triggered.
+
+If a correction is not firing as expected, compare the raw ASR transcript against your regex pattern. Common issues include unexpected whitespace, casing differences, or partial word boundaries.
+
+### Pronunciation
+
+Control how your agent pronounces specific terms using the [International Phonetic Alphabet (IPA)](https://pronunciationstudio.com/english-ipa-chart/) or SSML tags. Useful for brand names, proper nouns, and domain-specific vocabulary that TTS engines frequently mispronounce.
+
+<Info>
+Pronunciation rules apply to **voice agents only**. For text-channel agents, this section can be skipped.
+</Info>
+
+#### How it works
+
+Pronunciation rules use regex patterns to match text in the agent's response and replace it with IPA notation or SSML markup before it reaches the TTS engine. You can also use SSML such as `<break>`, `<prosody>`, and `<emphasis>` in the replacement string.
+
+#### Multilingual pronunciation rules
+
+For multilingual agents, pronunciation rules are organized by language. Each language has its own set of rules displayed as separate collapsible cards. Rules within a language card only apply to responses in that language.
+
+To add a rule for a specific language:
+1. Expand the language card.
+2. Add the regex pattern and replacement.
+3. The rule automatically scopes to that language.
+
+Rules with no language specified apply globally across all languages.
+
+#### Rule evaluation order
+
+Pronunciation rules are evaluated **from top to bottom**. Each rule runs on the text produced by the rule above it. Because rules are applied sequentially, later rules can modify or override earlier transformations.
+
+![Rule evaluation order](/images/response-control/response-order.png)
+
+#### Common pronunciation patterns
+
+![Pronunciation rules showing regex patterns for phone numbers, zip codes, and URLs](/images/response-control/regex-pronunciation-examples.png)
+
+<AccordionGroup>
+  <Accordion title="Simple text replacement">
+    Replace a specific string with a spoken equivalent.
+
+    - **Regex:** `3\-5`
+    - **Replacement:** `three to five`
+  </Accordion>
+  <Accordion title="Read a phone number digit by digit">
+    - **Regex:** `\b(\d)(\d)(\d)-(\d)(\d)(\d)-(\d)(\d)(\d)(\d)\b`
+    - **Replacement:** `\1 \2 \3, \4 \5 \6, \7 \8 \9 \10`
+
+    Produces "six five one, three five nine, two nine two three" for `651-359-2923`.
+  </Accordion>
+  <Accordion title="Read a zip code digit by digit">
+    - **Regex:** `\b(\d)(\d)(\d)(\d)(\d)\b`
+    - **Replacement:** `\1, \2, \3, \4, \5`
+  </Accordion>
+  <Accordion title="Make a URL speakable">
+    - **Regex:** `www\.`
+    - **Replacement:** `W, W, W, dot`
+  </Accordion>
+  <Accordion title="SSML pauses in phone numbers">
+    - **Regex:** `\(?(\d{3})\)?[ -]?(\d{3})[ -]?(\d{4})`
+    - **Replacement:** `\1 <break time="0.5s" /> \2 <break time="0.5s" /> \3`
+
+    Handles multiple formats — `(651) 359-2923`, `651-359-2923`, or `6513592923` — and inserts half-second pauses. See [SSML breaks](https://cloud.google.com/text-to-speech/docs/ssml#break) for more timing options.
+  </Accordion>
+  <Accordion title="IPA correction">
+    - **Regex:** `\bLouvre\b`
+    - **Replacement:** `/ˈluːvrə/`
+    - **Case sensitive:** `FALSE`
+  </Accordion>
+</AccordionGroup>
+
+![Example pronunciation rules](/images/response-control/tts-pronunciation.png)
+
+### Stop keywords
+
+When a response matches a stop keyword pattern, the system halts the response and logs the occurrence. Use stop keywords to catch sensitive content, remove unnecessary preambles, or enforce brand adherence.
+
+#### Stop keyword fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| **Title** | String | Unique name for the stop keyword rule (max 100 characters) |
+| **Description** | String | Optional note clarifying the keyword's purpose |
+| **Regular Expression** | String | One or more regex patterns that identify phrases to control |
+| **Say Phrases** | Boolean | `TRUE` – the agent speaks the text up to the matched phrase, then stops. `FALSE` – the agent is interrupted before speaking the phrase. |
+| **Language** | String | Which language this rule applies to. Defaults to "All languages". Only visible for multilingual agents. |
+| **Function** | Reference | Optional – a [function](/tools/introduction) to call when the phrase is detected |
+
+<Warning>
+When a function is triggered by a stop keyword, **caller input and LLM parameters are not passed** to the function. The function runs without conversation context, so it should return a static response or handle the absence of context gracefully.
+</Warning>
+
+#### Creating a stop keyword
+
+<Tabs>
+<Tab title="1. Create a function">
+![Creating a stop keyword function](/images/response-control/stop-keywords-function.png)
+
+Go to **[Tools](/tools/introduction)** to define a custom function for handling stop keywords.
+
+**Example setup**:
+- **Name**: restricted_phrase
+- **Description**: Respond when stop keywords are detected.
+- **Function definition**:
+
+```python
+def restricted_phrase(conv: Conversation):
+    return "I can only help with questions about our products and services."
+```
+
+</Tab>
+
+<Tab title="2. Configure the keyword">
+![Stop keyword configuration](/images/response-control/stop-keywords-response-control.png)
+
+In **Voice > Advanced settings > Speech**, add a new stop keyword.
+
+**Setup details**:
+- **ID**: restricted_phrase
+- **Description**: Restrict responses containing specific phrases.
+- **Regular Expression**: `\brestricted_term\b`
+- **Say Phrases**: `TRUE` (to halt responses when detected).
+- **Action**: Link to the `restricted_phrase` function.
+
+</Tab>
+
+<Tab title="3. Test">
+![Testing stop keyword](/images/response-control/stop-keywords-test.png)
+
+Go to the **Webchat** testing panel to validate your setup.
+
+**Steps**:
+1. Type a message containing the word "Ashmolean."
+2. Observe the agent's response: "The detected phrase is restricted. Please adjust your input."
+3. Confirm that the agent halts any further response generation.
+
+</Tab>
+</Tabs>
+
+#### Common use cases
+
+<AccordionGroup>
+  <Accordion title="Safety compliance" icon="shield-halved">
+    Prevent offensive or harmful language in user interactions.
+
+    | Field | Value |
+    |-------|-------|
+    | **ID** | `stop_inappropriate` |
+    | **Regex** | `\b(offensiveWord1\|offensiveWord2)\b` |
+    | **Say Phrases** | `TRUE` |
+  </Accordion>
+
+  <Accordion title="Remove LLM preambles" icon="scissors">
+    LLMs often add unnecessary meta-explanations before executing an action. Stop keywords cut these off instantly.
+
+    **Before:** "Let's start by gathering some information. Please hold on while I check your cancellation options. Here are your cancellation options."
+
+    **After:** "Here are your cancellation options."
+
+    Add a stop keyword in **Voice > Advanced settings > Speech**:
+
+    | Field | Value |
+    |-------|-------|
+    | **ID** | `flow_redundancy_cutoff` |
+    | **Regex** | `\b(let's start\|please hold on\|let me check)\b` |
+    | **Say Phrases** | `TRUE` |
+  </Accordion>
+
+  <Accordion title="Brand adherence" icon="badge-check">
+    Block responses with phrases outside approved messaging. Log matches for review in the [Analytics Dashboard](/analytics/dashboards/introduction).
+  </Accordion>
+</AccordionGroup>
+
+<Tip>
+  Use regex for complex patterns. See [regex101.com](https://regex101.com/) for a testing tool.
+</Tip>
+
+---
+
+## Diacritics
+
+If your agent operates in a language that uses [diacritics](https://www.sussex.ac.uk/informatics/punctuation/misc/diacritics) – such as **č, ć, š, ž, đ** – additional configuration is required before keyphrases and transcript corrections will work correctly.
+
+<Warning>
+Diacritics and multilingual ASR configuration cannot be self-served. **Contact your PolyAI representative before making changes** – they will configure the correct ASR language model, language codes, and any necessary preprocessing for your target language.
+</Warning>
+
+Transcript corrections can help with minor post-processing (e.g. fixing `Zeljko` → `Željko`) once the correct ASR model is in place, but they are not a substitute for proper language configuration.
 
 ## Environment behavior
 
-Voice configuration follows the same [branching behavior](/environments-and-versions/introduction) as other channel settings:
+Advanced voice settings follow the same [branching behavior](/environments-and-versions/introduction) as other channel settings:
 
 - Make changes in **Sandbox** for testing
 - Promote to **Pre-release** for UAT
@@ -96,15 +469,21 @@ Voice configuration follows the same [branching behavior](/environments-and-vers
 
 ## Related pages
 
-<CardGroup cols={2}>
-  <Card title="Agent Voice" icon="user" href="/voice-channel/agent">
-    Configure voice selection and settings
+<CardGroup cols={3}>
+  <Card title="Voice settings" icon="user" href="/voice-channel/agent">
+    Configure voice selection, greeting, and disclaimer
   </Card>
-  <Card title="Audio management" icon="volume-high" href="/voice-channel/audio-library">
-    Optimize latency and manage cached audio
+  <Card title="Audio library" icon="volume-high" href="/voice-channel/audio-library">
+    Manage cached audio files
   </Card>
-  <Card title="Response control" icon="shield-halved" href="/voice-channel/advanced/response-control">
-    Control response timing and behavior
+  <Card title="ASR biasing in flows" icon="diagram-project" href="/flows/asr-biasing">
+    Configure per-step biasing for structured input collection
+  </Card>
+  <Card title="CSAT surveys" icon="star" href="/analytics/csat/introduction">
+    Full CSAT configuration, scoring, and dashboard integration
+  </Card>
+  <Card title="Safety filters" icon="shield-halved" href="/behavior/guardrails/safety-filters">
+    Project-wide safety filter reference
   </Card>
   <Card title="Chat configuration" icon="message" href="/messaging-channel/advanced/chat-configuration">
     Configure the webchat channel equivalent

--- a/voice-channel/advanced/pronunciations.mdx
+++ b/voice-channel/advanced/pronunciations.mdx
@@ -147,7 +147,7 @@ If you need to customize the patterns above or write your own, here are the buil
 ## Related pages
 
 <CardGroup cols={2}>
-  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/stop-keywords">
+  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/call-settings#stop-keywords">
     Block or log specific phrases in agent responses.
   </Card>
   <Card title="Translations" icon="language" href="/behavior/language/translations">

--- a/voice-channel/advanced/response-control.mdx
+++ b/voice-channel/advanced/response-control.mdx
@@ -21,10 +21,10 @@ Response control settings here apply to **voice agents**. Stop keywords run only
 ![Response controls interface](/images/response-control/response-control.png)
 
 <CardGroup cols={2}>
-  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/stop-keywords">
+  <Card title="Stop keywords" icon="ban" href="/voice-channel/advanced/call-settings#stop-keywords">
     Block or log specific phrases in agent output (content moderation).
   </Card>
-  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/pronunciations">
+  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/call-settings#pronunciation">
     Control how your agent pronounces specific terms (voice tuning).
   </Card>
 </CardGroup>

--- a/voice-channel/advanced/stop-keywords.mdx
+++ b/voice-channel/advanced/stop-keywords.mdx
@@ -100,7 +100,7 @@ The agent successfully identifies the stop keyword, triggers the linked function
 
     <Steps>
       <Step title="Add the stop keyword">
-        Go to **Voice > Advanced > [Response control]esponse control** and click **Add Phrase**:
+        Go to **Voice > Advanced settings > Speech** and click **Add Phrase**:
 
         | Field | Value |
         |-------|-------|
@@ -134,7 +134,7 @@ The agent successfully identifies the stop keyword, triggers the linked function
 ## Related pages
 
 <CardGroup cols={2}>
-  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/pronunciations">
+  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/call-settings#pronunciation">
     Control how your agent pronounces specific terms.
   </Card>
   <Card title="Translations" icon="language" href="/behavior/language/translations">

--- a/voice-channel/agent.mdx
+++ b/voice-channel/agent.mdx
@@ -1,33 +1,31 @@
 ---
-title: "Agent Voice"
-sidebarTitle: "Agent Voice"
-description: "Configure your agent's voice settings."
+title: "Voice settings"
+sidebarTitle: "Settings"
+description: "Configure your agent's voice, greeting, disclaimer, and style prompt."
 keywords:
   - agent voice
   - voice settings
   - voice selection
   - voice tuning
   - disclaimer voice
+  - greeting
+  - style prompt
+  - ringing tone
 ---
 
-Use this page to select and fine-tune the voice your callers hear. The voice you choose shapes how callers perceive your brand – a mismatch in accent, tone, or quality can undermine an otherwise well-built agent.
+The **Settings** tab on the Voice page is where you configure how your agent sounds — the TTS voice it uses, the greeting callers hear, the disclaimer, and the style prompt that shapes tone and delivery.
 
-Configure voice settings in **Voice > Agent**.
+Open the Voice page and select the **Settings** tab.
 
-![Agent Voice page showing the Agent and Disclaimer sections, each with a selected voice and a Change button](/images/voice/agent-voice-page.png)
+![Voice Settings tab showing voice & speech, disclaimer, and style prompt sections](/images/voice/agent-voice-page.png)
 
-## Voice sections
+## Voice & speech
 
-The page displays two voice configurations:
+Pick a voice for each language enabled on the agent. The main language card is tagged as "Main language". Each language gets its own voice and tuning, and the agent switches automatically when the conversation language changes.
 
-| Section | Purpose |
-|---------|---------|
-| **Agent** | The main voice your users interact with during calls |
-| **Disclaimer** | A separate voice for legal or informational disclaimers |
+### Selecting a voice
 
-## Selecting a voice
-
-1. Click **Change** next to either the Agent or Disclaimer section.
+1. Click **Change** next to the voice you want to update.
 2. The **[Voice library](/voice-channel/voice-library)** opens.
 3. Browse voices using the **Explore** tab or access saved voices in **Favorites**.
 4. Filter by **language**, **region**, and **gender**.
@@ -36,12 +34,9 @@ The page displays two voice configurations:
 
 Use the Voice library's preview feature with text that matches your agent's typical responses to ensure the voice fits your use case.
 
-## Voice settings
+### Voice tuning
 
-Fine-tune the selected voice's parameters:
-
-1. Click the **Settings** icon <Icon icon="gear" iconType="solid" /> next to the voice.
-2. Adjust the sliders in the Voice Settings popup:
+Fine-tune the selected voice's parameters by clicking the **Settings** icon <Icon icon="gear" iconType="solid" /> next to the voice:
 
 <ParamField path="Stability" type="slider">
   Controls how consistent the voice sounds over time. Higher values keep tone and delivery more uniform across responses.
@@ -57,24 +52,50 @@ Fine-tune the selected voice's parameters:
   Controls stylistic expressiveness of the voice (0.0–1.0). Higher values produce more expressive speech with varied intonation. Lower values keep delivery more neutral and consistent. Only supported by certain TTS providers and voice models.
 </ParamField>
 
-3. Click **Done** to save changes.
+### Voice greeting
+
+The first thing your agent says when answering a call. Configure it in the **Voice greeting** field.
+
+**Example:** "Thank you for calling. How can I help you today?"
+
+Keep your greeting concise. Long greetings can frustrate callers who want to get to the point quickly.
+
+## Style prompt
+
+Tailor tone, format, and etiquette for your voice agent. The style prompt gives the LLM high-level guidance on how to respond — formal vs casual, verbose vs terse, and any brand-specific phrasing rules.
+
+## Disclaimer
+
+A message read once at the start of every call — typically a recording or AI-disclosure notice.
+
+<ParamField path="Enable disclaimer" type="boolean">
+  Toggle on to play a disclaimer before the greeting.
+</ParamField>
+
+<ParamField path="Disclaimer voice" type="dropdown">
+  Use a separate voice for the disclaimer to distinguish it from the main agent voice. Each language can have its own disclaimer voice.
+</ParamField>
+
+<ParamField path="Disclaimer text" type="string">
+  The text read aloud at the start of the call.
+
+  **Example:** "This call may be recorded for quality and training purposes."
+</ParamField>
+
+## Ringing tone
+
+A sound that plays after the disclaimer text and before the agent begins speaking. Gives the caller an audible signal that the call is about to start.
 
 ## Publishing changes
 
 After updating voice settings:
 
-1. Review your configuration on the Agent Voice page.
+1. Review your configuration on the Settings tab.
 2. Click **Publish** in the top right corner to apply changes to your live agent.
 
 <Warning>
 Voice changes only take effect after publishing. Test your agent after publishing to confirm the new voice sounds as expected.
 </Warning>
-
-## Disclaimer voice configuration
-
-If disclaimer audio is configured separately, the page provides a link to **Voice > Advanced > [Call settings]oice Configuration** for those settings.
-
-The Disclaimer voice is optional. If not configured, the Agent voice handles all agent speech.
 
 ## Related pages
 
@@ -85,8 +106,8 @@ The Disclaimer voice is optional. If not configured, the Agent voice handles all
   <Card title="Choosing a good voice" icon="ear-listen" href="/voice-channel/choosing-a-good-voice">
     Guidelines for voice selection and matching
   </Card>
-  <Card title="Voice configuration" icon="gear" href="/voice-channel/advanced/call-settings">
-    Configure greeting and disclaimer settings
+  <Card title="Advanced voice settings" icon="gear" href="/voice-channel/advanced/call-settings">
+    Configure model, barge-in, safety filters, and speech recognition
   </Card>
   <Card title="Add a voice" icon="plus" href="/voice-channel/add-a-new-voice">
     Configure custom voices programmatically

--- a/voice-channel/audio-library.mdx
+++ b/voice-channel/audio-library.mdx
@@ -1,8 +1,7 @@
 ---
-title: 'Audio management'
+title: 'Audio library'
 sidebarTitle: 'Audio library'
-description: 'Optimize agent audio quality and response latency.'
-tag: "Advanced"
+description: 'Manage cached audio files to reduce voice latency.'
 keywords:
   - audio management
   - audio files
@@ -12,23 +11,22 @@ keywords:
   - latency
 ---
 
-Use audio management to reduce voice latency and control how your agent sounds during key moments – greetings, transfer messages, and other frequently spoken phrases. Caching these responses means callers hear them faster and with consistent quality, instead of waiting for real-time TTS generation on every call.
+Use the audio library to reduce voice latency and control how your agent sounds during key moments – greetings, transfer messages, and other frequently spoken phrases. Caching these responses means callers hear them faster and with consistent quality, instead of waiting for real-time TTS generation on every call.
 
-The **Audio Management** tab is found under **Voice > Audio library**.
+Open the Voice page and select the **Audio library** tab.
 
-![audio-management-1](/images/audio-management/audio-management-1.png)
+![Audio library tab](/images/audio-management/audio-management-1.png)
 
-## Getting started
+## Managing cached audio
 
-To manage your agent's audio:
-1. Go to **Voice > Audio library**.
+1. Open the **Audio library** tab.
 2. Review all audio saved to the cache and monitor how often it has been used by the agent.
 3. You can delete cached files and upload new ones to overwrite existing audio.
 
 <Tabs>
   <Tab title="Edit options">
 
-You can edit the **stability** and **clarity** of the agent's voice specifically for this utterance. For more information on these settings, visit the [voice](/voice-channel/introduction) feature page. The edit tab also includes sync <Icon icon="arrows-rotate" iconType="solid" /> and play <Icon icon="play" iconType="solid" /> buttons so you can test changes to the utterance live in the edit panel.
+You can edit the **stability** and **clarity** of the agent's voice specifically for this utterance. The edit tab also includes sync <Icon icon="arrows-rotate" iconType="solid" /> and play <Icon icon="play" iconType="solid" /> buttons so you can test changes live in the edit panel.
 
 ![audio-management-edit-options](/images/audio-management/audio-management-edit-options.png)
 
@@ -48,71 +46,6 @@ The audio cache stores a file only if the same TTS is generated **at least twice
 To ensure key audios remain cached, consider generating them repeatedly or uploading static versions manually.
 </Tip>
 
-## Interaction style
-
-Adjust response latency to balance speed and accuracy.
-
-### Interaction style settings
-
-![audio-management-1](/images/audio-management/interaction-style.png)
-
-1. Locate the **Interaction style** section on the **Audio management** page (**Voice > Audio library**).
-2. Choose from the available modes:
-   - **Turbo Mode** – Fastest response time with high interruption tolerance
-   - **Balanced Mode** – Moderate latency with good accuracy
-   - **Precise Mode** – Longest latency for maximum accuracy
-3. Click on the bubble for your preferred mode. A brief description of the mode will appear.
-4. Save your settings to apply changes. Your agent will adjust its behavior immediately.
-
-### Performance characteristics
-
-Each response mode is designed for specific performance needs:
-
-| Mode | Latency | Interruption tolerance | Best for |
-|------|---------|----------------------|----------|
-| **Turbo** | 400ms | High (enable [barge-in](#barge-in)) | Ultra-responsive agents; pair with barge-in to let callers reclaim control |
-| **Balanced** | 1600ms | Moderate | General use cases balancing responsiveness and accuracy |
-| **Precise** | 2000ms | Low | Accuracy-critical scenarios with minimal interruptions |
-
-## Barge-in
-
-Allow callers to interrupt the agent mid-utterance. When enabled, the agent stops speaking as soon as it detects caller speech, shortening [VAD](https://en.wikipedia.org/wiki/Voice_activity_detection) time and reducing response latency.
-
-To enable this feature, go to **Voice > Audio Management** and toggle **Enable barge-in**.
-
-### How barge-in works
-
-When barge-in is enabled:
-1. The agent begins speaking its response.
-2. If the caller starts talking, the agent stops its current utterance and begins listening.
-3. The agent processes the caller's input and responds as a new turn.
-
-This also applies to [delay control](/tools/delay-control) responses – if the caller speaks during a filler phrase, the delay sequence is interrupted.
-
-### When to use barge-in
-
-Barge-in works well for:
-- FAQ-heavy agents where callers may already know what they need
-- Long agent responses where the caller wants to redirect the conversation
-- Turbo interaction style, where fast responsiveness is a priority
-
-### When to disable barge-in
-
-Consider disabling barge-in (globally or per flow/step) when:
-- The agent is executing a function with **external side effects** (bookings, payments, form submissions) – the caller may interrupt after the action completes but before hearing the confirmation
-- The agent must deliver a **mandatory disclosure or disclaimer** that cannot be skipped
-- The environment is **noisy**, causing false barge-in triggers from background sounds
-
-### Per-flow and per-step overrides
-
-You can configure barge-in at a granular level using the experimental JSON config. This lets you enable barge-in globally while disabling it for specific flows or steps where interruption would be problematic.
-
-Overrides follow a precedence order: **step > flow > global**. For example, you can have barge-in off globally, enabled for a specific flow, and disabled again for a sensitive step within that flow.
-
-<Note>
-Barge-in behavior cannot be fully tested in the chat panel. Always verify with a real phone call.
-</Note>
-
 ## Manage audio cache via API
 
 You can also manage the audio cache programmatically with the [Agents API](/api-reference/agents/introduction). The audio cache endpoints let you list cached entries, download or replace audio files, synthesize previews, and bulk-delete entries.
@@ -131,13 +64,13 @@ Common use cases:
 ## Related pages
 
 <CardGroup cols={3}>
-  <Card title="Voice configuration" icon="gear" href="/voice-channel/advanced/call-settings">
-    Configure VAD, greeting audio, and call handling settings.
+  <Card title="Advanced voice settings" icon="gear" href="/voice-channel/advanced/call-settings">
+    Configure model, barge-in, and speech recognition settings
   </Card>
-  <Card title="Agent Voice" icon="user" href="/voice-channel/agent">
-    Adjust voice stability and clarity for your TTS provider.
+  <Card title="Voice settings" icon="user" href="/voice-channel/agent">
+    Select voices and configure greeting and disclaimer
   </Card>
-  <Card title="Response control" icon="shield-halved" href="/voice-channel/advanced/response-control">
-    Block keywords and configure pronunciations.
+  <Card title="Pronunciations" icon="volume-high" href="/voice-channel/advanced/call-settings#pronunciation">
+    Control how your agent pronounces specific terms
   </Card>
 </CardGroup>

--- a/voice-channel/choosing-a-good-voice.mdx
+++ b/voice-channel/choosing-a-good-voice.mdx
@@ -14,7 +14,7 @@ Use this guide when setting up a new agent or changing an existing voice. A well
 
 The **[Voice library](/voice-channel/voice-library)** provides tools to find the right voice:
 
-1. Go to **Voice > Agent**.
+1. Go to **Voice > Settings**.
 2. Click **Change** to open the Voice library.
 3. Use filters for **language**, **region**, and **gender**.
 4. Preview voices with **custom text** before selecting.

--- a/voice-channel/introduction.mdx
+++ b/voice-channel/introduction.mdx
@@ -23,10 +23,23 @@ It is **not** about how customers reach your agent. For that, see [Phone](/voice
 
 ## What lives here
 
+The Voice page has five tabs:
+
 <CardGroup cols={2}>
-  <Card title="Agent Voice" icon="user" href="/voice-channel/agent">
-    Pick the TTS voice and tune stability, clarity, and speed.
+  <Card title="Settings" icon="user" href="/voice-channel/agent">
+    Pick the TTS voice, greeting, disclaimer, style prompt, and ringing tone.
   </Card>
+  <Card title="Audio library" icon="volume-high" href="/voice-channel/audio-library">
+    Manage cached audio to reduce latency and ensure consistent quality.
+  </Card>
+  <Card title="Advanced settings" icon="gear" href="/voice-channel/advanced/call-settings">
+    Model, call, and speech configuration — barge-in, keyphrases, pronunciation, safety filters, and more.
+  </Card>
+</CardGroup>
+
+Supporting pages:
+
+<CardGroup cols={2}>
   <Card title="Voice library" icon="list" href="/voice-channel/voice-library">
     Browse and compare voices across providers (ElevenLabs, Cartesia, Hume, and more).
   </Card>
@@ -36,30 +49,11 @@ It is **not** about how customers reach your agent. For that, see [Phone](/voice
   <Card title="Multi-voice" icon="users" href="/voice-channel/multi-voice">
     Use multiple voices in a single project.
   </Card>
-  <Card title="Voice configuration" icon="gear" href="/voice-channel/advanced/call-settings">
-    Greeting audio, disclaimer playback, model selection, safety filters, and call handling.
-  </Card>
-  <Card title="Response control" icon="sliders" href="/voice-channel/advanced/response-control">
-    Translations, pronunciations, and stop keywords.
-  </Card>
-  <Card title="Audio management" icon="volume-high" href="/voice-channel/audio-library">
-    Audio playback and recording settings.
-  </Card>
-  <Card title="Speech recognition" icon="microphone" href="/voice-channel/advanced/speech-recognition">
-    ASR settings – how the agent transcribes what callers say.
-  </Card>
 </CardGroup>
 
 ## How to think about it
 
-There are four concerns, and they're configured separately:
-
-1. **How it sounds** – Agent voice, voice library, multi-voice, custom voice. Picking a TTS voice and tuning it.
-2. **How it behaves in a call** – Voice configuration: greeting, disclaimer, model selection, safety filters, call handling.
-3. **How it listens** – Speech recognition (ASR) settings.
-4. **How it phrases things** – Response control: translations, pronunciations, stop keywords.
-
-Start with [Choosing a good voice](/voice-channel/choosing-a-good-voice), then configure the voice in [Agent Voice](/voice-channel/agent), and tune call-runtime behavior in [Voice configuration](/voice-channel/advanced/call-settings).
+Start with [Choosing a good voice](/voice-channel/choosing-a-good-voice), then configure the voice in [Voice settings](/voice-channel/agent), and tune call-runtime behavior in [Advanced voice settings](/voice-channel/advanced/call-settings).
 
 <div className="full-only">
 

--- a/voice-channel/voice-library.mdx
+++ b/voice-channel/voice-library.mdx
@@ -9,7 +9,7 @@ keywords:
   - TTS voices
 ---
 
-The **Voice library** lets you explore, preview, and select voices for your agent. Access it from **Voice > Agent**.
+The **Voice library** lets you explore, preview, and select voices for your agent. Access it from **Voice > Settings**.
 
 ![Voice library with the Test voice preview field, language, region, and gender filters, and a voice card showing Tara (English IE, Female) tagged Emotive and Friendly](/images/voice/voice-library.png)
 
@@ -19,7 +19,7 @@ The Voice library includes filters, favorites, and custom text preview.
 
 ## Accessing the Voice library
 
-1. Go to **Voice > Agent** in the sidebar.
+1. Go to **Voice > Settings** in the sidebar.
 2. Click **Change** next to either the **Agent** or **Disclaimer** voice section.
 3. The Voice library opens with two tabs: **Explore** and **Favorites**.
 

--- a/widgets/share.mdx
+++ b/widgets/share.mdx
@@ -70,7 +70,7 @@ A short checklist worth running before you send any link to anyone:
 
 - **Open the share link in an incognito tab.** That's what your recipient sees.
 - **Listen to the greeting.** If it's still the default scaffold message, ask Studio Assistant to make it warmer or more specific.
-- **Confirm the voice.** Set under **Voice > Agent**. You can swap it in one click and re-test.
+- **Confirm the voice.** Set under **Voice > Settings**. You can swap it in one click and re-test.
 - **Check the consent text** if consent is turned on. Lives in **Widgets > Content**.
 
 ## What happens next

--- a/widgets/web-calling.mdx
+++ b/widgets/web-calling.mdx
@@ -42,7 +42,7 @@ For Tag Manager, HTTPS, and the rest of the deployment details, see [Install on 
 
 ## The agent's voice
 
-Web Calling uses whichever voice you've set under **Voice > Agent**. The same voice plays whether someone reaches you through the embedded widget or a [shareable page link](/widgets/share).
+Web Calling uses whichever voice you've set under **Voice > Settings**. The same voice plays whether someone reaches you through the embedded widget or a [shareable page link](/widgets/share).
 
 </div>
 


### PR DESCRIPTION
## Summary

- **Voice settings** (`voice-channel/agent.mdx`): merged in greeting, disclaimer, style prompt, and ringing tone content — now covers the full Settings tab
- **Advanced voice settings** (`voice-channel/advanced/call-settings.mdx`): merged speech recognition (keyphrases, transcript corrections), pronunciations, stop keywords, and barge-in into three tab sections (Model, Call, Speech). Added new features: E2E voice mode, AI-coustics, filler phrases, turn-taking/speech end delay
- **Audio library** (`voice-channel/audio-library.mdx`): removed barge-in section (moved to Advanced settings)
- **Sidebar**: collapsed Advanced group from 5 pages to 1
- **Redirects**: added for all retired pages (`speech-recognition`, `response-control`, `stop-keywords`, `pronunciations`), plus updated old chained redirects to point to final destinations
- **Nav references**: updated ~40 cross-references across 39 files (`Voice > Agent` → `Voice > Settings`, `Voice > Advanced > Call settings` → `Voice > Advanced settings`, etc.)
- **Introduction page**: rewrote card grid to reflect new tab structure

## What's NOT in this PR

- Screenshot replacements — old images are still referenced. The UI has changed but the screenshots need manual capture.

## Test plan

- [ ] Check deploy preview renders correctly
- [ ] Verify redirects work (e.g. `/voice-channel/advanced/speech-recognition` → `/voice-channel/advanced/call-settings#keyphrases`)
- [ ] Spot-check nav references in a few pages (e.g. `behavior/language/multilingual.mdx`, `glossary/introduction.mdx`)
- [ ] Confirm sidebar shows collapsed Advanced group with single "Advanced settings" page

🤖 Generated with [Claude Code](https://claude.com/claude-code)