### PR TITLE
docs: move Outbound Calling API into Legacy section

### DIFF
--- a/api-reference/outbound/introduction.mdx
+++ b/api-reference/outbound/introduction.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Overview'
 description: 'Trigger outbound calls and monitor status for customer outreach, reminders, and notifications.'
 ---
 
+<Warning>
+**New integrations should use the [Agents API's outbound calls endpoints](/api-reference/agents/endpoint/outbound-calls/trigger-outbound-call).** Those endpoints are the official, supported way to trigger and monitor outbound calls for an agent going forward. The standalone Outbound Calling API documented on this page is the legacy endpoint — existing integrations continue to work, but new work should target the Agents API.
+</Warning>
+
 The Outbound Calling API lets you programmatically initiate outbound calls and monitor their status. Use it for proactive customer outreach, appointment reminders, and automated notifications.
 
 ## Prerequisites

--- a/docs.json
+++ b/docs.json
@@ -720,14 +720,6 @@
                 ]
               },
               {
-                "group": "Outbound Calling API",
-                "pages": [
-                  "api-reference/outbound/introduction",
-                  "api-reference/outbound/endpoint/trigger-call",
-                  "api-reference/outbound/endpoint/get-call-status"
-                ]
-              },
-              {
                 "group": "SMS API",
                 "pages": [
                   "api-reference/sms/introduction",
@@ -780,6 +772,14 @@
           {
             "group": "Legacy",
             "pages": [
+              {
+                "group": "Outbound Calling API (legacy)",
+                "pages": [
+                  "api-reference/outbound/introduction",
+                  "api-reference/outbound/endpoint/trigger-call",
+                  "api-reference/outbound/endpoint/get-call-status"
+                ]
+              },
               {
                 "group": "Conversations API v3 (legacy)",
                 "pages": [


### PR DESCRIPTION
## Summary
- Moves the standalone **Outbound Calling API** nav group from **Runtime & data** into the **Legacy** section, alongside the Conversations APIs (renamed to "Outbound Calling API (legacy)" for consistency with the other legacy groups).
- Adds a warning to `api-reference/outbound/introduction.mdx` pointing new integrations to the Agents API's [outbound-calls endpoints](/api-reference/agents/endpoint/outbound-calls/trigger-outbound-call), which supersede the standalone API — matching the existing pattern used on the legacy Conversations API page.

## Test plan
- [x] Validated `docs.json` is well-formed JSON
- [ ] Spot-check the Legacy nav section renders correctly in Mintlify preview