### PR TITLE
fix: correct Genesys handoff webhook URL path

### DIFF
--- a/integrations/messaging/genesys.mdx
+++ b/integrations/messaging/genesys.mdx
@@ -64,7 +64,7 @@ This integration is the channel over which Genesys forwards inbound messages to 
 3. Set the **Outbound Notification Webhook URL** to your PolyAI messaging webhook URL. The pattern is:
 
    ```
-   https://messaging.<CLUSTER>.poly.ai/webhooks/genesys/<ACCOUNT_ID>/<PROJECT_ID>/<CLIENT_ENV>/events
+   https://messaging.<CLUSTER>.poly.ai/handoff/webhooks/genesys/<ACCOUNT_ID>/<PROJECT_ID>/<CLIENT_ENV>/events
    ```
 
    Replace `<CLUSTER>`, `<ACCOUNT_ID>`, `<PROJECT_ID>`, and `<CLIENT_ENV>` (e.g. `live`) with your values, and adjust the base domain for your environment (`dev` vs `us-1` / `uk-1` / `euw-1`). This URL is shown in the Agent Studio Genesys setup wizard.
@@ -125,7 +125,7 @@ Agent Studio generates the values you paste back into Genesys in [step 4](#4-cre
 | Field | Use |
 | --- | --- |
 | Webhook Secret | Enter as the **Outbound Notification webhook signature secret token** in the Open Messaging integration |
-| Webhook URL | Set as the **Outbound Notification Webhook URL** in the Open Messaging integration: `https://messaging.<CLUSTER>.poly.ai/webhooks/genesys/<ACCOUNT_ID>/<PROJECT_ID>/<CLIENT_ENV>/events` |
+| Webhook URL | Set as the **Outbound Notification Webhook URL** in the Open Messaging integration: `https://messaging.<CLUSTER>.poly.ai/handoff/webhooks/genesys/<ACCOUNT_ID>/<PROJECT_ID>/<CLIENT_ENV>/events` |
 
 ## Verify
 


### PR DESCRIPTION
## Summary
- The **Outbound Notification Webhook URL** pattern on the Genesys integration page was missing the `/handoff` prefix. Correct path is `https://messaging.<CLUSTER>.poly.ai/handoff/webhooks/genesys/<ACCOUNT_ID>/<PROJECT_ID>/<CLIENT_ENV>/events`.
- Reported by Joe Thornton — the documented URL wouldn't route correctly as written.
- Fixed both occurrences (the setup step and the generated-values reference table).

## Test plan
- [ ] Confirm `/handoff/webhooks/genesys/...` is the correct live route (vs. `/webhooks/genesys/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)