### PR TITLE
docs: replace AI-isms with plain language

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -284,7 +284,7 @@ keywords:
 
 <CardGroup cols={2}>
   <Card title="Make my first API call" icon="rocket" href="/api-reference/quickstart">
-    End-to-end how-to: key → list conversations → fetch transcript → audio → webhooks. ~15 min.
+    Full walkthrough: key → list conversations → fetch transcript → audio → webhooks.
   </Card>
   <Card title="Pull conversation data" icon="database" href="/api-reference/conversations/introduction">
     Query transcripts, metrics, and audio for analytics and compliance pipelines.

--- a/api-reference/messaging/introduction.mdx
+++ b/api-reference/messaging/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Messaging API"
 sidebarTitle: "Overview"
-description: "Embed real-time text conversations into your application using WebSockets, with seamless handoff to live agents."
+description: "Embed real-time text conversations into your application using WebSockets, with handoff to live agents."
 ---
 
 The Messaging API lets you embed real-time text conversations into your application. End users chat with a PolyAI agent, and the conversation can be handed off to a live human agent inside the same session when needed.

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -76,7 +76,7 @@ All examples use Conversations API **v3** and the Webhooks API.
 
 ## Step 1: Make your first call
 
-Smoke-test your credentials by listing a single conversation from the last 24 hours:
+Verify your credentials by listing a single conversation from the last 24 hours:
 
 <CodeGroup>
 

--- a/extend/introduction.mdx
+++ b/extend/introduction.mdx
@@ -18,7 +18,7 @@ Write Python functions to extend your agent beyond what the visual interface cov
   **Python required.** Non-technical operators: see [Configure agents in the UI](/get-started/introduction) for the no-code path.
 </Info>
 
-<Tip>Before writing custom API code, check if a [pre-built integration](/integrations/introduction) already exists for your platform (e.g., Salesforce, Zendesk, OpenTable, Stripe). Pre-built integrations handle authentication, environment configuration, and common operations out of the box.</Tip>
+<Tip>Before writing custom API code, check if a [pre-built integration](/integrations/introduction) already exists for your platform (e.g., Salesforce, Zendesk, OpenTable, Stripe). Pre-built integrations handle authentication, environment configuration, and common operations for you.</Tip>
 
 ## What you can build
 

--- a/glossary/introduction.mdx
+++ b/glossary/introduction.mdx
@@ -28,7 +28,7 @@ The primary interface for designing, configuring, and deploying AI agents. Agent
 A conversation that ends before the user's request is resolved and without a handoff to a human — for example, the caller hangs up mid-conversation.
 
 - **Chat:** tracked internally via the `CHAT_ABANDONED` metric on conversations that disengage without resolution or handoff.
-- **Voice:** no dedicated "abandonment rate" widget is surfaced out of the box; abandoned calls can be identified in [Conversation Review](/analytics/conversations/review) (short duration, no handoff, no task completion) or via the [Conversations API](/api-reference/conversations/introduction) using `total_duration`, handoff fields, and [PolyScore](/analytics/polyscore).
+- **Voice:** no dedicated "abandonment rate" widget is surfaced by default; abandoned calls can be identified in [Conversation Review](/analytics/conversations/review) (short duration, no handoff, no task completion) or via the [Conversations API](/api-reference/conversations/introduction) using `total_duration`, handoff fields, and [PolyScore](/analytics/polyscore).
 
 For a business-specific definition, track it as a [custom metric](/analytics/kpis/introduction).
 

--- a/learn/guides/advanced/tool-return-values.mdx
+++ b/learn/guides/advanced/tool-return-values.mdx
@@ -54,7 +54,7 @@ The string is inserted into conversation history under the `function` role. The 
 
 ## Returning a dictionary
 
-Dictionaries unlock more specific control. The following keys are supported individually or in combination:
+Dictionaries give you more specific control. The following keys are supported individually or in combination:
 
 ### `content`
 

--- a/learn/guides/advanced/variants.mdx
+++ b/learn/guides/advanced/variants.mdx
@@ -219,7 +219,7 @@ Variants are most useful for content that is:
     Select a variant other than your default
   </Step>
 
-  <Step title="Run smoke tests">
+  <Step title="Run your tests">
     Execute the same tests you used earlier:
     - Simple FAQ (Chat and Call)
     - Multiturn FAQ

--- a/learn/guides/get-started.mdx
+++ b/learn/guides/get-started.mdx
@@ -15,7 +15,7 @@ You'll go from an empty project to a working agent that:
 - Speaks with a voice and personality you've configured
 - Lives safely in versioned environments (Sandbox → Pre-release → Live)
 
-## Your 6-lesson journey
+## The 6 lessons
 
 <Steps>
   <Step title="Create your project">

--- a/learn/guides/get-started/environments.mdx
+++ b/learn/guides/get-started/environments.mdx
@@ -141,7 +141,7 @@ This page shows every published version of your agent and where it is currently 
     <AccordionGroup>
       <Accordion title="Best practices" icon="circle-check">
         - Promote to Pre-release only after Sandbox tests pass
-        - Re-run your smoke test for what you've built so far:
+        - Re-run your tests for what you've built so far:
           - Simple FAQ (Chat and Call)
           - Voice and greeting
           - Out-of-scope refusal
@@ -337,7 +337,7 @@ This prevents accidental testing on production users.
       1. **Test pet policy topic** – ask "are dogs allowed?" in both Chat and Call; confirm the correct topic triggers.
       2. **Test SMS consent flow** – ask "can you text me the late checkout info?" and confirm the agent asks for consent before sending.
       3. **Make a test call** – listen for the voice stability change; confirm the agent sounds more consistent and no audio artifacts were introduced.
