### PR TITLE
docs: tighten API quickstart prose

### DIFF
--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API quickstart"
 sidebarTitle: "Quickstart"
-description: "Make your first PolyAI API call, walk a real end-to-end integration, and subscribe to webhook events — in under 15 minutes."
+description: "Get set up with the PolyAI API: list conversations, pull transcripts and audio, and wire up webhooks."
 keywords:
   - quickstart
   - getting started
@@ -11,47 +11,43 @@ keywords:
   - integration
 ---
 
-This guide takes you from an empty terminal to a working post-call data pipeline: pull yesterday's conversations, fetch one with full transcript and audio, and subscribe to a webhook so you don't have to poll. Every step uses real endpoints and copy-pasteable code.
+This guide walks through a typical post-call data integration: list conversations, pull a transcript with audio, and register a webhook so you don't need to poll.
 
-If you just want the conceptual map of the API families (Build & deploy vs. Runtime & data vs. Monitoring), read the [API overview](/api-reference/introduction) first. This page assumes you've picked the [Conversations](/api-reference/conversations/introduction) and [Webhooks](/api-reference/webhooks/introduction) APIs and want to ship.
+For an overview of the API families, see the [API overview](/api-reference/introduction). This page focuses on the [Conversations](/api-reference/conversations/introduction) and [Webhooks](/api-reference/webhooks/introduction) APIs.
 
 ## What you'll build
 
-By the end of this guide you'll have:
+1. Authenticate and list conversations from the last 24 hours
+2. Fetch a single conversation with its turn-by-turn transcript
+3. Download the audio recording
+4. Register a webhook endpoint for real-time delivery
 
-1. Authenticated against the PolyAI API
-2. Listed conversations from the last 24 hours
-3. Fetched a single conversation with its full turn-by-turn transcript
-4. Downloaded the audio recording for that call
-5. Registered a webhook endpoint so PolyAI pushes new conversations to you in real time
-
-Everything below uses the recommended Conversations API **v3** and the Webhooks API. Replace the placeholder values where indicated.
+All examples use Conversations API **v3** and the Webhooks API.
 
 ## Prerequisites
 
 <Steps>
   <Step title="Get an API key">
-    PolyAI provisions API keys — they aren't self-serve yet for runtime APIs.
+    API keys aren't self-serve yet — ask your PolyAI representative for a **v3 Conversations API key** scoped to your project and region.
 
-    - Ask your PolyAI representative for a **v3 Conversations API key** scoped to the project and region you want to query.
-    - The same key works for the [Data API](/api-reference/data/introduction), [Handoff](/api-reference/handoff/introduction), [Chat](/api-reference/chat/introduction), and other runtime APIs on the `platform.polyai.app` host.
-    - For the [Agents API](/api-reference/agents/introduction), [Alerts](/api-reference/alerts/introduction), and [Webhooks](/api-reference/webhooks/introduction), email [developers@poly.ai](mailto:developers@poly.ai) for a separate workspace-scoped key.
+    - The same key covers the [Data](/api-reference/data/introduction), [Handoff](/api-reference/handoff/introduction), [Chat](/api-reference/chat/introduction), and other runtime APIs on the `platform.polyai.app` host.
+    - The [Agents](/api-reference/agents/introduction), [Alerts](/api-reference/alerts/introduction), and [Webhooks](/api-reference/webhooks/introduction) APIs need a separate workspace-scoped key — email [developers@poly.ai](mailto:developers@poly.ai).
 
-    Treat the key like a password. Never commit it or embed it in client-side code.
+    Treat the key like a password. Don't commit it or put it in client-side code.
   </Step>
 
   <Step title="Find your account ID and project ID">
-    Open Agent Studio. Your IDs are the first two segments of the URL after the host:
+    Open Agent Studio. Your IDs are in the URL:
 
     ```
     https://studio.{region}.poly.ai/{account_id}/{project_id}/agent
     ```
 
