### PR TITLE
docs: add SDK GitHub repo links and fix iOS SPM URL

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -952,6 +952,14 @@
       {
         "label": "Studio",
         "href": "https://studio.us.poly.ai/"
+      },
+      {
+        "label": "Android SDK",
+        "href": "https://github.com/polyai/android-sdk"
+      },
+      {
+        "label": "iOS SDK",
+        "href": "https://github.com/polyai/ios-sdk"
       }
     ],
     "primary": {

--- a/messaging-channel/android-sdk.mdx
+++ b/messaging-channel/android-sdk.mdx
@@ -21,6 +21,10 @@ The Android SDK is a native Kotlin library that embeds PolyAI's messaging agent 
 The Android SDK wraps the [Messaging API](/api-reference/messaging/introduction). All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
 </Info>
 
+<Card title="Source on GitHub" icon="github" href="https://github.com/polyai/android-sdk">
+  polyai/android-sdk — Kotlin library, Maven Central, and example apps.
+</Card>
+
 ## How it works
 
 The SDK handles authentication, session management, WebSocket connections, and reconnection logic. Your app sends and receives messages through the SDK and renders them however you choose — in **Jetpack Compose** or **Android Views**.

--- a/messaging-channel/ios-sdk.mdx
+++ b/messaging-channel/ios-sdk.mdx
@@ -20,6 +20,10 @@ The iOS SDK is a native Swift library that embeds PolyAI's messaging agent direc
 The iOS SDK wraps the [Messaging API](/api-reference/messaging/introduction). All WebSocket events, streaming, and handoff behavior documented in the API reference apply.
 </Info>
 
+<Card title="Source on GitHub" icon="github" href="https://github.com/polyai/ios-sdk">
+  polyai/ios-sdk — Swift package, CocoaPods, and example apps.
+</Card>
+
 ## How it works
 
 The SDK handles authentication, session management, WebSocket connections, and reconnection logic. Your app sends and receives messages through the SDK and renders them however you choose.
@@ -48,7 +52,7 @@ The SDK is distributed as a native Swift package. Choose either method:
     In Xcode, go to **File > Add Package Dependencies** and enter the repository URL:
 
     ```
-    https://github.com/PolyAI-LDN/poly_messaging_ios
+    https://github.com/polyai/ios-sdk
     ```
 
     Select the latest version and add the package to your target.


### PR DESCRIPTION
## Summary
- **Fix broken iOS SPM URL** — the install instructions pointed to `PolyAI-LDN/poly_messaging_ios` which 404s; now points to the correct `polyai/ios-sdk`
- **Add "Source on GitHub" card** to both the iOS and Android SDK doc pages so developers can find the repo immediately
- **Add Android SDK and iOS SDK** to the navbar so they're accessible from any page

## Test plan
- [ ] Verify the iOS SPM URL (`https://github.com/polyai/ios-sdk`) resolves
- [ ] Preview both SDK pages and confirm the GitHub card renders
- [ ] Check the navbar shows the two new links

🤖 Generated with [Claude Code](https://claude.com/claude-code)