### PR TITLE
fix: restore missing useState import (lost to merge race in #554)

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -62,6 +62,8 @@ These standard codes apply across all PolyAI APIs.
 
 PolyAI APIs return domain-specific error codes alongside HTTP status codes. There are 63 of them across 13 categories — search by code, ID, or keyword below, or filter by HTTP status, instead of scanning tables.
 
+import { useState } from "react"
+
 export const ERROR_CODES = [
   { code: "AUTH_USER_NOT_FOUND", id: "3001", http: 401, category: "Authentication and authorization", description: "User not found in the auth system." },
   { code: "AUTH_USER_UNAUTHORISED", id: "3002", http: 401, category: "Authentication and authorization", description: "Invalid credentials or expired session." },


### PR DESCRIPTION
## This is currently broken in production, still
PR #554 merged at **19:34 UTC**. The commit with the actual fix (`import { useState } from "react"`) was pushed to that branch at **~21:00 UTC** -- after the merge already happened -- so it was never incorporated into `main`. Confirmed: `165755fe` (the fix commit) is not an ancestor of current `main`/`HEAD`.

Re-verified against `main` HEAD right now using the same reproduction as #554 (`@mdx-js/mdx`'s `evaluate()` + `react-dom/server`, the actual engine Mintlify's build is based on): it still throws

```
ReferenceError: useState is not defined
```

So `docs.poly.ai/api-reference/error-codes` is still broken (or will show the error again on next rebuild/cache expiry).

## Fix
Same one-line fix as before: `import { useState } from "react"` in the MDX body. Re-verified clean render with all 63 error codes present after this change.

## Test plan
- [ ] Merge and confirm the error codes page actually renders in production (please double check the merge actually lands this specific commit before considering this resolved, given what happened with #554)

🤖 Generated with [Claude Code](https://claude.com/claude-code)