-      4. **Run a full smoke test** – test a simple FAQ, out-of-scope refusal, and a handoff to confirm nothing regressed from your other changes.
+      4. **Run a regression test** – test a simple FAQ, out-of-scope refusal, and a handoff to confirm nothing regressed from your other changes.
       5. **Compare versions** – open the diff and confirm the three changes are the only ones present.
     </Accordion>
   </Step>

--- a/learn/maintain/health-checks.mdx
+++ b/learn/maintain/health-checks.mdx
@@ -15,7 +15,7 @@ Follow daily, weekly, and monthly health check routines to catch issues early. U
 |---------|-----------|---------------|---------------|
 | Daily check | Every day | 10-15 min | Dashboards, recent errors, handoff rate |
 | Weekly review | Every week | 30-60 min | Trends, unhandled queries, sample calls, test sets |
-| Monthly deep dive | Every month | 2-4 hours | Month-over-month metrics, knowledge audit, function optimization |
+| Monthly review | Every month | 2-4 hours | Month-over-month metrics, knowledge audit, function optimization |
 | Pre-deployment | Before each promotion | 20-30 min | Test sets, manual testing, integration checks |
 | Post-deployment | After each promotion | 30 min | Live calls, key metrics, function logs |
 
@@ -48,7 +48,7 @@ Spend 30-60 minutes each week:
 5. Check [test set](/simulation-testing/introduction) results for regressions
 6. Plan improvements for the following week based on Smart Analyst insights and test results
 
-## Monthly deep dive
+## Monthly review
 
 Spend 2-4 hours at month end:
 

--- a/messaging-channel/android-sdk.mdx
+++ b/messaging-channel/android-sdk.mdx
@@ -18,7 +18,7 @@ keywords:
 The Android SDK is a native Kotlin library that embeds PolyAI's messaging agent directly inside your Android app. It's **headless by design** — you own the UI, PolyAI provides the AI layer underneath. Your app connects to the same agent logic used across voice, webchat, and other channels.
 
 <Info>
-The Android SDK uses the [Messaging API](/api-reference/messaging/introduction) under the hood. All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
+The Android SDK wraps the [Messaging API](/api-reference/messaging/introduction). All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
 </Info>
 
 ## How it works
@@ -90,7 +90,7 @@ The SDK is published to Maven Central as `ai.poly:messaging`. Ensure `mavenCentr
 | **JDK** (to build) | 17 |
 | **Java consumers** | Supported |
 
-No permissions to declare — the SDK's manifest merges `INTERNET` and `ACCESS_NETWORK_STATE` into your app automatically. R8/minify works out of the box.
+No permissions to declare — the SDK's manifest merges `INTERNET` and `ACCESS_NETWORK_STATE` into your app automatically. R8/minify works without extra configuration.
 
 ## Authentication setup
 

--- a/messaging-channel/ios-sdk.mdx
+++ b/messaging-channel/ios-sdk.mdx
@@ -17,7 +17,7 @@ keywords:
 The iOS SDK is a native Swift library that embeds PolyAI's messaging agent directly inside your iOS app. It's **headless by design** — you own the UI, PolyAI provides the AI layer underneath. Your app connects to the same agent logic used across voice, webchat, and other channels.
 
 <Info>
-The iOS SDK uses the [Messaging API](/api-reference/messaging/introduction) under the hood. All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
+The iOS SDK wraps the [Messaging API](/api-reference/messaging/introduction). All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
 </Info>
 
 ## How it works

--- a/voice-channel/message-templates.mdx
+++ b/voice-channel/message-templates.mdx
@@ -151,7 +151,7 @@ Matching is case-insensitive and ignores leading or trailing whitespace and a si
 - The opt-out record persists indefinitely until the user opts back in, satisfying TCPA record-keeping requirements.
 
 <Note>
-A2P 10DLC campaigns in the US and Canada require you to disclose `STOP` and `HELP` behavior during opt-in. The replies above are designed to meet that requirement out of the box.
+A2P 10DLC campaigns in the US and Canada require you to disclose `STOP` and `HELP` behavior during opt-in. The replies above meet that requirement as-is.
 </Note>
 
 ## Best practices

--- a/widgets/configure.mdx
+++ b/widgets/configure.mdx
@@ -183,7 +183,7 @@ The dialog asks you to pick a **Widget type** first (**Phone** for Web Calling, 
 Click **Add** to create the widget. You'll land in the editor.
 
 <Tip>
-The **Chat** widget type is disabled until you've completed [Chat configuration](/messaging-channel/advanced/chat-configuration). **Phone** widgets are available out of the box, no chat agent required.
+The **Chat** widget type is disabled until you've completed [Chat configuration](/messaging-channel/advanced/chat-configuration). **Phone** widgets are available immediately — no chat agent required.
 </Tip>
 
 ## Widget editor


### PR DESCRIPTION
## Summary
- Replaced AI-generated phrasing with direct, human language across 14 files
- **smoke test** → "test", "regression test", "verify"
- **under the hood** → "wraps"
- **out of the box** → "by default", "immediately", "as-is", "for you"
- **deep dive** → "review"
- **unlock** → "give you"
- **seamless** → removed (the word adds nothing)
- **journey** → "lessons"
- **end-to-end how-to** → "full walkthrough"
- Skipped release notes (historical) and legitimate technical uses (e.g. "end-to-end" as a mode name, "robust" as an ElevenLabs stability setting)

## Test plan
- [ ] Spot-check a few pages in Mintlify preview to confirm no broken formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)