### PR TITLE
docs: reorder API nav by family, merge inbound SMS

### DIFF
--- a/api-reference/sms/introduction.mdx
+++ b/api-reference/sms/introduction.mdx
@@ -7,7 +7,7 @@ description: 'Send and receive SMS messages through your PolyAI agent.'
 The SMS API lets you programmatically send SMS messages to end users and handle inbound replies through your PolyAI agent. It supports two directions:
 
 - **Outbound** — your system triggers an SMS to a user via the [Send SMS](/api-reference/sms/endpoint/send-sms) endpoint. Each request creates a new conversation session.
-- **Inbound** — users reply to an outbound SMS (or message your agent's number directly). The agent handles the conversation automatically over SMS.
+- **Inbound** — users reply to an outbound SMS (or message your agent's number directly). The agent handles the conversation automatically over SMS. No API calls are needed from your side.
 
 ## Prerequisites
 
@@ -49,14 +49,50 @@ curl -X POST https://api.<cluster>.platform.polyai.app/v1/outbound-sms \
 
 When a user sends an SMS to one of your provisioned Twilio numbers:
 
-1. **Twilio routes the message** — Twilio forwards the inbound SMS to PolyAI via the configured webhook.
-2. **Session created or resumed** — If there's an active session with that user number, the message is added to the existing conversation. Otherwise, a new session is created.
-3. **Agent responds** — The agent processes the message and replies via SMS automatically.
-4. **Conversation continues** — The user and agent exchange messages over SMS until the conversation ends or times out.
+<Steps>
+  <Step title="Twilio routes to PolyAI">
+    Twilio forwards the message to PolyAI via a pre-configured webhook. This webhook is set up automatically when you provision a number through PolyAI.
+  </Step>
+  <Step title="Session handling">
+    If there's an active conversation session with that user's number, the message is added to the existing session. Otherwise, a new session is created and the agent greets the user (or processes the message directly, depending on your agent configuration).
+  </Step>
+  <Step title="Agent responds">
+    The agent processes the message using the same conversation engine as voice and webchat, and sends a reply via SMS.
+  </Step>
+</Steps>
 
 <Note>
 Inbound SMS requires Twilio webhook configuration. This is handled automatically when you provision a number through PolyAI. No additional API calls are needed — the agent handles inbound messages through the same conversation engine used for voice and webchat.
 </Note>
+
+### Session behavior
+
+| Scenario | Behavior |
+|---|---|
+| **New user** | A new conversation session is created. The agent's start function runs with `conv.channel_type = "sms"`. |
+| **Active session exists** | The message is added to the existing conversation. The agent continues where it left off. |
+| **Previous session timed out** | A new session is created. |
+| **Reply to an outbound SMS** | The message is added to the session created by the [Send SMS](/api-reference/sms/endpoint/send-sms) endpoint. The outbound message is part of the conversation context. |
+
+### Inactivity timeout
+
+Once a conversation is engaged (at least one user reply), an inactivity timer starts:
+
+1. After **24 hours** of no messages, a warning message is sent to the user.
+2. If the user replies within **10 minutes**, the session stays open and the timer resets.
+3. If no reply, the session terminates.
+
+### Channel detection
+
+In your agent's start function, detect inbound SMS using `conv.channel_type`:
+
+```python
+def start(conv):
+    if conv.channel_type == "sms":
+        conv.state.greet_message = "Hi, you've reached [Company]. How can I help?"
+    elif conv.channel_type == "voice":
+        conv.state.greet_message = "Thanks for calling. How can I help you today?"
+```
 
 ## Agent number selection
 

--- a/docs.json
+++ b/docs.json
@@ -513,281 +513,301 @@
             ]
           },
           {
-            "group": "Agents API",
+            "group": "Build & deploy",
             "pages": [
-              "api-reference/agents/introduction",
               {
-                "group": "Agents",
+                "group": "Agents API",
                 "pages": [
-                  "api-reference/agents/endpoint/agents/list-agents",
-                  "api-reference/agents/endpoint/agents/create-agent",
-                  "api-reference/agents/endpoint/agents/duplicate-agent",
-                  "api-reference/agents/endpoint/agents/delete-agent"
-                ]
-              },
-              {
-                "group": "Branches",
-                "pages": [
-                  "api-reference/agents/endpoint/branches/list-branches",
-                  "api-reference/agents/endpoint/branches/create-branch",
-                  "api-reference/agents/endpoint/branches/merge-branch",
-                  "api-reference/agents/endpoint/branches/delete-branch"
-                ]
-              },
-              {
-                "group": "Agent behavior",
-                "pages": [
-                  "api-reference/agents/endpoint/behavior/get-agent-behavior-rules",
-                  "api-reference/agents/endpoint/behavior/update-agent-behavior-rules"
-                ]
-              },
-              {
-                "group": "Knowledge base",
-                "pages": [
-                  "api-reference/agents/endpoint/knowledge-base/list-knowledge-base-topics",
-                  "api-reference/agents/endpoint/knowledge-base/create-knowledge-base-topic",
-                  "api-reference/agents/endpoint/knowledge-base/get-knowledge-base-topic",
-                  "api-reference/agents/endpoint/knowledge-base/update-knowledge-base-topic",
-                  "api-reference/agents/endpoint/knowledge-base/delete-knowledge-base-topic"
-                ]
-              },
-              {
-                "group": "Variants",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/variants/list-attributes",
-                  "api-reference/agents/endpoint/variants/create-attribute",
-                  "api-reference/agents/endpoint/variants/update-attribute",
-                  "api-reference/agents/endpoint/variants/delete-attribute",
-                  "api-reference/agents/endpoint/variants/list-variants",
-                  "api-reference/agents/endpoint/variants/create-variant",
-                  "api-reference/agents/endpoint/variants/update-variant",
-                  "api-reference/agents/endpoint/variants/delete-variant"
-                ]
-              },
-              {
-                "group": "Deployments",
-                "pages": [
-                  "api-reference/agents/endpoint/deployments/list-deployments-for-an-environment",
-                  "api-reference/agents/endpoint/deployments/get-active-deployment-per-environment",
-                  "api-reference/agents/endpoint/deployments/publish-the-current-draft-to-an-environment",
-                  "api-reference/agents/endpoint/deployments/promote-a-deployment-to-the-next-environment",
-                  "api-reference/agents/endpoint/deployments/rollback-to-a-previous-deployment"
-                ]
-              },
-              {
-                "group": "Connectors",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/connectors/list-all-connectors-for-a-project",
-                  "api-reference/agents/endpoint/connectors/get-a-connector-by-id",
-                  "api-reference/agents/endpoint/connectors/update-a-connector",
-                  "api-reference/agents/endpoint/connectors/delete-a-connector-and-its-phone-numbers",
-                  "api-reference/agents/endpoint/connectors/batch-get-connectors-by-id",
-                  "api-reference/agents/endpoint/connectors/batch-update-connectors",
-                  "api-reference/agents/endpoint/connectors/look-up-connector-by-phone-number"
-                ]
-              },
-              {
-                "group": "Outbound calls",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/outbound-calls/trigger-outbound-call",
-                  "api-reference/agents/endpoint/outbound-calls/get-outbound-call-status"
-                ]
-              },
-              {
-                "group": "Phone numbers",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/phone-numbers/list-all-phone-numbers-for-a-project",
-                  "api-reference/agents/endpoint/phone-numbers/import-phone-numbers-into-a-project",
-                  "api-reference/agents/endpoint/phone-numbers/import-a-single-phone-number",
-                  "api-reference/agents/endpoint/phone-numbers/get-a-specific-phone-number",
-                  "api-reference/agents/endpoint/phone-numbers/reassign-a-phone-number-to-a-different-connector",
-                  "api-reference/agents/endpoint/phone-numbers/delete-a-single-phone-number",
-                  "api-reference/agents/endpoint/phone-numbers/delete-phone-numbers-from-a-project",
-                  "api-reference/agents/endpoint/phone-numbers/batch-get-phone-numbers"
-                ]
-              },
-              {
-                "group": "Real-time configs",
-                "pages": [
-                  "api-reference/agents/endpoint/real-time-configs/list-all-config-pages",
-                  "api-reference/agents/endpoint/real-time-configs/get-a-config-page-by-environment",
-                  "api-reference/agents/endpoint/real-time-configs/upsert-the-json-schema-for-a-config-page",
-                  "api-reference/agents/endpoint/real-time-configs/update-config-variables-for-an-environment"
-                ]
-              },
-              {
-                "group": "Voice Library",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/voice-library/list-voices",
-                  "api-reference/agents/endpoint/voice-library/register-voice",
-                  "api-reference/agents/endpoint/voice-library/get-voice",
-                  "api-reference/agents/endpoint/voice-library/update-voice",
-                  "api-reference/agents/endpoint/voice-library/synthesize-voice-sample"
-                ]
-              },
-              {
-                "group": "Audio cache",
-                "expanded": false,
-                "pages": [
-                  "api-reference/agents/endpoint/audio-cache/list-audio-cache",
-                  "api-reference/agents/endpoint/audio-cache/download-audio-file",
-                  "api-reference/agents/endpoint/audio-cache/replace-audio-file",
-                  "api-reference/agents/endpoint/audio-cache/update-audio-cache-details",
-                  "api-reference/agents/endpoint/audio-cache/synthesize-audio-preview",
-                  "api-reference/agents/endpoint/audio-cache/delete-audio-cache-entry",
-                  "api-reference/agents/endpoint/audio-cache/bulk-delete-audio-cache"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Chat API",
-            "pages": [
-              "api-reference/chat/introduction",
-              "api-reference/chat/endpoint/create-a-chat",
-              "api-reference/chat/endpoint/respond-to-a-chat",
-              "api-reference/chat/endpoint/close-a-chat"
-            ]
-          },
-          {
-            "group": "Concurrent Calls API",
-            "pages": [
-              "api-reference/concurrent-calls/introduction",
-              "api-reference/concurrent-calls/endpoint/get-max-concurrent"
-            ]
-          },
-          {
-            "group": "Data API",
-            "pages": [
-              "api-reference/data/introduction",
-              "api-reference/data/endpoint/list-conversations",
-              "api-reference/data/endpoint/get-conversation-by-id",
-              "api-reference/data/endpoint/get-conversation-audio",
-              "api-reference/data/endpoint/add-annotations",
-              "api-reference/data/endpoint/upsert-note",
-              {
-                "group": "Debug Chat",
-                "pages": [
-                  "api-reference/data/debug-chat/create-debug-chat-session",
-                  "api-reference/data/debug-chat/send-debug-chat-message"
+                  "api-reference/agents/introduction",
+                  {
+                    "group": "Agents",
+                    "pages": [
+                      "api-reference/agents/endpoint/agents/list-agents",
+                      "api-reference/agents/endpoint/agents/create-agent",
+                      "api-reference/agents/endpoint/agents/duplicate-agent",
+                      "api-reference/agents/endpoint/agents/delete-agent"
+                    ]
+                  },
+                  {
+                    "group": "Branches",
+                    "pages": [
+                      "api-reference/agents/endpoint/branches/list-branches",
+                      "api-reference/agents/endpoint/branches/create-branch",
+                      "api-reference/agents/endpoint/branches/merge-branch",
+                      "api-reference/agents/endpoint/branches/delete-branch"
+                    ]
+                  },
+                  {
+                    "group": "Agent behavior",
+                    "pages": [
+                      "api-reference/agents/endpoint/behavior/get-agent-behavior-rules",
+                      "api-reference/agents/endpoint/behavior/update-agent-behavior-rules"
+                    ]
+                  },
+                  {
+                    "group": "Knowledge base",
+                    "pages": [
+                      "api-reference/agents/endpoint/knowledge-base/list-knowledge-base-topics",
+                      "api-reference/agents/endpoint/knowledge-base/create-knowledge-base-topic",
+                      "api-reference/agents/endpoint/knowledge-base/get-knowledge-base-topic",
+                      "api-reference/agents/endpoint/knowledge-base/update-knowledge-base-topic",
+                      "api-reference/agents/endpoint/knowledge-base/delete-knowledge-base-topic"
+                    ]
+                  },
+                  {
+                    "group": "Variants",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/variants/list-attributes",
+                      "api-reference/agents/endpoint/variants/create-attribute",
+                      "api-reference/agents/endpoint/variants/update-attribute",
+                      "api-reference/agents/endpoint/variants/delete-attribute",
+                      "api-reference/agents/endpoint/variants/list-variants",
+                      "api-reference/agents/endpoint/variants/create-variant",
+                      "api-reference/agents/endpoint/variants/update-variant",
+                      "api-reference/agents/endpoint/variants/delete-variant"
+                    ]
+                  },
+                  {
+                    "group": "Deployments",
+                    "pages": [
+                      "api-reference/agents/endpoint/deployments/list-deployments-for-an-environment",
+                      "api-reference/agents/endpoint/deployments/get-active-deployment-per-environment",
+                      "api-reference/agents/endpoint/deployments/publish-the-current-draft-to-an-environment",
+                      "api-reference/agents/endpoint/deployments/promote-a-deployment-to-the-next-environment",
+                      "api-reference/agents/endpoint/deployments/rollback-to-a-previous-deployment"
+                    ]
+                  },
+                  {
+                    "group": "Connectors",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/connectors/list-all-connectors-for-a-project",
+                      "api-reference/agents/endpoint/connectors/get-a-connector-by-id",
+                      "api-reference/agents/endpoint/connectors/update-a-connector",
+                      "api-reference/agents/endpoint/connectors/delete-a-connector-and-its-phone-numbers",
+                      "api-reference/agents/endpoint/connectors/batch-get-connectors-by-id",
+                      "api-reference/agents/endpoint/connectors/batch-update-connectors",
+                      "api-reference/agents/endpoint/connectors/look-up-connector-by-phone-number"
+                    ]
+                  },
+                  {
+                    "group": "Outbound calls",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/outbound-calls/trigger-outbound-call",
+                      "api-reference/agents/endpoint/outbound-calls/get-outbound-call-status"
+                    ]
+                  },
+                  {
+                    "group": "Phone numbers",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/phone-numbers/list-all-phone-numbers-for-a-project",
+                      "api-reference/agents/endpoint/phone-numbers/import-phone-numbers-into-a-project",
+                      "api-reference/agents/endpoint/phone-numbers/import-a-single-phone-number",
+                      "api-reference/agents/endpoint/phone-numbers/get-a-specific-phone-number",
+                      "api-reference/agents/endpoint/phone-numbers/reassign-a-phone-number-to-a-different-connector",
+                      "api-reference/agents/endpoint/phone-numbers/delete-a-single-phone-number",
+                      "api-reference/agents/endpoint/phone-numbers/delete-phone-numbers-from-a-project",
+                      "api-reference/agents/endpoint/phone-numbers/batch-get-phone-numbers"
+                    ]
+                  },
+                  {
+                    "group": "Real-time configs",
+                    "pages": [
+                      "api-reference/agents/endpoint/real-time-configs/list-all-config-pages",
+                      "api-reference/agents/endpoint/real-time-configs/get-a-config-page-by-environment",
+                      "api-reference/agents/endpoint/real-time-configs/upsert-the-json-schema-for-a-config-page",
+                      "api-reference/agents/endpoint/real-time-configs/update-config-variables-for-an-environment"
+                    ]
+                  },
+                  {
+                    "group": "Voice Library",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/voice-library/list-voices",
+                      "api-reference/agents/endpoint/voice-library/register-voice",
+                      "api-reference/agents/endpoint/voice-library/get-voice",
+                      "api-reference/agents/endpoint/voice-library/update-voice",
+                      "api-reference/agents/endpoint/voice-library/synthesize-voice-sample"
+                    ]
+                  },
+                  {
+                    "group": "Audio cache",
+                    "expanded": false,
+                    "pages": [
+                      "api-reference/agents/endpoint/audio-cache/list-audio-cache",
+                      "api-reference/agents/endpoint/audio-cache/download-audio-file",
+                      "api-reference/agents/endpoint/audio-cache/replace-audio-file",
+                      "api-reference/agents/endpoint/audio-cache/update-audio-cache-details",
+                      "api-reference/agents/endpoint/audio-cache/synthesize-audio-preview",
+                      "api-reference/agents/endpoint/audio-cache/delete-audio-cache-entry",
+                      "api-reference/agents/endpoint/audio-cache/bulk-delete-audio-cache"
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
-            "group": "DNI API",
+            "group": "Runtime & data",
             "pages": [
-              "api-reference/dni/introduction",
-              "api-reference/dni/endpoint/dni-reservation"
-            ]
-          },
-          {
-            "group": "External Events API",
-            "pages": [
-              "api-reference/external-events/introduction",
-              "api-reference/external-events/endpoint/webhook",
-              "api-reference/external-events/endpoint/bridge-ended"
-            ]
-          },
-          {
-            "group": "Handoff API",
-            "pages": [
-              "api-reference/handoff/introduction",
-              "api-reference/handoff/endpoint/get-handoff"
-            ]
-          },
-          {
-            "group": "Messaging API",
-            "pages": [
-              "api-reference/messaging/introduction",
-              "api-reference/messaging/sessions",
-              "api-reference/messaging/websocket",
-              "api-reference/messaging/events",
-              "api-reference/messaging/events-send",
-              "api-reference/messaging/events-receive",
-              "api-reference/messaging/streaming",
-              "api-reference/messaging/handoff",
-              "api-reference/messaging/lifecycle",
-              "api-reference/messaging/errors",
-              "api-reference/messaging/best-practices"
-            ]
-          },
-          {
-            "group": "Outbound Calling API",
-            "pages": [
-              "api-reference/outbound/introduction",
-              "api-reference/outbound/endpoint/trigger-call",
-              "api-reference/outbound/endpoint/get-call-status"
-            ]
-          },
-          {
-            "group": "SMS API",
-            "pages": [
-              "api-reference/sms/introduction",
-              "api-reference/sms/endpoint/send-sms"
-            ]
-          },
-          {
-            "group": "WebRTC Gateway",
-            "pages": [
-              "api-reference/webrtc-gateway/introduction",
-              "api-reference/webrtc-gateway/ws/signaling"
-            ]
-          },
-          {
-            "group": "Alerts API",
-            "pages": [
-              "api-reference/alerts/introduction",
               {
-                "group": "Alert rules",
+                "group": "Chat API",
                 "pages": [
-                  "api-reference/alerts/endpoint/create-alert-rule",
-                  "api-reference/alerts/endpoint/list-alert-rules",
-                  "api-reference/alerts/endpoint/get-alert-rule",
-                  "api-reference/alerts/endpoint/update-alert-rule",
-                  "api-reference/alerts/endpoint/delete-alert-rule"
+                  "api-reference/chat/introduction",
+                  "api-reference/chat/endpoint/create-a-chat",
+                  "api-reference/chat/endpoint/respond-to-a-chat",
+                  "api-reference/chat/endpoint/close-a-chat"
                 ]
               },
-              "api-reference/alerts/endpoint/list-active-alerts"
-            ]
-          },
-          {
-            "group": "Webhooks API",
-            "pages": [
-              "api-reference/webhooks/introduction",
-              "api-reference/webhooks/endpoint/create-webhook-endpoint",
-              "api-reference/webhooks/endpoint/list-webhook-endpoints",
-              "api-reference/webhooks/endpoint/get-webhook-endpoint",
-              "api-reference/webhooks/endpoint/update-webhook-endpoint",
-              "api-reference/webhooks/endpoint/delete-webhook-endpoint",
-              "api-reference/webhooks/endpoint/rotate-webhook-signing-secret"
-            ]
-          },
-          {
-            "group": "Conversations API v3 (legacy)",
-            "pages": [
-              "api-reference/conversations/introduction",
-              "api-reference/conversations/v3/endpoint/get-conversations",
-              "api-reference/conversations/v3/endpoint/get-conversation-by-id",
-              "api-reference/conversations/v3/endpoint/get-conversation-audio",
               {
-                "group": "Debug Chat",
+                "group": "Concurrent Calls API",
                 "pages": [
-                  "api-reference/conversations/v3/debug-chat/create-debug-chat-session",
-                  "api-reference/conversations/v3/debug-chat/send-debug-chat-message"
+                  "api-reference/concurrent-calls/introduction",
+                  "api-reference/concurrent-calls/endpoint/get-max-concurrent"
+                ]
+              },
+              {
+                "group": "Data API",
+                "pages": [
+                  "api-reference/data/introduction",
+                  "api-reference/data/endpoint/list-conversations",
+                  "api-reference/data/endpoint/get-conversation-by-id",
+                  "api-reference/data/endpoint/get-conversation-audio",
+                  "api-reference/data/endpoint/add-annotations",
+                  "api-reference/data/endpoint/upsert-note",
+                  {
+                    "group": "Debug Chat",
+                    "pages": [
+                      "api-reference/data/debug-chat/create-debug-chat-session",
+                      "api-reference/data/debug-chat/send-debug-chat-message"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "DNI API",
+                "pages": [
+                  "api-reference/dni/introduction",
+                  "api-reference/dni/endpoint/dni-reservation"
+                ]
+              },
+              {
+                "group": "External Events API",
+                "pages": [
+                  "api-reference/external-events/introduction",
+                  "api-reference/external-events/endpoint/webhook",
+                  "api-reference/external-events/endpoint/bridge-ended"
+                ]
+              },
+              {
+                "group": "Handoff API",
+                "pages": [
+                  "api-reference/handoff/introduction",
+                  "api-reference/handoff/endpoint/get-handoff"
+                ]
+              },
+              {
+                "group": "Messaging API",
+                "pages": [
+                  "api-reference/messaging/introduction",
+                  "api-reference/messaging/sessions",
+                  "api-reference/messaging/websocket",
+                  "api-reference/messaging/events",
+                  "api-reference/messaging/events-send",
+                  "api-reference/messaging/events-receive",
+                  "api-reference/messaging/streaming",
+                  "api-reference/messaging/handoff",
+                  "api-reference/messaging/lifecycle",
+                  "api-reference/messaging/errors",
+                  "api-reference/messaging/best-practices"
+                ]
+              },
+              {
+                "group": "Outbound Calling API",
+                "pages": [
+                  "api-reference/outbound/introduction",
+                  "api-reference/outbound/endpoint/trigger-call",
+                  "api-reference/outbound/endpoint/get-call-status"
+                ]
+              },
+              {
+                "group": "SMS API",
+                "pages": [
+                  "api-reference/sms/introduction",
+                  "api-reference/sms/endpoint/send-sms"
+                ]
+              },
+              {
+                "group": "WebRTC Gateway",
+                "pages": [
+                  "api-reference/webrtc-gateway/introduction",
+                  "api-reference/webrtc-gateway/ws/signaling"
                 ]
               }
             ]
           },
           {
-            "group": "Conversations API v1 (legacy)",
+            "group": "Monitoring",
             "pages": [
-              "api-reference/conversations/v1/endpoint/get-conversations"
+              {
+                "group": "Alerts API",
+                "pages": [
+                  "api-reference/alerts/introduction",
+                  {
+                    "group": "Alert rules",
+                    "pages": [
+                      "api-reference/alerts/endpoint/create-alert-rule",
+                      "api-reference/alerts/endpoint/list-alert-rules",
+                      "api-reference/alerts/endpoint/get-alert-rule",
+                      "api-reference/alerts/endpoint/update-alert-rule",
+                      "api-reference/alerts/endpoint/delete-alert-rule"
+                    ]
+                  },
+                  "api-reference/alerts/endpoint/list-active-alerts"
+                ]
+              },
+              {
+                "group": "Webhooks API",
+                "pages": [
+                  "api-reference/webhooks/introduction",
+                  "api-reference/webhooks/endpoint/create-webhook-endpoint",
+                  "api-reference/webhooks/endpoint/list-webhook-endpoints",
+                  "api-reference/webhooks/endpoint/get-webhook-endpoint",
+                  "api-reference/webhooks/endpoint/update-webhook-endpoint",
+                  "api-reference/webhooks/endpoint/delete-webhook-endpoint",
+                  "api-reference/webhooks/endpoint/rotate-webhook-signing-secret"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Legacy",
+            "pages": [
+              {
+                "group": "Conversations API v3 (legacy)",
+                "pages": [
+                  "api-reference/conversations/introduction",
+                  "api-reference/conversations/v3/endpoint/get-conversations",
+                  "api-reference/conversations/v3/endpoint/get-conversation-by-id",
+                  "api-reference/conversations/v3/endpoint/get-conversation-audio",
+                  {
+                    "group": "Debug Chat",
+                    "pages": [
+                      "api-reference/conversations/v3/debug-chat/create-debug-chat-session",
+                      "api-reference/conversations/v3/debug-chat/send-debug-chat-message"
+                    ]
+                  }
+                ]
+              },
+              {
+                "group": "Conversations API v1 (legacy)",
+                "pages": [
+                  "api-reference/conversations/v1/endpoint/get-conversations"
+                ]
+              }
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -646,23 +646,6 @@
             ]
           },
           {
-            "group": "Alerts API",
-            "pages": [
-              "api-reference/alerts/introduction",
-              {
-                "group": "Alert rules",
-                "pages": [
-                  "api-reference/alerts/endpoint/create-alert-rule",
-                  "api-reference/alerts/endpoint/list-alert-rules",
-                  "api-reference/alerts/endpoint/get-alert-rule",
-                  "api-reference/alerts/endpoint/update-alert-rule",
-                  "api-reference/alerts/endpoint/delete-alert-rule"
-                ]
-              },
-              "api-reference/alerts/endpoint/list-active-alerts"
-            ]
-          },
-          {
             "group": "Chat API",
             "pages": [
               "api-reference/chat/introduction",
@@ -746,8 +729,31 @@
             "group": "SMS API",
             "pages": [
               "api-reference/sms/introduction",
-              "api-reference/sms/endpoint/send-sms",
-              "api-reference/sms/inbound"
+              "api-reference/sms/endpoint/send-sms"
+            ]
+          },
+          {
+            "group": "WebRTC Gateway",
+            "pages": [
+              "api-reference/webrtc-gateway/introduction",
+              "api-reference/webrtc-gateway/ws/signaling"
+            ]
+          },
+          {
+            "group": "Alerts API",
+            "pages": [
+              "api-reference/alerts/introduction",
+              {
+                "group": "Alert rules",
+                "pages": [
+                  "api-reference/alerts/endpoint/create-alert-rule",
+                  "api-reference/alerts/endpoint/list-alert-rules",
+                  "api-reference/alerts/endpoint/get-alert-rule",
+                  "api-reference/alerts/endpoint/update-alert-rule",
+                  "api-reference/alerts/endpoint/delete-alert-rule"
+                ]
+              },
+              "api-reference/alerts/endpoint/list-active-alerts"
             ]
           },
           {
@@ -760,13 +766,6 @@
               "api-reference/webhooks/endpoint/update-webhook-endpoint",
               "api-reference/webhooks/endpoint/delete-webhook-endpoint",
               "api-reference/webhooks/endpoint/rotate-webhook-signing-secret"
-            ]
-          },
-          {
-            "group": "WebRTC Gateway",
-            "pages": [
-              "api-reference/webrtc-gateway/introduction",
-              "api-reference/webrtc-gateway/ws/signaling"
             ]
           },
           {
@@ -1003,6 +1002,10 @@
     }
   },
   "redirects": [
+    {
+      "source": "/api-reference/sms/inbound",
+      "destination": "/api-reference/sms/introduction"
+    },
     {
       "source": "/releases/whats-changed-agent-studio",
       "destination": "/get-started/whats-new"


### PR DESCRIPTION
## Summary

- Reorders the API reference sidebar to match the three API families on the [home page](https://docs.poly.ai/api-reference/introduction):
  1. **Build & deploy** (`api.{region}.poly.ai`): Agents API
  2. **Runtime & data** (`api.{region}-1.platform.polyai.app`): Chat, Concurrent Calls, Data, DNI, External Events, Handoff, Messaging, Outbound Calling, SMS, WebRTC Gateway
  3. **Monitoring** (`api.{region}.poly.ai`): Alerts, Webhooks
  4. **Legacy**: Conversations v3, v1
- Merges the standalone [Inbound SMS](https://docs.poly.ai/api-reference/sms/inbound) page into the [SMS overview](https://docs.poly.ai/api-reference/sms/introduction) — inbound SMS is not a customer-facing API endpoint, just a feature description
- Adds redirect from `/api-reference/sms/inbound` → `/api-reference/sms/introduction`

## Test plan

- [ ] Verify sidebar order matches the three families
- [ ] Check the SMS overview includes session behavior, inactivity timeout, and channel detection sections
- [ ] Confirm `/api-reference/sms/inbound` redirects to the overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)