-    For example, `https://studio.uk.poly.ai/acme-uk/acme-team-4/agent` gives `account_id=acme-uk` and `project_id=acme-team-4`. Both the slug form and the prefixed form (`ws-xxxxxxxx`, `PROJECT-xxxxxxxx`) are valid in API paths. The `account_id` workspace prefix is `ws-`, not `ACCOUNT-`.
+    For example, `https://studio.uk.poly.ai/acme-uk/acme-team-4/agent` → `account_id=acme-uk`, `project_id=acme-team-4`. Both slug and prefixed forms (`ws-xxxxxxxx`, `PROJECT-xxxxxxxx`) work in API paths. The workspace prefix is `ws-`, not `ACCOUNT-`.
   </Step>
 
   <Step title="Pick the right base URL">
-    Runtime and data APIs live on regional hosts under `platform.polyai.app`. Match the region your project is provisioned in:
+    Runtime and data APIs use regional hosts under `platform.polyai.app`:
 
     | Region | Base URL                                  |
     | ------ | ----------------------------------------- |
@@ -60,12 +56,12 @@ Everything below uses the recommended Conversations API **v3** and the Webhooks 
     | EUW    | `https://api.euw-1.platform.polyai.app`   |
 
     <Warning>
-    The Webhooks API uses a different host family (`api.{region}.poly.ai`, no `-1` suffix). Don't mix them up — it's the most common source of 404s. See [base URLs](/api-reference/introduction#base-urls) for the full table.
+    The Webhooks API uses a different host (`api.{region}.poly.ai` — no `-1` suffix). Mixing these up is the most common cause of 404s. See [base URLs](/api-reference/introduction#base-urls) for the full table.
     </Warning>
   </Step>
 
   <Step title="Set environment variables">
-    Stash your key and IDs in environment variables so they stay out of code samples and source control.
+    Export your key and IDs so they stay out of source control:
 
     ```bash
     export POLYAI_API_KEY="your_api_key_here"
@@ -74,13 +70,13 @@ Everything below uses the recommended Conversations API **v3** and the Webhooks 
     export POLYAI_PROJECT_ID="PROJECT-xxxxxxxx"
     ```
 
-    Every example below assumes these are set.
+    All examples below assume these are set.
   </Step>
 </Steps>
 
 ## Step 1: Make your first call
 
-A quick smoke test confirms the key, IDs, region, and network path all line up. List a single conversation from the last 24 hours:
+Smoke-test your credentials by listing a single conversation from the last 24 hours:
 
 <CodeGroup>
 
@@ -144,15 +140,15 @@ console.log(await res.json());
 
 </CodeGroup>
 
-A successful response returns a JSON object with a `conversations` array and a `cursor` field. If you get `401`, the key is wrong or missing. If you get `404`, the region host or IDs are wrong. See [troubleshooting](#troubleshooting) below.
+You should get back a JSON object with a `conversations` array and a `cursor` field. `401` means a bad key; `404` usually means wrong base URL or IDs — see [troubleshooting](#troubleshooting).
 
 <Tip>
-No conversations in the last 24 hours? Place a test call against your sandbox agent — see [Quickstart > Test your agent](/get-started/quickstart) — and re-run the request.
+No conversations? Place a test call against your sandbox agent ([Quickstart > Test your agent](/get-started/quickstart)) and retry.
 </Tip>
 
-## Step 2: Page through a full day of calls
+## Step 2: Paginate through results
 
-The smoke test used `limit=1`. For real workloads, use a larger `limit` and walk pages with the opaque `cursor` field. Cursors stay stable as new conversations arrive, so the iteration is safe to run during business hours.
+For real workloads, bump `limit` and page with the opaque `cursor`. Cursors are stable — safe to iterate while new conversations are still coming in.
 
 <CodeGroup>
 
@@ -220,12 +216,12 @@ for await (const conv of iterConversations(start.toISOString(), end.toISOString(
 </CodeGroup>
 
 <Tip>
-Use `client_env=live` (the default) for production traffic, `sandbox` for your test calls, or `pre-release` for staging. Mixing environments is a common source of "no results" confusion.
+`client_env` defaults to `live` (production). Use `sandbox` for test calls or `pre-release` for staging. Getting an empty result set? Check you're querying the right environment.
 </Tip>
 
-## Step 3: Fetch one conversation with its transcript
+## Step 3: Fetch a conversation with its transcript
 
-The list response includes per-conversation summaries plus the `turns` array — but if you want a single conversation in detail, hit the by-ID endpoint:
+To get a single conversation in full detail, use the by-ID endpoint:
 
 <CodeGroup>
 
@@ -267,15 +263,15 @@ for (const turn of conv.turns) {
 
 </CodeGroup>
 
-See the [conversation object reference](/api-reference/conversations/introduction#response-structure) for the full field list (latency metrics, intents, entities, handoff metadata, translation outputs).
+See the [conversation object reference](/api-reference/conversations/introduction#response-structure) for all available fields (latency, intents, entities, handoff metadata, etc.).
 
 <Warning>
-If `num_turns > 0` but `turns` is empty, transcript visibility is disabled at the project level. Open **API Keys > Configuration** on the workspace homepage and enable **Conversation transcript**. See [transcript visibility](/api-reference/conversations/introduction#transcript-visibility) for the full diagnosis.
+`num_turns > 0` but `turns` is empty? Transcript visibility is off at the project level. Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio. See [transcript visibility](/api-reference/conversations/introduction#transcript-visibility).
 </Warning>
 
 ## Step 4: Download the audio recording
 
-Voice calls have an audio recording, fetched via a separate endpoint. The response is a binary stream — write it to disk or pipe it to your storage.
+Voice calls have a recording available on a separate endpoint. The response is a binary stream:
 
 <CodeGroup>
 
@@ -313,13 +309,13 @@ await writeFile(`${convId}.wav`, buf);
 
 </CodeGroup>
 
-Recordings are only generated for voice channels (`VOICE-SIP`). Chat conversations (`WEBCHAT`, `CHAT`) return `404` on this endpoint — filter on `channel` before calling.
+Only voice channels (`VOICE-SIP`) have recordings. Chat conversations (`WEBCHAT`, `CHAT`) return `404` — filter on `channel` before calling.
 
-## Step 5: Stop polling, subscribe to webhooks
+## Step 5: Subscribe to webhooks
 
-Polling the list endpoint every few minutes works, but it wastes requests and adds lag. PolyAI can push a JSON payload to a URL of yours every time a call ends, an alert fires, or a handoff happens. Set it up once and your pipeline becomes event-driven.
+Instead of polling, register a webhook and PolyAI will POST to your endpoint when a call ends, an alert fires, or a handoff occurs.
 
-The Webhooks API lives on the `poly.ai` host family — base URL changes:
+The Webhooks API uses a different host — note the base URL change:
 
 ```bash
 export POLYAI_PLATFORM_URL="https://api.us.poly.ai"  # not us-1
@@ -357,11 +353,11 @@ print(endpoint["id"], endpoint["signing_secret"])
 
 </CodeGroup>
 
-Store the `signing_secret` securely — you'll need it to verify every incoming request.
+Store the `signing_secret` — you'll need it to verify incoming requests.
 
 ### Verify the signature
 
-PolyAI signs each delivery with HMAC-SHA256 in the `X-PolyAI-Signature` header. Reject any request whose signature doesn't match.
+Every delivery is signed with HMAC-SHA256 via the `X-PolyAI-Signature` header. Always verify before processing:
 
 ```python Python
 import hashlib
@@ -386,46 +382,46 @@ def handle():
     return "", 204
 ```
 
-Respond with a 2xx status within 5 seconds. PolyAI retries on non-2xx responses with exponential backoff — keep the handler thin and offload work to a queue. See the [Webhooks API](/api-reference/webhooks/introduction) for the full event catalog, retry semantics, and signing-secret rotation.
+Return `2xx` within 5 seconds. Non-2xx responses trigger retries with exponential backoff, so keep the handler thin and push work to a queue. See the [Webhooks API reference](/api-reference/webhooks/introduction) for the full event catalog and retry semantics.
 
-## Step 6: Promote from sandbox to live
+## Step 6: Go live
 
-You probably built and tested against your sandbox environment. To run against production traffic, change one parameter:
+Once you've tested against sandbox, switch to production traffic:
 
 ```python
 params["client_env"] = "live"  # was "sandbox" or "pre-release"
 ```
 
-Webhook endpoints fire across all environments by default. If you only want production events, filter on `data.environment == "live"` in your handler, or register separate endpoints per environment.
+Webhook endpoints fire for all environments by default. To limit to production events, filter on `data.environment == "live"` in your handler or register separate endpoints per environment.
 
 ## Troubleshooting
 
-| Symptom                                        | Likely cause                                                                                       | Fix                                                                                                                  |
-| ---------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `401 Unauthorized`                             | Missing or wrong `x-api-key` header, or key revoked.                                               | Check the env var is set; ask PolyAI to confirm the key is active.                                                   |
-| `403 Forbidden`                                | Key is valid but lacks permission for this project or scope.                                       | Confirm the key was provisioned for the project ID in the URL.                                                       |
-| `404 Not Found` on conversations endpoint      | Wrong base URL (most often `api.us.poly.ai` instead of `api.us-1.platform.polyai.app`).            | Use the `platform.polyai.app` host with the regional `-1` suffix for runtime/data APIs.                              |
-| `404 Not Found` on webhooks endpoint           | You hit the runtime host. Webhooks live on `api.{region}.poly.ai`.                                 | Use `api.us.poly.ai` (no `-1`) for Agents, Alerts, Webhooks.                                                          |
-| Empty `conversations` array                    | Time window has no calls, or wrong `client_env` (live vs. sandbox).                                | Place a test call, widen the time window, or set `client_env=sandbox`.                                               |
-| `turns` is empty but `num_turns > 0`           | Transcript visibility is off at the project level.                                                 | Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio.                               |
-| `429 Too Many Requests`                        | You hit the rate limit.                                                                            | Back off using the `Retry-After` header; switch from offset to cursor pagination for large pulls.                    |
-| Webhook handler never fires                    | Endpoint not yet active, or signature verification rejecting valid requests.                       | Hit your handler URL directly; log the request body and computed signature; confirm the secret matches what you saved. |
+| Symptom                                        | Likely cause                                                                              | Fix                                                                                                  |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `401 Unauthorized`                             | Missing or wrong `x-api-key`, or key revoked.                                             | Check the env var; confirm with PolyAI the key is active.                                            |
+| `403 Forbidden`                                | Key lacks permission for this project.                                                    | Confirm the key was provisioned for the project ID in the URL.                                       |
+| `404` on conversations endpoint                | Wrong base URL — usually `api.us.poly.ai` instead of `api.us-1.platform.polyai.app`.      | Use the `platform.polyai.app` host with the `-1` suffix for runtime/data APIs.                       |
+| `404` on webhooks endpoint                     | You hit the runtime host. Webhooks use `api.{region}.poly.ai`.                            | Use `api.us.poly.ai` (no `-1`) for Agents, Alerts, and Webhooks.                                    |
+| Empty `conversations` array                    | No calls in the time window, or wrong `client_env`.                                       | Place a test call, widen the window, or try `client_env=sandbox`.                                    |
+| `turns` empty but `num_turns > 0`              | Transcript visibility disabled.                                                           | Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio.               |
+| `429 Too Many Requests`                        | Rate limit hit.                                                                           | Back off per the `Retry-After` header; use cursor pagination for large pulls.                        |
+| Webhook never fires                            | Endpoint inactive, or signature verification rejecting valid payloads.                    | Curl your handler directly; log the body and computed signature; check the secret matches.            |
 
-For the full error-code reference, see [Error codes](/api-reference/error-codes).
+See [Error codes](/api-reference/error-codes) for the full reference.
 
-## Where to go next
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="API overview" icon="map" href="/api-reference/introduction">
-    The three API families, base URLs, and version policy.
+    API families, base URLs, and versioning.
   </Card>
-  <Card title="Conversations API reference" icon="comments" href="/api-reference/conversations/introduction">
-    Full schema, retrieval modes, pagination, and streaming.
+  <Card title="Conversations API" icon="comments" href="/api-reference/conversations/introduction">
+    Full schema, pagination, and retrieval modes.
   </Card>
   <Card title="Agents API" icon="hammer" href="/api-reference/agents/introduction">
     Build and deploy agents programmatically.
   </Card>
   <Card title="Webhooks API" icon="bell" href="/api-reference/webhooks/introduction">
-    Event types, retries, and signature verification in depth.
+    Event types, retries, and signature verification.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Cut marketing-speak and AI-generated filler from the API quickstart page
- Shortened section intros, callouts, and troubleshooting table descriptions
- Kept all code samples and structure intact — prose-only changes

## Test plan
- [ ] Preview the page on Mintlify and confirm formatting renders correctly
- [ ] Check troubleshooting table columns aren't truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)