### PR TITLE
docs: clean up navbar — Studio as primary button, drop release notes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -214,7 +214,8 @@
           {
             "group": "Testing",
             "pages": [
-              "simulation-testing/introduction"
+              "simulation-testing/introduction",
+              "simulation-testing/create-tests"
             ]
           },
           {
@@ -946,26 +947,22 @@
   "navbar": {
     "links": [
       {
-        "label": "Release notes",
-        "href": "https://docs.poly.ai/releases/overview"
-      },
-      {
-        "label": "Studio",
-        "href": "https://studio.us.poly.ai/"
-      },
-      {
         "label": "Android SDK",
         "href": "https://github.com/polyai/android-sdk"
       },
       {
         "label": "iOS SDK",
         "href": "https://github.com/polyai/ios-sdk"
+      },
+      {
+        "label": "Request a demo",
+        "href": "https://poly.ai/request-a-demo/"
       }
     ],
     "primary": {
       "type": "button",
-      "label": "Request a demo",
-      "href": "https://poly.ai/request-a-demo/"
+      "label": "Open Studio",
+      "href": "https://studio.poly.ai/"
     }
   },
   "footer": {

--- a/styles.css
+++ b/styles.css
@@ -770,6 +770,37 @@ html.dark .dev-accordion > .developer-only {
   }
 }
 
+/* ── Navbar link overrides ────────────────────────────────────────────────── */
+
+/* "Request a demo" — styled as a secondary pill button so it stands out
+   from the plain-text SDK links without competing with the primary CTA. */
+li.navbar-link a[href*="request-a-demo"] {
+  background: transparent;
+  border: 1.5px solid var(--studio-lime);
+  border-radius: 999px;
+  padding: 0.3rem 0.85rem;
+  color: var(--studio-ink) !important;
+  font-weight: 600;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease,
+              box-shadow 140ms ease, transform 140ms ease;
+}
+
+li.navbar-link a[href*="request-a-demo"]:hover {
+  background: var(--studio-lime-12);
+  border-color: var(--studio-lime);
+  box-shadow: 0 0 0 3px var(--studio-lime-12);
+  transform: translateY(-0.5px);
+}
+
+html.dark li.navbar-link a[href*="request-a-demo"] {
+  color: #f5f5f5 !important;
+  border-color: var(--studio-lime);
+}
+
+html.dark li.navbar-link a[href*="request-a-demo"]:hover {
+  background: var(--studio-lime-12);
+}
+
 /* ── Hide the "Log in" button from the topbar ────────────────────────────── */
 
 #navbar a[href="/login"],


### PR DESCRIPTION
## Summary
- **Remove "Release notes"** from navbar (already in the sidebar)
- **"Open Studio"** promoted to the green primary button (`studio.poly.ai`)
- **"Request a demo"** styled as a secondary outlined pill via custom CSS — lime border, transparent background, hover glow — distinct from plain links without competing with the Studio CTA
- **SDK links** stay as plain text links

**Navbar result:** `Android SDK · iOS SDK · [Request a demo] · [Open Studio]`

### Custom CSS details
Targets `li.navbar-link a[href*="request-a-demo"]` to apply:
- Lime-bordered pill (`border-radius: 999px`)
- Transparent bg with lime-tinted hover state
- Dark mode compatible
- Matches the existing PolyAI design tokens (`--studio-lime`, `--studio-lime-12`)

## Test plan
- [ ] Preview navbar — "Open Studio" renders as green filled button
- [ ] "Request a demo" renders as an outlined pill (not plain text)
- [ ] Dark mode: both buttons readable and styled
- [ ] SDK links remain plain text
- [ ] "Release notes" gone from topbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)