### PR TITLE
docs: restructure API quickstart around build lifecycle

### DIFF
--- a/analytics/conversations/annotations.mdx
+++ b/analytics/conversations/annotations.mdx
@@ -24,14 +24,14 @@ Hover over any agent turn in the transcript to reveal a four-icon feedback toolb
 
 | Icon | Annotation | What it captures |
 |---|---|---|
-| 👍 | **Good response** | The agent handled the turn well. Use this for spot-checking and to mark positive examples. |
-| 👎 | **Bad response** | The agent's response was poor. Opens a reason picker so you can categorize the failure. |
-| ⚠️ | **Wrong information** | The agent gave a factually incorrect response. Use this alongside or instead of Bad response when the issue is content accuracy rather than response shape. |
-| 📋 | **Copy turn text** | Copies the turn's text to your clipboard — handy when sharing examples in Slack or tickets. |
+| <Icon icon="thumbs-up" iconType="solid" /> | **Good response** | The agent handled the turn well. Use this for spot-checking and to mark positive examples. |
+| <Icon icon="thumbs-down" iconType="solid" /> | **Bad response** | The agent's response was poor. Opens a reason picker so you can categorize the failure. |
+| <Icon icon="triangle-exclamation" iconType="solid" /> | **Wrong information** | The agent gave a factually incorrect response. Use this alongside or instead of Bad response when the issue is content accuracy rather than response shape. |
+| <Icon icon="copy" iconType="solid" /> | **Copy turn text** | Copies the turn's text to your clipboard — handy when sharing examples in Slack or tickets. |
 
 ### Bad response reasons
 
-When you click 👎 a searchable reason picker opens. Pick the category that best matches the failure:
+When you click <Icon icon="thumbs-down" iconType="solid" /> a searchable reason picker opens. Pick the category that best matches the failure:
 
 - **Response too general** — the answer was vague when it should have been specific.
 - **Response too specific** — the answer over-committed to detail the agent shouldn't have had.
@@ -43,7 +43,7 @@ Use the search field to filter the list when you know the category name.
 
 ### Wrong information
 
-Click ⚠️ to mark a turn as containing factually wrong content. **Wrong information** is a single toggle — there are no sub-reasons.
+Click <Icon icon="triangle-exclamation" iconType="solid" /> to mark a turn as containing factually wrong content. **Wrong information** is a single toggle — there are no sub-reasons.
 
 ![Conversation Review agent turn with the feedback toolbar visible and the Wrong information annotation checkbox selected](/images/analytics/conv-review-annotation-wrong-info.png)
 

--- a/api-reference/agents/introduction.mdx
+++ b/api-reference/agents/introduction.mdx
@@ -80,6 +80,17 @@ curl https://api.us.poly.ai/v1/accounts/ACCOUNT_ID/agents \
 API keys for the Agents API are not yet available through self-service. Contact your PolyAI representative to request access.
 </Note>
 
+## Identifiers
+
+Agent Studio labels and API parameters use different names for the same things. `ACCOUNT_ID` above is your **account ID** — Agent Studio's UI calls it the **Workspace ID** and shows it prefixed (`ws-xxxxxxxx`):
+
+| Agent Studio label    | API parameter | Example              |
+| ---------------------- | -------------- | --------------------- |
+| Workspace ID           | `accountId`    | `ws-fd112d8f`          |
+| Project ID / Agent ID  | `agentId`      | `PROJECT-58RP822I`    |
+
+<Note>**Agent ID is the same value as Project ID.** "Agent" is the current product name; "Project" is the legacy term still surfaced in some Agent Studio screens and URLs, and used by the Conversations and Chat APIs. Use the value you see in Agent Studio directly — no transformation needed.</Note>
+
 ## Quick start
 
 ### 1. Create an agent

--- a/api-reference/concurrent-calls/introduction.mdx
+++ b/api-reference/concurrent-calls/introduction.mdx
@@ -26,6 +26,10 @@ Where:
 Example:
 `GET https://api.<region>.platform.polyai.app/v1/ws-t53y16r3/PROJECT-f76d75c2/conversations/concurrency`
 
+## Identifiers
+
+`account_id` is your **account ID** — Agent Studio's UI calls this the **Workspace ID** and shows it prefixed (`ws-xxxxxxxx`, e.g. `ws-t53y16r3` above). `project_id` is the same value as the **Agent ID** shown in Agent Studio (prefixed `PROJECT-xxxxxxxx`); "Project" is the legacy term for the same resource. Both the slug form from the Agent Studio URL and the prefixed form work in API calls.
+
 ## Required query parameters
 
 - `start_time`

--- a/api-reference/conversations/introduction.mdx
+++ b/api-reference/conversations/introduction.mdx
@@ -73,6 +73,17 @@ The Conversations API uses API key authentication.
 v3 keys are project- and region-scoped and are issued by PolyAI.
 Your PolyAI representative will confirm the appropriate scope and provision access.
 
+## Identifiers
+
+`account_id` above is your **account ID** — Agent Studio's UI calls this the **Workspace ID** and shows it prefixed (`ws-xxxxxxxx`). `project_id` is the same value as the **Agent ID** shown in Agent Studio (prefixed `PROJECT-xxxxxxxx`); "Project" is the legacy term for the same resource.
+
+| Agent Studio label   | API parameter | Example             |
+| --------------------- | -------------- | -------------------- |
+| Workspace ID          | `account_id`   | `ws-fd112d8f`         |
+| Project ID / Agent ID | `project_id`   | `PROJECT-58RP822I`   |
+
+Both the slug form from the Agent Studio URL and the prefixed form work in API calls.
+
 ## Retrieval modes (optional)
 
 The v3 endpoint supports three optional retrieval modes powered by Smart Analyst tooling: **transcript search**, **semantic search**, and **random sampling**. When no retrieval mode is specified, the endpoint returns all conversations matching the given filters (default behavior). Only one mode may be used per request.

--- a/api-reference/external-events/introduction.mdx
+++ b/api-reference/external-events/introduction.mdx
@@ -50,6 +50,10 @@ You must also include:
 
 These four query parameters together tell PolyAI how to extract the correct event ID and map the payload to the right conversation.
 
+## Identifiers
+
+`account_id` above is your **account ID** — Agent Studio's UI calls this the **Workspace ID** and shows it prefixed (`ws-xxxxxxxx`). `project_id` is the same value as the **Agent ID** shown in Agent Studio (prefixed `PROJECT-xxxxxxxx`); "Project" is the legacy term for the same resource. Both the slug form from the Agent Studio URL and the prefixed form work in API calls.
+
 ## Payload formats
 
 The webhook accepts multiple content types:

--- a/api-reference/handoff/introduction.mdx
+++ b/api-reference/handoff/introduction.mdx
@@ -52,6 +52,10 @@ If both are supplied, shared_id takes precedence.
 The Handoff API uses API key authentication with the x-api-key header.
 API keys are scoped to account, project, and region. Your PolyAI representative will confirm which key is configured for handoff retrieval.
 
+## Identifiers
+
+`account_id` above is your **account ID** — Agent Studio's UI calls this the **Workspace ID** and shows it prefixed (`ws-xxxxxxxx`). `project_id` is the same value as the **Agent ID** shown in Agent Studio (prefixed `PROJECT-xxxxxxxx`); "Project" is the legacy term for the same resource. Both the slug form from the Agent Studio URL and the prefixed form work in API calls.
+
 ## Typical flow
 
 A downstream platform receives an inbound call that has just transitioned from the PolyAI agent. It queries the handoff state, then uses the data to populate the agent desktop, route the interaction, or enrich CRM entries.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -320,6 +320,7 @@ keywords:
     { flag: '🇺🇸', region: 'US', runtime: 'api.us-1.platform.polyai.app', build: 'api.us.poly.ai' },
     { flag: '🇬🇧', region: 'UK', runtime: 'api.uk-1.platform.polyai.app', build: 'api.uk.poly.ai' },
     { flag: '🇪🇺', region: 'EU', runtime: 'api.euw-1.platform.polyai.app', build: 'api.eu.poly.ai' },
