### PR TITLE
docs: add Studio Assistant to testing overview

### DIFF
--- a/testing/introduction.mdx
+++ b/testing/introduction.mdx
@@ -11,12 +11,13 @@ keywords:
   - regression testing
 ---
 
-Testing in Agent Studio gives you two ways to validate your agent:
+Testing in Agent Studio gives you three ways to validate your agent:
 
 - **Simulation tests** — automated conversations that verify your agent handles specific scenarios correctly. Author a test by describing what a caller will do and asserting how the agent should respond, then run it against Draft or Sandbox to catch regressions before they reach production.
 - **A/B tests** — split live traffic between two versions and compare real-world performance before fully rolling out a change.
+- **Studio Assistant** — generate simulation test scenarios from natural language. Describe a flow and [Studio Assistant](/studio-assistant/introduction) authors the test cases for you, keeping them in sync as your agent changes.
 
-Use simulation tests throughout development to catch issues early. Use A/B tests when you need real-world evidence that a change improves outcomes.
+Use simulation tests throughout development to catch issues early. Use A/B tests when you need real-world evidence that a change improves outcomes. Use Studio Assistant when you want to quickly scaffold test coverage without writing each case by hand.
 
 <CardGroup cols={2}>
   <Card title="Create simulation tests" icon="flask-vial" href="/testing/simulation-tests">


### PR DESCRIPTION
## Summary
- Add Studio Assistant as a third testing method on the testing overview page, alongside simulation tests and A/B tests
- Links through to the Studio Assistant introduction for details on natural-language test generation

## Test plan
- [ ] Verify testing overview renders with three bullet points
- [ ] Confirm Studio Assistant link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)