+    { flag: '🛠️', region: 'Studio', runtime: 'api.studio.poly.ai', build: 'api.studio.poly.ai' },
   ].map((r) => (
     <div key={r.region} style={{
       padding: '1.1rem 1.2rem',

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -320,7 +320,7 @@ keywords:
     { flag: '🇺🇸', region: 'US', runtime: 'api.us-1.platform.polyai.app', build: 'api.us.poly.ai' },
     { flag: '🇬🇧', region: 'UK', runtime: 'api.uk-1.platform.polyai.app', build: 'api.uk.poly.ai' },
     { flag: '🇪🇺', region: 'EU', runtime: 'api.euw-1.platform.polyai.app', build: 'api.eu.poly.ai' },
-    { flag: '🛠️', region: 'Studio', runtime: 'api.studio.poly.ai', build: 'api.studio.poly.ai' },
+    { flag: '', region: 'Studio', runtime: 'api.studio.poly.ai', build: 'api.studio.poly.ai' },
   ].map((r) => (
     <div key={r.region} style={{
       padding: '1.1rem 1.2rem',

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -531,4 +531,42 @@ Only the Conversations API is versioned today. Everything else is unversioned.
   alignItems: 'center',
   justifyContent: 'space-between',
 }}>
+  <div>
+    <div style={{ fontSize: '1.1rem', fontWeight: 700, color: '#1f3a04' }}>
+      Need a hand getting started?
+    </div>
+    <p style={{ margin: '0.3rem 0 0', fontSize: '0.92rem', color: '#4b5563' }}>
+      Walk through building an agent end-to-end, or talk to a PolyAI rep about API keys and access.
+    </p>
+  </div>
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+    <a href="/api-reference/quickstart" style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+      padding: '0.65rem 1.1rem',
+      borderRadius: '12px',
+      background: '#4a7c10',
+      color: '#fff',
+      fontWeight: 600,
+      textDecoration: 'none',
+      boxShadow: '0 8px 20px -8px rgba(74, 124, 16, 0.45)',
+    }}>
+      Start the quickstart →
+    </a>
+    <a href="mailto:developers@poly.ai" style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+      padding: '0.65rem 1.1rem',
+      borderRadius: '12px',
+      background: 'transparent',
+      border: '1px solid rgba(74, 124, 16, 0.3)',
+      color: '#3a6b08',
+      fontWeight: 500,
+      textDecoration: 'none',
+    }}>
+      Contact developers@poly.ai
+    </a>
+  </div>
 </div>

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -536,37 +536,21 @@ Only the Conversations API is versioned today. Everything else is unversioned.
       Need a hand getting started?
     </div>
     <p style={{ margin: '0.3rem 0 0', fontSize: '0.92rem', color: '#4b5563' }}>
-      Walk through building an agent end-to-end, or talk to a PolyAI rep about API keys and access.
+      Walk through building an agent end-to-end, from your first API key to a live deployment.
     </p>
   </div>
-  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
-    <a href="/api-reference/quickstart" style={{
-      display: 'inline-flex',
-      alignItems: 'center',
-      gap: '0.5rem',
-      padding: '0.65rem 1.1rem',
-      borderRadius: '12px',
-      background: '#4a7c10',
-      color: '#fff',
-      fontWeight: 600,
-      textDecoration: 'none',
-      boxShadow: '0 8px 20px -8px rgba(74, 124, 16, 0.45)',
-    }}>
-      Start the quickstart →
-    </a>
-    <a href="mailto:developers@poly.ai" style={{
-      display: 'inline-flex',
-      alignItems: 'center',
-      gap: '0.5rem',
-      padding: '0.65rem 1.1rem',
-      borderRadius: '12px',
-      background: 'transparent',
-      border: '1px solid rgba(74, 124, 16, 0.3)',
-      color: '#3a6b08',
-      fontWeight: 500,
-      textDecoration: 'none',
-    }}>
-      Contact developers@poly.ai
-    </a>
-  </div>
+  <a href="/api-reference/quickstart" style={{
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.65rem 1.1rem',
+    borderRadius: '12px',
+    background: '#4a7c10',
+    color: '#fff',
+    fontWeight: 600,
+    textDecoration: 'none',
+    boxShadow: '0 8px 20px -8px rgba(74, 124, 16, 0.45)',
+  }}>
+    Start the quickstart →
+  </a>
 </div>

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -193,7 +193,7 @@ keywords:
       justifyContent: 'center',
       fontSize: '1.3rem',
       marginBottom: '0.9rem',
-    }}>🛠️</div>
+    }}><Icon icon="hammer" iconType="solid" size={20} color="#d9ee50" /></div>
     <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#4a7c10' }}>
       Build & deploy
     </div>
@@ -227,7 +227,7 @@ keywords:
       justifyContent: 'center',
       fontSize: '1.3rem',
       marginBottom: '0.9rem',
-    }}>⚡</div>
+    }}><Icon icon="bolt" iconType="solid" size={20} color="#fff" /></div>
     <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#386dbf' }}>
       Runtime & data
     </div>
@@ -261,7 +261,7 @@ keywords:
       justifyContent: 'center',
       fontSize: '1.3rem',
       marginBottom: '0.9rem',
-    }}>📡</div>
+    }}><Icon icon="satellite-dish" iconType="solid" size={20} color="#fff" /></div>
     <div style={{ fontSize: '0.75rem', fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: '#b45a1e' }}>
       Monitoring
     </div>
@@ -317,10 +317,10 @@ keywords:
   marginBottom: '1.5rem',
 }}>
   {[
-    { flag: '🇺🇸', region: 'US', runtime: 'api.us-1.platform.polyai.app', build: 'api.us.poly.ai' },
-    { flag: '🇬🇧', region: 'UK', runtime: 'api.uk-1.platform.polyai.app', build: 'api.uk.poly.ai' },
-    { flag: '🇪🇺', region: 'EU', runtime: 'api.euw-1.platform.polyai.app', build: 'api.eu.poly.ai' },
-    { flag: '', region: 'Studio', runtime: 'api.studio.poly.ai', build: 'api.studio.poly.ai' },
+    { region: 'US', runtime: 'api.us-1.platform.polyai.app', build: 'api.us.poly.ai' },
+    { region: 'UK', runtime: 'api.uk-1.platform.polyai.app', build: 'api.uk.poly.ai' },
+    { region: 'EU', runtime: 'api.euw-1.platform.polyai.app', build: 'api.eu.poly.ai' },
+    { region: 'Studio', runtime: 'api.studio.poly.ai', build: 'api.studio.poly.ai' },
   ].map((r) => (
     <div key={r.region} style={{
       padding: '1.1rem 1.2rem',
@@ -329,7 +329,7 @@ keywords:
       background: 'rgba(217, 238, 80, 0.04)',
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.6rem' }}>
-        <span style={{ fontSize: '1.4rem' }}>{r.flag}</span>
+        <Icon icon="location-dot" iconType="solid" size={18} color="#4a7c10" />
         <span style={{ fontWeight: 600, fontSize: '1rem' }}>{r.region}</span>
       </div>
       <div style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: '#386dbf', fontWeight: 600 }}>Runtime · data</div>

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -16,11 +16,33 @@ This guide builds an agent from scratch using only the API — no Agent Studio r
 
 For an overview of the API families, see the [API overview](/api-reference/introduction). This page uses the [Agents](/api-reference/agents/introduction) API to build and ship, and the [Data](/api-reference/data/introduction) API to test — the same API key and host work for both.
 
-<div style={{ display: 'flex', flexWrap: 'wrap', gap: '1.5rem', margin: '1.5rem 0 2rem', fontSize: '0.9rem', color: '#4b5563' }}>
-  <span>🔑&nbsp; <strong>1</strong> API key</span>
-  <span>🧱&nbsp; <strong>4</strong> steps</span>
-  <span>🌍&nbsp; <strong>4</strong> regions</span>
-  <span>🚀&nbsp; Draft → Sandbox → Pre-release → Live</span>
+<div style={{
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  gap: '2rem',
+  margin: '1.5rem 0 2rem',
+  padding: '1rem 1.75rem',
+  borderRadius: '14px',
+  background: 'rgba(74, 124, 16, 0.05)',
+  border: '1px solid rgba(74, 124, 16, 0.15)',
+}}>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="key" iconType="solid" size={14} color="#4a7c10" />
+    <span><strong>1</strong> API key</span>
+  </div>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="list-ol" iconType="solid" size={14} color="#4a7c10" />
+    <span><strong>4</strong> steps</span>
+  </div>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="globe" iconType="solid" size={14} color="#4a7c10" />
+    <span><strong>4</strong> regions</span>
+  </div>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="route" iconType="solid" size={14} color="#4a7c10" />
+    <span>Draft → Sandbox → Pre-release → Live</span>
+  </div>
 </div>
 
 ## What you'll build

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -1,425 +1,318 @@
 ---
 title: "API quickstart"
 sidebarTitle: "Quickstart"
-description: "Get set up with the PolyAI API: list conversations, pull transcripts and audio, and wire up webhooks."
+description: "Build a PolyAI agent from the API: create it, configure its behavior and knowledge, test it in a live conversation, and ship it to production."
 keywords:
   - quickstart
   - getting started
   - first API call
   - tutorial
   - end to end
-  - integration
+  - build an agent
+  - create agent
 ---
 
-This guide walks through a typical post-call data integration: list conversations, pull a transcript with audio, and register a webhook so you don't need to poll.
+This guide builds an agent from scratch using only the API — no Agent Studio required. By the end you'll have created an agent, given it a behavior and a knowledge base topic, held a test conversation with it, and promoted it to production.
 
-For an overview of the API families, see the [API overview](/api-reference/introduction). This page focuses on the [Conversations](/api-reference/conversations/introduction) and [Webhooks](/api-reference/webhooks/introduction) APIs.
+For an overview of the API families, see the [API overview](/api-reference/introduction). This page uses the [Agents](/api-reference/agents/introduction) API to build and ship, and the [Data](/api-reference/data/introduction) API to test — the same API key and host work for both.
 
 ## What you'll build
 
-1. Authenticate and list conversations from the last 24 hours
-2. Fetch a single conversation with its turn-by-turn transcript
-3. Download the audio recording
-4. Register a webhook endpoint for real-time delivery
-
-All examples use Conversations API **v3** and the Webhooks API.
+1. Create an agent
+2. Configure its behavior and knowledge base
+3. Hold a test conversation with it
+4. Deploy it through sandbox → pre-release → live
+5. Pull the conversation data it generates
 
 ## Prerequisites
 
 <Steps>
   <Step title="Get an API key">
-    API keys aren't self-serve yet — ask your PolyAI representative for a **v3 Conversations API key** scoped to your project and region.
+    Self-serve API keys aren't available yet — ask your PolyAI representative for a **workspace-scoped API key**. The same key authenticates the Agents API (this guide's steps 1–4) and the Data API (step 3, and pulling call data in step 5).
 
-    - The same key covers the [Data](/api-reference/data/introduction), [Handoff](/api-reference/handoff/introduction), [Chat](/api-reference/chat/introduction), and other runtime APIs on the `platform.polyai.app` host.
-    - The [Agents](/api-reference/agents/introduction), [Alerts](/api-reference/alerts/introduction), and [Webhooks](/api-reference/webhooks/introduction) APIs need a separate workspace-scoped key — email [developers@poly.ai](mailto:developers@poly.ai).
+    - The [Chat](/api-reference/chat/introduction) and [Conversations v3](/api-reference/conversations/introduction) APIs need a separate, project-scoped key and, for Chat, a connector token — request those only once you're integrating a real channel (webchat, SMS, telephony). You don't need them for this guide.
 
     Treat the key like a password. Don't commit it or put it in client-side code.
   </Step>
 
-  <Step title="Find your account ID and project ID">
-    Open Agent Studio. Your IDs are in the URL:
+  <Step title="Find your account ID">
+    Open Agent Studio. Your account ID is the first path segment in the URL:
 
     ```
     https://studio.{region}.poly.ai/{account_id}/{project_id}/agent
     ```
 
-    For example, `https://studio.uk.poly.ai/acme-uk/acme-team-4/agent` → `account_id=acme-uk`, `project_id=acme-team-4`. Both slug and prefixed forms (`ws-xxxxxxxx`, `PROJECT-xxxxxxxx`) work in API paths. The workspace prefix is `ws-`, not `ACCOUNT-`.
+    For example, `https://studio.uk.poly.ai/acme-uk/acme-team-4/agent` → `account_id=acme-uk`.
+
+    <Note>
+    **"Account ID" and "Workspace ID" are the same thing.** Agent Studio's UI calls this the **Workspace ID** and shows it in a prefixed form (`ws-xxxxxxxx`). The API parameter is named `accountId` (Agents and Data APIs) or `account_id` (Conversations, Chat, Webhooks, and most other APIs) — same value, different casing convention depending on which API family you're calling. Both the slug form from the URL (`acme-uk`) and the prefixed form (`ws-xxxxxxxx`) work in API calls.
+    </Note>
   </Step>
 
   <Step title="Pick the right base URL">
-    Runtime and data APIs use regional hosts under `platform.polyai.app`:
+    The Agents and Data APIs — everything in steps 1–4 of this guide — share one regional host family:
 
-    | Region | Base URL                                  |
-    | ------ | ----------------------------------------- |
-    | US     | `https://api.us-1.platform.polyai.app`    |
-    | UK     | `https://api.uk-1.platform.polyai.app`    |
-    | EUW    | `https://api.euw-1.platform.polyai.app`   |
+    | Region | Base URL                     |
+    | ------ | ----------------------------- |
+    | US     | `https://api.us.poly.ai`      |
+    | UK     | `https://api.uk.poly.ai`      |
+    | EU     | `https://api.eu.poly.ai`      |
+    | Studio | `https://api.studio.poly.ai`  |
 
     <Warning>
-    The Webhooks API uses a different host (`api.{region}.poly.ai` — no `-1` suffix). Mixing these up is the most common cause of 404s. See [base URLs](/api-reference/introduction#base-urls) for the full table.
+    The Conversations v3 API (used in step 5) is on a *different* host — `api.{region}-1.platform.polyai.app`, with a `-1` suffix. Mixing these up is the most common cause of `404`s. See [base URLs](/api-reference/introduction#base-urls) for the full table across every API family.
     </Warning>
   </Step>
 
   <Step title="Set environment variables">
-    Export your key and IDs so they stay out of source control:
-
     ```bash
     export POLYAI_API_KEY="your_api_key_here"
-    export POLYAI_BASE_URL="https://api.us-1.platform.polyai.app"
+    export POLYAI_BASE_URL="https://api.us.poly.ai"
     export POLYAI_ACCOUNT_ID="ws-xxxxxxxx"
-    export POLYAI_PROJECT_ID="PROJECT-xxxxxxxx"
     ```
 
     All examples below assume these are set.
   </Step>
 </Steps>
 
-## Step 1: Make your first call
-
-Verify your credentials by listing a single conversation from the last 24 hours:
+## Step 1: Create an agent
 
 <CodeGroup>
 
 ```bash curl
-START=$(date -u -d "24 hours ago" +"%Y-%m-%dT%H:%M:%SZ")
-END=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-curl -X GET \
-  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations?start_time=$START&end_time=$END&limit=1" \
-  -H "x-api-key: $POLYAI_API_KEY"
-```
-
-```python Python
-import os
-from datetime import datetime, timedelta, timezone
-import requests
-
-base_url = os.environ["POLYAI_BASE_URL"]
-account_id = os.environ["POLYAI_ACCOUNT_ID"]
-project_id = os.environ["POLYAI_PROJECT_ID"]
-headers = {"x-api-key": os.environ["POLYAI_API_KEY"]}
-
-end = datetime.now(timezone.utc)
-start = end - timedelta(hours=24)
-
-response = requests.get(
-    f"{base_url}/v3/{account_id}/{project_id}/conversations",
-    headers=headers,
-    params={
-        "start_time": start.isoformat().replace("+00:00", "Z"),
-        "end_time": end.isoformat().replace("+00:00", "Z"),
-        "limit": 1,
-    },
-)
-response.raise_for_status()
-print(response.json())
-```
-
-```typescript TypeScript
-const baseUrl = process.env.POLYAI_BASE_URL!;
-const accountId = process.env.POLYAI_ACCOUNT_ID!;
-const projectId = process.env.POLYAI_PROJECT_ID!;
-const headers = { "x-api-key": process.env.POLYAI_API_KEY! };
-
-const end = new Date();
-const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
-
-const params = new URLSearchParams({
-  start_time: start.toISOString(),
-  end_time: end.toISOString(),
-  limit: "1",
-});
-
-const res = await fetch(
-  `${baseUrl}/v3/${accountId}/${projectId}/conversations?${params}`,
-  { headers },
-);
-if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
-console.log(await res.json());
-```
-
-</CodeGroup>
-
-You should get back a JSON object with a `conversations` array and a `cursor` field. `401` means a bad key; `404` usually means wrong base URL or IDs — see [troubleshooting](#troubleshooting).
-
-<Tip>
-No conversations? Place a test call against your sandbox agent ([Quickstart > Test your agent](/get-started/quickstart)) and retry.
-</Tip>
-
-## Step 2: Paginate through results
-
-For real workloads, bump `limit` and page with the opaque `cursor`. Cursors are stable — safe to iterate while new conversations are still coming in.
-
-<CodeGroup>
-
-```python Python
-def iter_conversations(start, end, page_size=200):
-    cursor = None
-    while True:
-        params = {
-            "start_time": start,
-            "end_time": end,
-            "limit": page_size,
-            "client_env": "live",
-        }
-        if cursor:
-            params["cursor"] = cursor
-
-        page = requests.get(
-            f"{base_url}/v3/{account_id}/{project_id}/conversations",
-            headers=headers,
-            params=params,
-        )
-        page.raise_for_status()
-        body = page.json()
-
-        for conv in body["conversations"]:
-            yield conv
-
-        cursor = body.get("cursor")
-        if not cursor:
-            return
-
-for conv in iter_conversations(start.isoformat(), end.isoformat()):
-    print(conv["id"], conv["num_turns"], conv["total_duration"])
-```
-
-```typescript TypeScript
-async function* iterConversations(startIso: string, endIso: string, pageSize = 200) {
-  let cursor: string | null = null;
-  do {
-    const params = new URLSearchParams({
-      start_time: startIso,
-      end_time: endIso,
-      limit: String(pageSize),
-      client_env: "live",
-    });
-    if (cursor) params.set("cursor", cursor);
-
-    const res = await fetch(
-      `${baseUrl}/v3/${accountId}/${projectId}/conversations?${params}`,
-      { headers },
-    );
-    if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
-    const body = await res.json();
-
-    for (const conv of body.conversations) yield conv;
-    cursor = body.cursor;
-  } while (cursor);
-}
-
-for await (const conv of iterConversations(start.toISOString(), end.toISOString())) {
-  console.log(conv.id, conv.num_turns, conv.total_duration);
-}
-```
-
-</CodeGroup>
-
-<Tip>
-`client_env` defaults to `live` (production). Use `sandbox` for test calls or `pre-release` for staging. Getting an empty result set? Check you're querying the right environment.
-</Tip>
-
-## Step 3: Fetch a conversation with its transcript
-
-To get a single conversation in full detail, use the by-ID endpoint:
-
-<CodeGroup>
-
-```bash curl
-curl -X GET \
-  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations/CONVERSATION_ID" \
-  -H "x-api-key: $POLYAI_API_KEY"
-```
-
-```python Python
-conv_id = "your_conversation_id"
-res = requests.get(
-    f"{base_url}/v3/{account_id}/{project_id}/conversations/{conv_id}",
-    headers=headers,
-)
-res.raise_for_status()
-conv = res.json()
-
-for turn in conv["turns"]:
-    speaker = "USER " if turn["user_input"] else "AGENT"
-    text = turn["user_input"] or turn["agent_response"]
-    print(f"{turn['user_input_datetime']}  {speaker}  {text}")
-```
-
-```typescript TypeScript
-const convId = "your_conversation_id";
-const convRes = await fetch(
-  `${baseUrl}/v3/${accountId}/${projectId}/conversations/${convId}`,
-  { headers },
-);
-const conv = await convRes.json();
-
-for (const turn of conv.turns) {
-  const speaker = turn.user_input ? "USER " : "AGENT";
-  const text = turn.user_input || turn.agent_response;
-  console.log(`${turn.user_input_datetime}  ${speaker}  ${text}`);
-}
-```
-
-</CodeGroup>
-
-See the [conversation object reference](/api-reference/conversations/introduction#response-structure) for all available fields (latency, intents, entities, handoff metadata, etc.).
-
-<Warning>
-`num_turns > 0` but `turns` is empty? Transcript visibility is off at the project level. Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio. See [transcript visibility](/api-reference/conversations/introduction#transcript-visibility).
-</Warning>
-
-## Step 4: Download the audio recording
-
-Voice calls have a recording available on a separate endpoint. The response is a binary stream:
-
-<CodeGroup>
-
-```bash curl
-curl -X GET \
-  "$POLYAI_BASE_URL/v3/$POLYAI_ACCOUNT_ID/$POLYAI_PROJECT_ID/conversations/CONVERSATION_ID/audio" \
-  -H "x-api-key: $POLYAI_API_KEY" \
-  --output conversation.wav
-```
-
-```python Python
-res = requests.get(
-    f"{base_url}/v3/{account_id}/{project_id}/conversations/{conv_id}/audio",
-    headers=headers,
-    stream=True,
-)
-res.raise_for_status()
-
-with open(f"{conv_id}.wav", "wb") as f:
-    for chunk in res.iter_content(chunk_size=1 << 14):
-        f.write(chunk)
-```
-
-```typescript TypeScript
-const audioRes = await fetch(
-  `${baseUrl}/v3/${accountId}/${projectId}/conversations/${convId}/audio`,
-  { headers },
-);
-if (!audioRes.ok) throw new Error(`${audioRes.status}`);
-
-import { writeFile } from "node:fs/promises";
-const buf = Buffer.from(await audioRes.arrayBuffer());
-await writeFile(`${convId}.wav`, buf);
-```
-
-</CodeGroup>
-
-Only voice channels (`VOICE-SIP`) have recordings. Chat conversations (`WEBCHAT`, `CHAT`) return `404` — filter on `channel` before calling.
-
-## Step 5: Subscribe to webhooks
-
-Instead of polling, register a webhook and PolyAI will POST to your endpoint when a call ends, an alert fires, or a handoff occurs.
-
-The Webhooks API uses a different host — note the base URL change:
-
-```bash
-export POLYAI_PLATFORM_URL="https://api.us.poly.ai"  # not us-1
-```
-
-### Register an endpoint
-
-<CodeGroup>
-
-```bash curl
-curl -X POST "$POLYAI_PLATFORM_URL/v1/webhooks/endpoints" \
+curl -X POST "$POLYAI_BASE_URL/v1/accounts/$POLYAI_ACCOUNT_ID/agents" \
   -H "x-api-key: $POLYAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://your-service.example.com/polyai-events",
-    "description": "Post-call ingestion",
-    "events": ["conversation.completed", "handoff.created"]
+    "name": "Support Agent",
+    "responseSettings": {
+      "greeting": "Hi, thanks for calling Acme Corp. How can I help?"
+    }
   }'
 ```
 
 ```python Python
-res = requests.post(
-    f"{os.environ['POLYAI_PLATFORM_URL']}/v1/webhooks/endpoints",
-    headers={**headers, "Content-Type": "application/json"},
+import os
+import requests
+
+base_url = os.environ["POLYAI_BASE_URL"]
+account_id = os.environ["POLYAI_ACCOUNT_ID"]
+headers = {"x-api-key": os.environ["POLYAI_API_KEY"]}
+
+response = requests.post(
+    f"{base_url}/v1/accounts/{account_id}/agents",
+    headers=headers,
     json={
-        "url": "https://your-service.example.com/polyai-events",
-        "description": "Post-call ingestion",
-        "events": ["conversation.completed", "handoff.created"],
+        "name": "Support Agent",
+        "responseSettings": {
+            "greeting": "Hi, thanks for calling Acme Corp. How can I help?",
+        },
     },
 )
-res.raise_for_status()
-endpoint = res.json()
-print(endpoint["id"], endpoint["signing_secret"])
+response.raise_for_status()
+agent = response.json()
+print(agent["agentId"])
 ```
 
 </CodeGroup>
 
-Store the `signing_secret` — you'll need it to verify incoming requests.
+**Response**
 
-### Verify the signature
-
-Every delivery is signed with HMAC-SHA256 via the `X-PolyAI-Signature` header. Always verify before processing:
-
-```python Python
-import hashlib
-import hmac
-from flask import Flask, request, abort
-
-app = Flask(__name__)
-SIGNING_SECRET = os.environ["POLYAI_WEBHOOK_SECRET"].encode()
-
-@app.post("/polyai-events")
-def handle():
-    body = request.get_data()
-    sig = request.headers.get("X-PolyAI-Signature", "")
-
-    expected = hmac.new(SIGNING_SECRET, body, hashlib.sha256).hexdigest()
-    if not hmac.compare_digest(sig, expected):
-        abort(401)
-
-    event = request.get_json()
-    if event["type"] == "conversation.completed":
-        process_conversation(event["data"]["conversation_id"])
-    return "", 204
+```json
+{
+  "accountId": "ws-xxxxxxxx",
+  "agentId": "PROJECT-58RP822I",
+  "agentName": "Support Agent",
+  "createdAt": "2026-07-02T10:00:00.000Z",
+  "updatedAt": "2026-07-02T10:00:00.000Z",
+  "branchCount": 1
+}
 ```
 
-Return `2xx` within 5 seconds. Non-2xx responses trigger retries with exponential backoff, so keep the handler thin and push work to a queue. See the [Webhooks API reference](/api-reference/webhooks/introduction) for the full event catalog and retry semantics.
+Save `agentId` — every remaining call in this guide uses it. The agent starts with one branch, `main`.
 
-## Step 6: Go live
-
-Once you've tested against sandbox, switch to production traffic:
-
-```python
-params["client_env"] = "live"  # was "sandbox" or "pre-release"
+```bash
+export POLYAI_AGENT_ID="PROJECT-58RP822I"  # use the agentId from your response
 ```
 
-Webhook endpoints fire for all environments by default. To limit to production events, filter on `data.environment == "live"` in your handler or register separate endpoints per environment.
+## Step 2: Configure it
+
+### Set the behavior
+
+The behavior is the system prompt that governs how the agent responds.
+
+```bash curl
+curl -X PATCH "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/branches/main/behavior" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "behavior": "You are a friendly, concise support agent for Acme Corp. Answer questions using the knowledge base. If you cannot help, offer to hand off to a human agent."
+  }'
+```
+
+### Add a knowledge base topic
+
+Topics are what the agent draws on to answer questions — each one pairs content with example queries that should trigger it.
+
+```bash curl
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/branches/main/knowledge-base/topics" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Password reset",
+    "content": "Users can reset their password at acme.com/reset. Resets take effect immediately and any active sessions are logged out.",
+    "exampleQueries": {
+      "queries": ["How do I reset my password?", "I forgot my password"]
+    }
+  }'
+```
+
+See [Knowledge base](/api-reference/agents/endpoint/knowledge-base/create-knowledge-base-topic) for the full schema, including `actions` and `isActive`.
+
+## Step 3: Test it
+
+Hold a test conversation using the Data API's debug chat — it authenticates with the same key and host as the Agents API, so there's no extra credential to request. Debug chat runs against the agent's current draft, which is why you can test before you've published anything.
+
+<Tip>
+Prefer a UI? Agent Studio has a built-in **Test** panel — see [Test in Sandbox](/environments-and-versions/introduction#test-in-sandbox).
+</Tip>
+
+**Start a session:**
+
+```bash curl
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/debug-chat" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "clientEnv": "sandbox" }'
+```
+
+```json
+{
+  "conversationId": "CONV-1234567890",
+  "userInput": "",
+  "response": "Hi, thanks for calling Acme Corp. How can I help?",
+  "metadata": { },
+  "conversationEnded": false,
+  "delayedResponse": false
+}
+```
+
+**Send a message** — try the knowledge base topic you just added:
+
+```bash curl
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/debug-chat/CONV-1234567890" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientEnv": "sandbox",
+    "message": "I forgot my password"
+  }'
+```
+
+If the response references `acme.com/reset`, the topic is wired up correctly. Keep sending messages against the same `conversationId` to continue the conversation.
+
+<Note>
+Building a real webchat, SMS, or in-app integration instead of a one-off test? Use the [Chat API](/api-reference/chat/introduction) — it's built for driving conversations from an end-user-facing client and requires its own connector token.
+</Note>
+
+## Step 4: Deploy it
+
+Once you're happy with a draft, publish it to Sandbox, then promote it through Pre-release to Live. See [Environments](/environments-and-versions/introduction) for the full model.
+
+**Publish the draft to sandbox:**
+
+```bash curl
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/publish" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "sandbox",
+    "deploymentMessage": "Initial support agent"
+  }'
+```
+
+The response's `deployment.id` identifies this deployment — save it as `$DEPLOYMENT_ID`.
+
+**Promote to pre-release, then live:**
+
+```bash curl
+# sandbox -> pre-release
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/$DEPLOYMENT_ID/promote" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "targetEnvironment": "pre-release" }'
+
+# pre-release -> live (use the deployment.id returned above)
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/$PRE_RELEASE_DEPLOYMENT_ID/promote" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "targetEnvironment": "live" }'
+```
+
+Each promote call returns a new deployment for the target environment — chain the returned `deployment.id` into the next call. `targetEnvironment` only accepts `pre-release` or `live`; you can't skip straight from sandbox to live.
+
+Made a mistake? [Roll back](/api-reference/agents/endpoint/deployments/rollback-to-a-previous-deployment) to the previous deployment in any environment.
+
+## Step 5: Work with the calls it takes
+
+Once your agent is live (or you've made test calls), pull the data back with the [Conversations API](/api-reference/conversations/introduction). This uses a different host and a project-scoped key — see [prerequisites](#prerequisites) above.
+
+<Note>
+The `project_id` this API expects is the same value as the `agentId` you've used throughout this guide — "Agent" and "Project" are the current and legacy names for the same resource.
+</Note>
+
+```bash curl
+curl -X GET \
+  "https://api.us-1.platform.polyai.app/v3/$POLYAI_ACCOUNT_ID/$POLYAI_AGENT_ID/conversations?limit=5" \
+  -H "x-api-key: $POLYAI_CONVERSATIONS_API_KEY"
+```
+
+This returns a `conversations` array and a `cursor` for pagination. Fetch one by ID to get its full turn-by-turn transcript:
+
+```bash curl
+curl -X GET \
+  "https://api.us-1.platform.polyai.app/v3/$POLYAI_ACCOUNT_ID/$POLYAI_AGENT_ID/conversations/CONVERSATION_ID" \
+  -H "x-api-key: $POLYAI_CONVERSATIONS_API_KEY"
+```
+
+From here:
+
+<CardGroup cols={2}>
+  <Card title="Download call audio" icon="waveform-lines" href="/api-reference/conversations/introduction">
+    Voice calls have a recording available on a separate binary endpoint.
+  </Card>
+  <Card title="Subscribe to webhooks" icon="webhook" href="/api-reference/webhooks/introduction">
+    Get a signed POST when a call completes instead of polling for it.
+  </Card>
+</CardGroup>
 
 ## Troubleshooting
 
 | Symptom                                        | Likely cause                                                                              | Fix                                                                                                  |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `401 Unauthorized`                             | Missing or wrong `x-api-key`, or key revoked.                                             | Check the env var; confirm with PolyAI the key is active.                                            |
-| `403 Forbidden`                                | Key lacks permission for this project.                                                    | Confirm the key was provisioned for the project ID in the URL.                                       |
-| `404` on conversations endpoint                | Wrong base URL — usually `api.us.poly.ai` instead of `api.us-1.platform.polyai.app`.      | Use the `platform.polyai.app` host with the `-1` suffix for runtime/data APIs.                       |
-| `404` on webhooks endpoint                     | You hit the runtime host. Webhooks use `api.{region}.poly.ai`.                            | Use `api.us.poly.ai` (no `-1`) for Agents, Alerts, and Webhooks.                                    |
-| Empty `conversations` array                    | No calls in the time window, or wrong `client_env`.                                       | Place a test call, widen the window, or try `client_env=sandbox`.                                    |
-| `turns` empty but `num_turns > 0`              | Transcript visibility disabled.                                                           | Enable **Conversation transcript** under **API Keys > Configuration** in Agent Studio.               |
-| `429 Too Many Requests`                        | Rate limit hit.                                                                           | Back off per the `Retry-After` header; use cursor pagination for large pulls.                        |
-| Webhook never fires                            | Endpoint inactive, or signature verification rejecting valid payloads.                    | Curl your handler directly; log the body and computed signature; check the secret matches.            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `401 Unauthorized`                             | Missing or wrong `x-api-key`, or a key from the wrong region.                              | Confirm the key was issued for the region in your base URL — see [region mismatches](/api-reference/data/introduction#authentication). |
+| `403 Forbidden`                                | Key lacks permission for this account or agent.                                            | Confirm the key was provisioned for the account ID / agent ID you're using.                          |
+| `400` on create agent                          | Missing `responseSettings.greeting`, which is required.                                    | Include a non-empty `greeting` — it's the agent's opening line.                                       |
+| `404` on debug-chat message                    | Wrong or expired `conversationId`.                                                          | Start a new session with `POST /debug-chat` and use the returned `conversationId`.                    |
+| `404` on promote                               | Wrong `deploymentId`, or trying to promote a deployment that's already at that environment. | Use the `deployment.id` from the most recent publish/promote response, not an old one.                |
+| `400` on promote                               | `targetEnvironment` isn't `pre-release` or `live`, or you tried to skip a step.             | Promote sandbox → pre-release → live in order; no other values are accepted.                          |
+| `404` on Conversations endpoint (step 5)       | Wrong base URL — usually the build host (`api.us.poly.ai`) instead of the platform host.    | Conversations v3 uses `api.{region}-1.platform.polyai.app`, with the `-1` suffix.                     |
+| Empty `conversations` array                    | No calls yet in the time window, or wrong `client_env`.                                     | Place a test call via debug chat, widen the window, or try `client_env=sandbox`.                      |
+| `429 Too Many Requests`                        | Rate limit hit.                                                                             | Back off per the `Retry-After` header; use cursor pagination for large pulls.                          |
 
 See [Error codes](/api-reference/error-codes) for the full reference.
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="API overview" icon="map" href="/api-reference/introduction">
-    API families, base URLs, and versioning.
-  </Card>
-  <Card title="Conversations API" icon="comments" href="/api-reference/conversations/introduction">
-    Full schema, pagination, and retrieval modes.
-  </Card>
   <Card title="Agents API" icon="hammer" href="/api-reference/agents/introduction">
-    Build and deploy agents programmatically.
+    Branches, telephony, real-time configs, and variants for multi-site agents.
+  </Card>
+  <Card title="Chat API" icon="comments" href="/api-reference/chat/introduction">
+    Wire a real webchat, web SDK, or SMS integration into a live conversation.
+  </Card>
+  <Card title="Conversations API" icon="database" href="/api-reference/conversations/introduction">
+    Full schema, pagination, and retrieval modes for call data.
   </Card>
   <Card title="Webhooks API" icon="bell" href="/api-reference/webhooks/introduction">
     Event types, retries, and signature verification.

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -28,9 +28,9 @@ For an overview of the API families, see the [API overview](/api-reference/intro
 
 <Steps>
   <Step title="Get an API key">
-    Self-serve API keys aren't available yet — ask your PolyAI representative for a **workspace-scoped API key**. The same key authenticates the Agents API (this guide's steps 1–4) and the Data API (step 3, and pulling call data in step 5).
+    Self-serve API keys aren't available yet — ask your PolyAI representative for a **workspace-scoped API key**. The same key authenticates the Agents API and the Data API's debug chat — everything through step 4 of this guide.
 
-    - The [Chat](/api-reference/chat/introduction) and [Conversations v3](/api-reference/conversations/introduction) APIs need a separate, project-scoped key and, for Chat, a connector token — request those only once you're integrating a real channel (webchat, SMS, telephony). You don't need them for this guide.
+    - Step 5 (pulling call data back out) uses the [Conversations v3](/api-reference/conversations/introduction) API, which needs a separate project-scoped key. The [Chat API](/api-reference/chat/introduction) needs its own connector token too. Request either only once you're integrating a real channel or data pipeline — you don't need them for steps 1–4.
 
     Treat the key like a password. Don't commit it or put it in client-side code.
   </Step>
@@ -171,10 +171,28 @@ See [Knowledge base](/api-reference/agents/endpoint/knowledge-base/create-knowle
 
 ## Step 3: Test it
 
-Hold a test conversation using the Data API's debug chat — it authenticates with the same key and host as the Agents API, so there's no extra credential to request. Debug chat runs against the agent's current draft, which is why you can test before you've published anything.
+<Note>
+**Publish before you test.** Behavior and knowledge base edits live on the draft until you publish — [changes apply to an environment only once they're promoted to it](/knowledge/faqs/RAG/introduction#why-rag). There's no way to hold a debug-chat conversation against the raw draft over the API, so publishing to Sandbox is the first move here, not an afterthought.
+</Note>
+
+**Publish the draft to Sandbox:**
+
+```bash curl
+curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/publish" \
+  -H "x-api-key: $POLYAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "sandbox",
+    "deploymentMessage": "Initial support agent"
+  }'
+```
+
+The response's `deployment.id` identifies this deployment — save it as `$DEPLOYMENT_ID`, you'll need it in the next step.
+
+Now hold a test conversation using the Data API's debug chat — it authenticates with the same key and host as the Agents API, so there's no extra credential to request.
 
 <Tip>
-Prefer a UI? Agent Studio has a built-in **Test** panel — see [Test in Sandbox](/environments-and-versions/introduction#test-in-sandbox).
+Prefer a UI? Agent Studio has a built-in **Test** panel that talks to the draft directly, no publish required — see [Test in Sandbox](/environments-and-versions/introduction#test-in-sandbox).
 </Tip>
 
 **Start a session:**
@@ -191,11 +209,13 @@ curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/debug-chat" \
   "conversationId": "CONV-1234567890",
   "userInput": "",
   "response": "Hi, thanks for calling Acme Corp. How can I help?",
-  "metadata": { },
+  "metadata": { "currentNode": "greeting", "nodeTrace": ["greeting"], "retrievedTopics": [] },
   "conversationEnded": false,
   "delayedResponse": false
 }
 ```
+
+(`metadata` has more fields than shown — trimmed here for readability.)
 
 **Send a message** — try the knowledge base topic you just added:
 
@@ -209,7 +229,7 @@ curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/debug-chat/CONV-123456
   }'
 ```
 
-If the response references `acme.com/reset`, the topic is wired up correctly. Keep sending messages against the same `conversationId` to continue the conversation.
+Check `metadata.citedTopic` (and `metadata.retrievedTopics`) in the response rather than eyeballing the reply text — it names the knowledge base topic the agent actually retrieved, which is a more reliable signal that "Password reset" is wired up than scanning for `acme.com/reset` in the wording. Keep sending messages against the same `conversationId` to continue the conversation, matching `clientEnv` to whichever environment you're checking.
 
 <Note>
 Building a real webchat, SMS, or in-app integration instead of a one-off test? Use the [Chat API](/api-reference/chat/introduction) — it's built for driving conversations from an end-user-facing client and requires its own connector token.
@@ -217,23 +237,7 @@ Building a real webchat, SMS, or in-app integration instead of a one-off test? U
 
 ## Step 4: Deploy it
 
-Once you're happy with a draft, publish it to Sandbox, then promote it through Pre-release to Live. See [Environments](/environments-and-versions/introduction) for the full model.
-
-**Publish the draft to sandbox:**
-
-```bash curl
-curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/publish" \
-  -H "x-api-key: $POLYAI_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "environment": "sandbox",
-    "deploymentMessage": "Initial support agent"
-  }'
-```
-
-The response's `deployment.id` identifies this deployment — save it as `$DEPLOYMENT_ID`.
-
-**Promote to pre-release, then live:**
+Sandbox is for testing, not customer traffic. Promote the same deployment through Pre-release and into Live — that's what real callers hit. See [Environments](/environments-and-versions/introduction) for the full model.
 
 ```bash curl
 # sandbox -> pre-release
@@ -242,14 +246,14 @@ curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/$DEPLOYMEN
   -H "Content-Type: application/json" \
   -d '{ "targetEnvironment": "pre-release" }'
 
-# pre-release -> live (use the deployment.id returned above)
+# pre-release -> live (use the deployment.id returned above, not $DEPLOYMENT_ID)
 curl -X POST "$POLYAI_BASE_URL/v1/agents/$POLYAI_AGENT_ID/deployments/$PRE_RELEASE_DEPLOYMENT_ID/promote" \
   -H "x-api-key: $POLYAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "targetEnvironment": "live" }'
 ```
 
-Each promote call returns a new deployment for the target environment — chain the returned `deployment.id` into the next call. `targetEnvironment` only accepts `pre-release` or `live`; you can't skip straight from sandbox to live.
+Each promote call returns a new deployment for the target environment — chain the returned `deployment.id` into the next call. A sandbox deployment can promote straight to `live` too (skip the `targetEnvironment` field entirely and it defaults to the next stage in sequence: sandbox → pre-release → live) — going through pre-release first is a safety choice, not an API requirement.
 
 Made a mistake? [Roll back](/api-reference/agents/endpoint/deployments/rollback-to-a-previous-deployment) to the previous deployment in any environment.
 
@@ -293,9 +297,11 @@ From here:
 | `401 Unauthorized`                             | Missing or wrong `x-api-key`, or a key from the wrong region.                              | Confirm the key was issued for the region in your base URL — see [region mismatches](/api-reference/data/introduction#authentication). |
 | `403 Forbidden`                                | Key lacks permission for this account or agent.                                            | Confirm the key was provisioned for the account ID / agent ID you're using.                          |
 | `400` on create agent                          | Missing `responseSettings.greeting`, which is required.                                    | Include a non-empty `greeting` — it's the agent's opening line.                                       |
+| Debug chat replies with the old behavior/topic | You edited the draft but tested against an environment you haven't republished.             | Publish again — edits only take effect in an environment once you publish or promote into it.         |
 | `404` on debug-chat message                    | Wrong or expired `conversationId`.                                                          | Start a new session with `POST /debug-chat` and use the returned `conversationId`.                    |
-| `404` on promote                               | Wrong `deploymentId`, or trying to promote a deployment that's already at that environment. | Use the `deployment.id` from the most recent publish/promote response, not an old one.                |
-| `400` on promote                               | `targetEnvironment` isn't `pre-release` or `live`, or you tried to skip a step.             | Promote sandbox → pre-release → live in order; no other values are accepted.                          |
+| `409 Conflict` on publish                      | Nothing has changed since the last publish to this environment.                             | Publish is a no-op if the draft is already live there — make an edit first, or move on to promote.    |
+| `404` on promote                               | Wrong `deploymentId`.                                                                        | Use the `deployment.id` from the most recent publish/promote response, not an old one.                |
+| `400` on promote                               | `targetEnvironment` isn't a later stage than the deployment's current one.                   | Sandbox can promote to `pre-release` or `live`; pre-release can only promote to `live`.                |
 | `404` on Conversations endpoint (step 5)       | Wrong base URL — usually the build host (`api.us.poly.ai`) instead of the platform host.    | Conversations v3 uses `api.{region}-1.platform.polyai.app`, with the `-1` suffix.                     |
 | Empty `conversations` array                    | No calls yet in the time window, or wrong `client_env`.                                     | Place a test call via debug chat, widen the window, or try `client_env=sandbox`.                      |
 | `429 Too Many Requests`                        | Rate limit hit.                                                                             | Back off per the `Retry-After` header; use cursor pagination for large pulls.                          |

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -16,13 +16,45 @@ This guide builds an agent from scratch using only the API — no Agent Studio r
 
 For an overview of the API families, see the [API overview](/api-reference/introduction). This page uses the [Agents](/api-reference/agents/introduction) API to build and ship, and the [Data](/api-reference/data/introduction) API to test — the same API key and host work for both.
 
+<div style={{ display: 'flex', flexWrap: 'wrap', gap: '1.5rem', margin: '1.5rem 0 2rem', fontSize: '0.9rem', color: '#4b5563' }}>
+  <span>🔑&nbsp; <strong>1</strong> API key</span>
+  <span>🧱&nbsp; <strong>4</strong> steps</span>
+  <span>🌍&nbsp; <strong>4</strong> regions</span>
+  <span>🚀&nbsp; Draft → Sandbox → Pre-release → Live</span>
+</div>
+
 ## What you'll build
 
-1. Create an agent
-2. Configure its behavior and knowledge base
-3. Hold a test conversation with it
-4. Deploy it through sandbox → pre-release → live
-5. Pull the conversation data it generates
+<CardGroup cols={3}>
+  <Card title="1. Create" icon="hammer" href="#step-1-create-an-agent">
+    Stand up a new agent with a greeting.
+  </Card>
+  <Card title="2. Configure" icon="sliders" href="#step-2-configure-it">
+    Give it a behavior and a knowledge base topic.
+  </Card>
+  <Card title="3. Test" icon="flask-vial" href="#step-3-test-it">
+    Publish to Sandbox and hold a conversation with it.
+  </Card>
+  <Card title="4. Deploy" icon="rocket" href="#step-4-deploy-it">
+    Promote through Pre-release into Live traffic.
+  </Card>
+  <Card title="5. Observe" icon="database" href="#step-5-work-with-the-calls-it-takes">
+    Pull back the conversations it has.
+  </Card>
+</CardGroup>
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: Create + configure
+    Draft --> Sandbox: Publish
+    Sandbox --> Sandbox: Test (debug chat)
+    Sandbox --> PreRelease: Promote
+    PreRelease --> Live: Promote
+
+    note right of Draft: Steps 1-2
+    note right of Sandbox: Step 3 — nothing is testable until it's published here
+    note right of Live: Step 4 — real callers
+```
 
 ## Prerequisites
 
@@ -310,7 +342,7 @@ See [Error codes](/api-reference/error-codes) for the full reference.
 
 ## Next steps
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Agents API" icon="hammer" href="/api-reference/agents/introduction">
     Branches, telephony, real-time configs, and variants for multi-site agents.
   </Card>
@@ -322,5 +354,11 @@ See [Error codes](/api-reference/error-codes) for the full reference.
   </Card>
   <Card title="Webhooks API" icon="bell" href="/api-reference/webhooks/introduction">
     Event types, retries, and signature verification.
+  </Card>
+  <Card title="Outbound Calling API" icon="phone-arrow-up-right" href="/api-reference/outbound/introduction">
+    Have your new agent place a real call out — needs outbound enabled on the project first.
+  </Card>
+  <Card title="WebRTC Gateway" icon="microphone" href="/api-reference/webrtc-gateway/introduction">
+    Talk to your agent by voice from a browser tab instead of typing.
   </Card>
 </CardGroup>

--- a/flows/triggering-flows.mdx
+++ b/flows/triggering-flows.mdx
@@ -103,7 +103,7 @@ def identify_and_verify_user(conv: Conversation, account_type: str):
     if conv.state.is_verified == False:
         conv.state.original_topic = "check_account_balance"
         conv.goto_flow("Identify & Verify User")
-        # ⚠️ Nothing below runs as you'd expect:
+        # Nothing below runs as you'd expect:
         # - The verification flow hasn't run yet (it runs next turn).
         # - `verification_successful` is undefined.
         # - The branch reading `conv.state.is_verified` runs against

--- a/messaging-channel/android-sdk.mdx
+++ b/messaging-channel/android-sdk.mdx
@@ -386,7 +386,7 @@ def start(conv):
     if conv.channel_type == "android":
         conv.state.greet_message = "Hi! How can I help you today?"
     elif conv.channel_type.startswith("webchat"):
-        conv.state.greet_message = "Hi there! 👋 How can I help?"
+        conv.state.greet_message = "Hi there! How can I help?"
 ```
 
 ## Related pages

--- a/messaging-channel/ios-sdk.mdx
+++ b/messaging-channel/ios-sdk.mdx
@@ -145,7 +145,7 @@ def start(conv):
     if conv.channel_type == "ios":
         conv.state.greet_message = "Hi! How can I help you today?"
     elif conv.channel_type.startswith("webchat"):
-        conv.state.greet_message = "Hi there! 👋 How can I help?"
+        conv.state.greet_message = "Hi there! How can I help?"
 ```
 
 ## Related pages

--- a/messaging-channel/multichannel.mdx
+++ b/messaging-channel/multichannel.mdx
@@ -52,7 +52,7 @@ def start(conv):
     if conv.channel_type.startswith("webchat"):
         conv.state.greet_message = (
             f"Hi, you're speaking with Poly, a virtual agent for "
-            f"{conv.variant.webchat_site_name} 👋<br><br>How may I help you today?"
+            f"{conv.variant.webchat_site_name}<br><br>How may I help you today?"
         )
     else:
         conv.state.greet_message = (


### PR DESCRIPTION
## Summary

Acts on Naorin Sharmin and James O'Sullivan's feedback from the mid-cycle check-in thread on `api-reference/quickstart.mdx`:

- **Naorin:** the quickstart previously walked through *reading* data (list conversations, pull transcript, download audio, register webhook) instead of the full build lifecycle a first-time API developer expects. It's now restructured around **create → configure → test → deploy**, using the Agents API to build/ship and the Data API's debug chat to test (same key, same host — no extra credential needed for step 3). Data export is condensed into a final section that links out to the Conversations/Webhooks/Data API pages instead of duplicating all the code inline.
- **James (1): Studio as a region** — added to the region grid in `api-reference/introduction.mdx`, matching the region tables already in `agents/introduction.mdx` and `data/introduction.mdx`.
- **James (2): self-serve API keys** — confirmed still accurate today (checked internally); tightened the wording in the new quickstart without referencing internal timelines.
- **James (3): account_id / Workspace ID naming** — kept `account_id`/`accountId` as the canonical API term per team decision, but added an explicit "Identifiers" mapping note (Agent Studio label → API parameter → example) everywhere it was missing: `agents/introduction.mdx`, `conversations/introduction.mdx`, `handoff/introduction.mdx`, `concurrent-calls/introduction.mdx`, `external-events/introduction.mdx`.

## Correction found while verifying against the actual backend

Cross-checked the new content against the real `poly_core` handlers (not just the docs' own OpenAPI spec). The public `debug-chat` endpoint tests whichever environment (`sandbox`/`pre-release`/`live`) you point it at — it can't test the raw, unpublished draft over the API (that's only possible via Agent Studio's own internal Test panel). So "test" now publishes to Sandbox first, then converses — this matches the platform's existing documented pipeline (Publish → Test in Sandbox → Promote) rather than testing before any deployment exists. Also corrected an invented claim that sandbox can't promote directly to live — it can (`ALLOWED_PROMOTIONS` in `deployment_interactor.py` permits sandbox → live directly, pre-release is a safety choice, not a requirement).

## Design pass

- Added an icon `CardGroup` lifecycle map, a Mermaid state diagram (Draft → Sandbox → Pre-release → Live, matching the style already used in `environments-and-versions/introduction.mdx`), and Outbound Calling / WebRTC Gateway cards to "Next steps."
- Filled in an empty, content-less closing CTA box on `api-reference/introduction.mdx` that predated this PR.
- **Site-wide emoji sweep:** scanned all 382 `.mdx` files and replaced every remaining emoji with Mintlify's `<Icon>` (FontAwesome) component or plain text, per new standing style guidance. Notably, the annotation-toolbar emoji in `analytics/conversations/annotations.mdx` didn't match the actual product UI (verified against the real screenshot) — that fix is an accuracy correction, not just style. A few emoji inside code-fence strings/comments (example greet messages, a Python comment) have no `<Icon>` equivalent since components can't render inside code blocks — those were just removed.

## Verification

- Every documented endpoint path returns `401` (routed, needs auth) vs `404` for a nonsense path — confirmed live across all 4 regions.
- Request/response schemas and environment-promotion rules cross-checked against the actual backend source (`poly_core`), not just the docs repo's own `openapi.json`.
- All internal links/anchors re-verified after each restructure.
- `docs.json` navigation entries for all touched pages confirmed unchanged and valid.
- Full-repo grep confirms zero remaining emoji.
- [ ] Visual review in Mintlify preview once deployed