### PR TITLE
docs: replace custom interactive error code explorer with plain Accordions

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -60,282 +60,137 @@ These standard codes apply across all PolyAI APIs.
 
 ## Platform error codes
 
-PolyAI APIs return domain-specific error codes alongside HTTP status codes. There are 63 of them across 13 categories — search by code, ID, or keyword below, or filter by HTTP status, instead of scanning tables.
+PolyAI APIs return domain-specific error codes alongside HTTP status codes. There are 63 of them across the 13 categories below — expand the category you're hitting, or use page search (Cmd/Ctrl+F) to jump straight to a code.
 
-import { useState } from "react"
+<AccordionGroup>
+  <Accordion title="Authentication and authorization" icon="key">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `AUTH_USER_NOT_FOUND` | 3001 | 401 | User not found in the auth system. |
+    | `AUTH_USER_UNAUTHORISED` | 3002 | 401 | Invalid credentials or expired session. |
+    | `AUTH_USER_INVALID_TOKEN` | 3003 | 401 | Token is malformed, expired, or revoked. |
+    | `USER_ACCESS_FORBIDDEN` | 2 | 403 | User lacks permission for the requested action. |
+    | `EXTERNAL_USER_FORBIDDEN` | 3 | 403 | External user privilege level is too low. |
+    | `ACCOUNT_INSUFFICIENT_PERMISSIONS` | 1003 | 403 | User lacks permissions for this account operation. |
+  </Accordion>
 
-export const ERROR_CODES = [
-  { code: "AUTH_USER_NOT_FOUND", id: "3001", http: 401, category: "Authentication and authorization", description: "User not found in the auth system." },
-  { code: "AUTH_USER_UNAUTHORISED", id: "3002", http: 401, category: "Authentication and authorization", description: "Invalid credentials or expired session." },
-  { code: "AUTH_USER_INVALID_TOKEN", id: "3003", http: 401, category: "Authentication and authorization", description: "Token is malformed, expired, or revoked." },
-  { code: "USER_ACCESS_FORBIDDEN", id: "2", http: 403, category: "Authentication and authorization", description: "User lacks permission for the requested action." },
-  { code: "EXTERNAL_USER_FORBIDDEN", id: "3", http: 403, category: "Authentication and authorization", description: "External user privilege level is too low." },
-  { code: "ACCOUNT_INSUFFICIENT_PERMISSIONS", id: "1003", http: 403, category: "Authentication and authorization", description: "User lacks permissions for this account operation." },
-  { code: "CONVERSATIONS_NOT_FOUND", id: "5001", http: 404, category: "Conversations", description: "Conversation ID does not exist." },
-  { code: "CONVERSATIONS_VALIDATION_FAILED", id: "5002", http: 400, category: "Conversations", description: "Conversation request body failed validation." },
-  { code: "CONVERSATIONS_RECORDING_NOT_FOUND", id: "5003", http: 404, category: "Conversations", description: "Audio recording not found for this conversation." },
-  { code: "GET_CONVERSATIONS_FILTER_PARSE_ERROR", id: "—", http: 400, category: "Conversations", description: "Filter expression syntax is invalid." },
-  { code: "GET_CONVERSATIONS_INVALID_SORT_PARAMETER", id: "—", http: 400, category: "Conversations", description: "Sort field is not in the allowed set." },
-  { code: "CHAT_DRAFT_NOT_EXIST", id: "4001", http: 400, category: "Chat", description: "The draft you are attempting to chat with does not exist." },
-  { code: "CHAT_TIMEOUT", id: "4002", http: 400, category: "Chat", description: "Chat session exceeded the timeout limit." },
-  { code: "CHAT_DRAFT_DEPLOYMENT_FAILED", id: "4003", http: 500, category: "Chat", description: "Draft auto-deploy failed before the chat could start." },
-  { code: "ChatConversationEnded", id: "—", http: 410, category: "Chat", description: "You sent a message to a conversation that has already ended." },
-  { code: "DEPLOYMENT_NOT_FOUND", id: "6001", http: 404, category: "Deployments", description: "Deployment ID does not exist." },
-  { code: "DEPLOYMENTS_ALREADY_PUBLISHED", id: "6009", http: 409, category: "Deployments", description: "Draft is already published to the target environment." },
-  { code: "DEPLOYMENTS_ENVIRONMENT_ALREADY_PUBLISHED", id: "6002", http: 200, category: "Deployments", description: "Environment already has this version (idempotent)." },
-  { code: "DEPLOYMENTS_VALIDATION_FAILED", id: "6007", http: 400, category: "Deployments", description: "Request body validation failed." },
-  { code: "DEPLOYMENTS_INVALID_ENVIRONMENT", id: "6008", http: 400, category: "Deployments", description: "Invalid or missing `environment` query parameter." },
-  { code: "ErrPreReleaseNotReady", id: "—", http: 412, category: "Deployments", description: "You must deploy to pre-release before promoting to live." },
-  { code: "FLOW_NOT_FOUND", id: "8001", http: 404, category: "Flows", description: "Flow ID does not exist." },
-  { code: "FLOWS_NAME_ALREADY_EXISTS", id: "8003", http: 409, category: "Flows", description: "A flow with this name already exists." },
-  { code: "FLOWS_FUNCTION_NAME_ALREADY_EXISTS", id: "8004", http: 409, category: "Flows", description: "A function with this name already exists in the flow." },
-  { code: "FLOWS_RESERVED_PARAMETER_NAME", id: "8005", http: 400, category: "Flows", description: "You used a reserved parameter name." },
-  { code: "FLOWS_RESERVED_FUNCTION_NAME", id: "8006", http: 400, category: "Flows", description: "You used a reserved function name." },
-  { code: "FUNCTION_NOT_FOUND", id: "9001", http: 404, category: "Functions", description: "Function ID does not exist." },
-  { code: "FUNCTIONS_DEPLOYMENT_HAS_ERRORS", id: "9004", http: 400, category: "Functions", description: "Function code contains errors that prevent deployment." },
-  { code: "FUNCTION_EXECUTION_FAILED", id: "9006", http: 400, category: "Functions", description: "Function encountered a runtime execution error." },
-  { code: "FUNCTION_FAILED_TO_PARSE", id: "9007", http: 400, category: "Functions", description: "Function source code has parse errors." },
-  { code: "FUNCTION_NAME_ALREADY_EXISTS", id: "9009", http: 409, category: "Functions", description: "A function with this name already exists." },
-  { code: "FUNCTIONS_RESERVED_NAME", id: "9010", http: 400, category: "Functions", description: "You used a system-reserved function name." },
-  { code: "KNOWLEDGE_BASE_TOPIC_ALREADY_EXISTS", id: "11001", http: 409, category: "Knowledge base", description: "A topic with this name already exists." },
-  { code: "KNOWLEDGE_BASE_IMPORT_NO_CSV_FOUND", id: "11002", http: 400, category: "Knowledge base", description: "No CSV file found in the import request." },
-  { code: "KNOWLEDGE_BASE_IMPORT_INVALID_TYPE", id: "11003", http: 415, category: "Knowledge base", description: "The uploaded file type is not supported." },
-  { code: "KNOWLEDGE_BASE_IMPORT_MISSING_COLUMNS", id: "11004", http: 400, category: "Knowledge base", description: "Required columns are missing from the CSV import." },
-  { code: "KNOWLEDGE_BASE_TOPICS_INVALID", id: "11005", http: 400, category: "Knowledge base", description: "Topic data failed validation." },
-  { code: "KNOWLEDGE_BASE_RICH_TEXT_INVALID", id: "11006", http: 400, category: "Knowledge base", description: "Rich text markup is malformed or references a missing entity." },
-  { code: "PHONE_NUMBERS_NOT_FOUND", id: "14006", http: 404, category: "Phone numbers and connectors", description: "Phone number does not exist." },
-  { code: "PHONE_NUMBERS_ALREADY_EXISTS", id: "14007", http: 409, category: "Phone numbers and connectors", description: "Phone number has already been imported." },
-  { code: "PHONE_NUMBERS_INVALID_PHONE_NUMBER_FORMAT", id: "14003", http: 400, category: "Phone numbers and connectors", description: "Number is not in valid E.164 format." },
-  { code: "PHONE_NUMBERS_CONNECTOR_DOES_NOT_EXIST", id: "14005", http: 404, category: "Phone numbers and connectors", description: "Referenced connector not found." },
-  { code: "CONNECTORS_NOT_FOUND", id: "14100", http: 404, category: "Phone numbers and connectors", description: "Connector ID does not exist." },
-  { code: "CONNECTORS_VALIDATION_FAILED", id: "14101", http: 400, category: "Phone numbers and connectors", description: "Connector request body failed validation." },
-  { code: "VARIANTS_BAD_ATTRIBUTES_ERROR", id: "26001", http: 400, category: "Variants", description: "Attribute values do not match the expected schema." },
-  { code: "VARIANTS_DUPLICATE_NAME_ERROR", id: "26002", http: 409, category: "Variants", description: "A variant with this name already exists." },
-  { code: "VARIANTS_REMOVE_DEFAULT_ERROR", id: "26003", http: 400, category: "Variants", description: "You cannot remove the default variant." },
-  { code: "VariantsImportInvalidDelimiter", id: "—", http: 400, category: "Variants", description: "CSV delimiter not recognized." },
-  { code: "VariantImportMissingColumnsHttp", id: "—", http: 400, category: "Variants", description: "CSV is missing required columns." },
-  { code: "VariantImportDuplicateColumnsHttp", id: "—", http: 400, category: "Variants", description: "CSV has duplicate column headers." },
-  { code: "REAL_TIME_CONFIG_FORBIDDEN_ACCESS", id: "29001", http: 403, category: "Real-time configuration", description: "Not authorized to access real-time configs." },
-  { code: "REAL_TIME_CONFIG_INVALID_FOR_SCHEMA", id: "29002", http: 400, category: "Real-time configuration", description: "Config values fail JSON Schema validation." },
-  { code: "REAL_TIME_CONFIG_INVALID_SCHEMA", id: "29004", http: 400, category: "Real-time configuration", description: "JSON Schema definition is invalid." },
-  { code: "REAL_TIME_CONFIG_UNKNOWN_CLIENT_ENVIRONMENT", id: "29006", http: 400, category: "Real-time configuration", description: "Client environment is not one of `sandbox`, `pre-release`, or `live`." },
-  { code: "ACCOUNT_NOT_FOUND", id: "1002", http: 404, category: "Accounts and projects", description: "Account ID does not exist." },
-  { code: "ACCOUNT_CREATE_INVALID_ID", id: "1004", http: 400, category: "Accounts and projects", description: "Account ID contains non-alphanumeric characters or is too similar to an existing ID." },
-  { code: "ACCOUNT_CREATE_EXISTING_ID", id: "1006", http: 409, category: "Accounts and projects", description: "Account ID is already taken." },
-  { code: "PROJECT_NOT_FOUND", id: "15001", http: 404, category: "Accounts and projects", description: "Project ID does not exist." },
-  { code: "PROJECT_ID_ALREADY_EXISTS", id: "15005", http: 409, category: "Accounts and projects", description: "Project ID is already taken." },
-  { code: "PROJECT_ID_INVALID", id: "15006", http: 400, category: "Accounts and projects", description: "Project ID does not meet format requirements." },
-  { code: "SMS_TEMPLATE_NOT_FOUND", id: "20001", http: 404, category: "SMS", description: "SMS template ID does not exist." },
-  { code: "MissingTestCasesHttp", id: "—", http: 422, category: "Test suite", description: "One or more test case IDs were not found." },
-  { code: "NoTestCasesHttp", id: "—", http: 422, category: "Test suite", description: "No test cases exist for this project." },
-]
+  <Accordion title="Conversations" icon="messages">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `CONVERSATIONS_NOT_FOUND` | 5001 | 404 | Conversation ID does not exist. |
+    | `CONVERSATIONS_VALIDATION_FAILED` | 5002 | 400 | Conversation request body failed validation. |
+    | `CONVERSATIONS_RECORDING_NOT_FOUND` | 5003 | 404 | Audio recording not found for this conversation. |
+    | `GET_CONVERSATIONS_FILTER_PARSE_ERROR` | — | 400 | Filter expression syntax is invalid. |
+    | `GET_CONVERSATIONS_INVALID_SORT_PARAMETER` | — | 400 | Sort field is not in the allowed set. |
+  </Accordion>
 
-export const ERROR_CATEGORIES = [
-  "Authentication and authorization", "Conversations", "Chat", "Deployments", "Flows",
-  "Functions", "Knowledge base", "Phone numbers and connectors", "Variants",
-  "Real-time configuration", "Accounts and projects", "SMS", "Test suite",
-]
+  <Accordion title="Chat" icon="comment">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `CHAT_DRAFT_NOT_EXIST` | 4001 | 400 | The draft you are attempting to chat with does not exist. |
+    | `CHAT_TIMEOUT` | 4002 | 400 | Chat session exceeded the timeout limit. |
+    | `CHAT_DRAFT_DEPLOYMENT_FAILED` | 4003 | 500 | Draft auto-deploy failed before the chat could start. |
+    | `ChatConversationEnded` | — | 410 | You sent a message to a conversation that has already ended. |
+  </Accordion>
 
-export const ERROR_HTTP_STATUSES = [200, 400, 401, 403, 404, 409, 410, 412, 415, 422, 500]
+  <Accordion title="Deployments" icon="rocket">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `DEPLOYMENT_NOT_FOUND` | 6001 | 404 | Deployment ID does not exist. |
+    | `DEPLOYMENTS_ALREADY_PUBLISHED` | 6009 | 409 | Draft is already published to the target environment. |
+    | `DEPLOYMENTS_ENVIRONMENT_ALREADY_PUBLISHED` | 6002 | 200 | Environment already has this version (idempotent). |
+    | `DEPLOYMENTS_VALIDATION_FAILED` | 6007 | 400 | Request body validation failed. |
+    | `DEPLOYMENTS_INVALID_ENVIRONMENT` | 6008 | 400 | Invalid or missing `environment` query parameter. |
+    | `ErrPreReleaseNotReady` | — | 412 | You must deploy to pre-release before promoting to live. |
+  </Accordion>
 
-export const errorStatusColor = (http) => {
-  if (http < 300) return { bg: "rgba(74, 124, 16, 0.1)", fg: "#3a6b08", border: "rgba(74, 124, 16, 0.35)" }
-  if (http < 500) return { bg: "rgba(180, 90, 30, 0.1)", fg: "#8a4517", border: "rgba(180, 90, 30, 0.35)" }
-  return { bg: "rgba(190, 40, 40, 0.1)", fg: "#a02020", border: "rgba(190, 40, 40, 0.35)" }
-}
+  <Accordion title="Flows" icon="diagram-project">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `FLOW_NOT_FOUND` | 8001 | 404 | Flow ID does not exist. |
+    | `FLOWS_NAME_ALREADY_EXISTS` | 8003 | 409 | A flow with this name already exists. |
+    | `FLOWS_FUNCTION_NAME_ALREADY_EXISTS` | 8004 | 409 | A function with this name already exists in the flow. |
+    | `FLOWS_RESERVED_PARAMETER_NAME` | 8005 | 400 | You used a reserved parameter name. |
+    | `FLOWS_RESERVED_FUNCTION_NAME` | 8006 | 400 | You used a reserved function name. |
+  </Accordion>
 
-export const renderErrorInline = (text) => {
-  const parts = text.split("`")
-  return parts.map((part, i) => (i % 2 === 1 ? <code key={i} style={{ fontSize: "0.85em" }}>{part}</code> : part))
-}
+  <Accordion title="Functions" icon="code">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `FUNCTION_NOT_FOUND` | 9001 | 404 | Function ID does not exist. |
+    | `FUNCTIONS_DEPLOYMENT_HAS_ERRORS` | 9004 | 400 | Function code contains errors that prevent deployment. |
+    | `FUNCTION_EXECUTION_FAILED` | 9006 | 400 | Function encountered a runtime execution error. |
+    | `FUNCTION_FAILED_TO_PARSE` | 9007 | 400 | Function source code has parse errors. |
+    | `FUNCTION_NAME_ALREADY_EXISTS` | 9009 | 409 | A function with this name already exists. |
+    | `FUNCTIONS_RESERVED_NAME` | 9010 | 400 | You used a system-reserved function name. |
+  </Accordion>
 
-export const ErrorCodeExplorer = () => {
-  const [query, setQuery] = useState("")
-  const [activeStatuses, setActiveStatuses] = useState([])
-  const [copied, setCopied] = useState("")
+  <Accordion title="Knowledge base" icon="book">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `KNOWLEDGE_BASE_TOPIC_ALREADY_EXISTS` | 11001 | 409 | A topic with this name already exists. |
+    | `KNOWLEDGE_BASE_IMPORT_NO_CSV_FOUND` | 11002 | 400 | No CSV file found in the import request. |
+    | `KNOWLEDGE_BASE_IMPORT_INVALID_TYPE` | 11003 | 415 | The uploaded file type is not supported. |
+    | `KNOWLEDGE_BASE_IMPORT_MISSING_COLUMNS` | 11004 | 400 | Required columns are missing from the CSV import. |
+    | `KNOWLEDGE_BASE_TOPICS_INVALID` | 11005 | 400 | Topic data failed validation. |
+    | `KNOWLEDGE_BASE_RICH_TEXT_INVALID` | 11006 | 400 | Rich text markup is malformed or references a missing entity. |
+  </Accordion>
 
-  const toggleStatus = (status) => {
-    setActiveStatuses((prev) => (prev.includes(status) ? prev.filter((s) => s !== status) : [...prev, status]))
-  }
+  <Accordion title="Phone numbers and connectors" icon="phone">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `PHONE_NUMBERS_NOT_FOUND` | 14006 | 404 | Phone number does not exist. |
+    | `PHONE_NUMBERS_ALREADY_EXISTS` | 14007 | 409 | Phone number has already been imported. |
+    | `PHONE_NUMBERS_INVALID_PHONE_NUMBER_FORMAT` | 14003 | 400 | Number is not in valid E.164 format. |
+    | `PHONE_NUMBERS_CONNECTOR_DOES_NOT_EXIST` | 14005 | 404 | Referenced connector not found. |
+    | `CONNECTORS_NOT_FOUND` | 14100 | 404 | Connector ID does not exist. |
+    | `CONNECTORS_VALIDATION_FAILED` | 14101 | 400 | Connector request body failed validation. |
+  </Accordion>
 
-  const copyCode = (code) => {
-    try {
-      if (typeof navigator !== "undefined" && navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(code).catch(() => {})
-      }
-    } catch (err) {
-      // Clipboard API unavailable or blocked -- still show feedback below, just don't copy.
-    }
-    setCopied(code)
-    setTimeout(() => setCopied(""), 1500)
-  }
+  <Accordion title="Variants" icon="shuffle">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `VARIANTS_BAD_ATTRIBUTES_ERROR` | 26001 | 400 | Attribute values do not match the expected schema. |
+    | `VARIANTS_DUPLICATE_NAME_ERROR` | 26002 | 409 | A variant with this name already exists. |
+    | `VARIANTS_REMOVE_DEFAULT_ERROR` | 26003 | 400 | You cannot remove the default variant. |
+    | `VariantsImportInvalidDelimiter` | — | 400 | CSV delimiter not recognized. |
+    | `VariantImportMissingColumnsHttp` | — | 400 | CSV is missing required columns. |
+    | `VariantImportDuplicateColumnsHttp` | — | 400 | CSV has duplicate column headers. |
+  </Accordion>
 
-  const q = query.trim().toLowerCase()
-  const filtered = ERROR_CODES.filter((e) => {
-    const matchesQuery =
-      !q ||
-      e.code.toLowerCase().includes(q) ||
-      e.id.toLowerCase().includes(q) ||
-      e.description.toLowerCase().includes(q) ||
-      String(e.http).includes(q)
-    const matchesStatus = activeStatuses.length === 0 || activeStatuses.includes(e.http)
-    return matchesQuery && matchesStatus
-  })
+  <Accordion title="Real-time configuration" icon="sliders">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `REAL_TIME_CONFIG_FORBIDDEN_ACCESS` | 29001 | 403 | Not authorized to access real-time configs. |
+    | `REAL_TIME_CONFIG_INVALID_FOR_SCHEMA` | 29002 | 400 | Config values fail JSON Schema validation. |
+    | `REAL_TIME_CONFIG_INVALID_SCHEMA` | 29004 | 400 | JSON Schema definition is invalid. |
+    | `REAL_TIME_CONFIG_UNKNOWN_CLIENT_ENVIRONMENT` | 29006 | 400 | Client environment is not one of `sandbox`, `pre-release`, or `live`. |
+  </Accordion>
 
-  const grouped = ERROR_CATEGORIES.map((category) => ({
-    category,
-    rows: filtered.filter((e) => e.category === category),
-  })).filter((g) => g.rows.length > 0)
+  <Accordion title="Accounts and projects" icon="building">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `ACCOUNT_NOT_FOUND` | 1002 | 404 | Account ID does not exist. |
+    | `ACCOUNT_CREATE_INVALID_ID` | 1004 | 400 | Account ID contains non-alphanumeric characters or is too similar to an existing ID. |
+    | `ACCOUNT_CREATE_EXISTING_ID` | 1006 | 409 | Account ID is already taken. |
+    | `PROJECT_NOT_FOUND` | 15001 | 404 | Project ID does not exist. |
+    | `PROJECT_ID_ALREADY_EXISTS` | 15005 | 409 | Project ID is already taken. |
+    | `PROJECT_ID_INVALID` | 15006 | 400 | Project ID does not meet format requirements. |
+  </Accordion>
 
-  return (
-    <div style={{ margin: "1.5rem 0", maxWidth: "100%", boxSizing: "border-box" }}>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem", alignItems: "center", marginBottom: "0.9rem" }}>
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by code, ID, or description..."
-          style={{
-            flex: "1 1 260px",
-            padding: "0.6rem 0.9rem",
-            borderRadius: "10px",
-            border: "1px solid rgba(0,0,0,0.15)",
-            fontSize: "0.9rem",
-            outline: "none",
-            boxSizing: "border-box",
-          }}
-        />
-        {(query || activeStatuses.length > 0) && (
-          <button
-            type="button"
-            onClick={() => { setQuery(""); setActiveStatuses([]) }}
-            style={{
-              padding: "0.55rem 0.9rem",
-              borderRadius: "10px",
-              border: "1px solid rgba(0,0,0,0.15)",
-              background: "transparent",
-              fontSize: "0.85rem",
-              cursor: "pointer",
-              color: "#4b5563",
-            }}
-          >
-            Clear
-          </button>
-        )}
-      </div>
+  <Accordion title="SMS" icon="comment-sms">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `SMS_TEMPLATE_NOT_FOUND` | 20001 | 404 | SMS template ID does not exist. |
+  </Accordion>
 
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", marginBottom: "0.9rem" }}>
-        {ERROR_HTTP_STATUSES.map((status) => {
-          const active = activeStatuses.includes(status)
-          const c = errorStatusColor(status)
-          return (
-            <button
-              key={status}
-              type="button"
-              onClick={() => toggleStatus(status)}
-              style={{
-                padding: "0.25rem 0.65rem",
-                borderRadius: "999px",
-                border: `1px solid ${active ? c.fg : c.border}`,
-                background: active ? c.fg : c.bg,
-                color: active ? "#fff" : c.fg,
-                fontSize: "0.78rem",
-                fontWeight: 600,
-                cursor: "pointer",
-              }}
-            >
-              {status}
-            </button>
-          )
-        })}
-      </div>
-
-      <div style={{ fontSize: "0.82rem", color: "#6b7280", marginBottom: "0.6rem" }}>
-        Showing {filtered.length} of {ERROR_CODES.length} error codes
-      </div>
-
-      {filtered.length === 0 ? (
-        <div style={{
-          padding: "2rem 1.5rem",
-          textAlign: "center",
-          borderRadius: "12px",
-          border: "1px dashed rgba(0,0,0,0.15)",
-          color: "#6b7280",
-          fontSize: "0.9rem",
-        }}>
-          No error codes match "{query}". Try a different search term or clear the status filters.
-        </div>
-      ) : (
-        grouped.map((group) => (
-          <div key={group.category} style={{ marginBottom: "1.5rem" }}>
-            <h4 style={{ fontSize: "0.95rem", margin: "0 0 0.5rem", color: "#374151" }}>{group.category}</h4>
-            <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-              {group.rows.map((row) => {
-                const c = errorStatusColor(row.http)
-                return (
-                  <div
-                    key={row.code}
-                    style={{
-                      display: "flex",
-                      flexWrap: "wrap",
-                      alignItems: "center",
-                      gap: "0.4rem 0.6rem",
-                      padding: "0.55rem 0.7rem",
-                      borderRadius: "10px",
-                      border: "1px solid rgba(0,0,0,0.08)",
-                      fontSize: "0.88rem",
-                      maxWidth: "100%",
-                      boxSizing: "border-box",
-                    }}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => copyCode(row.code)}
-                      title="Copy error code"
-                      style={{
-                        fontFamily: "monospace",
-                        fontSize: "0.82rem",
-                        background: "rgba(74, 124, 16, 0.06)",
-                        border: "none",
-                        borderRadius: "6px",
-                        padding: "0.2rem 0.45rem",
-                        cursor: "pointer",
-                        color: "#3a6b08",
-                        maxWidth: "100%",
-                        minWidth: 0,
-                        overflowWrap: "anywhere",
-                        wordBreak: "break-word",
-                        whiteSpace: "normal",
-                        textAlign: "left",
-                      }}
-                    >
-                      {copied === row.code ? "Copied!" : row.code}
-                    </button>
-                    <span style={{
-                      padding: "0.1rem 0.5rem",
-                      borderRadius: "999px",
-                      background: c.bg,
-                      color: c.fg,
-                      fontSize: "0.78rem",
-                      fontWeight: 600,
-                      flexShrink: 0,
-                    }}>{row.http}</span>
-                    {row.id !== "—" && (
-                      <span style={{ color: "#9ca3af", fontSize: "0.78rem", flexShrink: 0 }}>ID {row.id}</span>
-                    )}
-                    <span style={{ flexBasis: "100%", minWidth: 0, overflowWrap: "anywhere", color: "#374151" }}>{renderErrorInline(row.description)}</span>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        ))
-      )}
-    </div>
-  )
-}
-
-<ErrorCodeExplorer />
+  <Accordion title="Test suite" icon="flask-vial">
+    | Code | ID | HTTP | Description |
+    |------|----|------|-------------|
+    | `MissingTestCasesHttp` | — | 422 | One or more test case IDs were not found. |
+    | `NoTestCasesHttp` | — | 422 | No test cases exist for this project. |
+  </Accordion>
+</AccordionGroup>
 
 ## WebSocket close codes
 


### PR DESCRIPTION
## Why
Three rounds of live production breakage (#550, #553, #554, #555) traced back to Mintlify's own docs claiming hooks like `useState` are "pre-injected, no imports needed" in MDX components -- which turned out to be wrong for their actual build pipeline -- plus a merge race that dropped the one fix that did work, leaving the page broken again.

Rather than keep iterating against a build system I can't reproduce or get real error output from in this sandbox (three attempts to run the Mintlify CLI locally all died silently), this drops the custom `useState`-based search/filter component entirely.

## What changed
Replaced the interactive explorer with a plain `<AccordionGroup>` -- one `<Accordion>` per category, each containing a standard markdown table. This is a first-party Mintlify component already used successfully elsewhere in this repo (e.g. `behavior/introduction.mdx`), so there's:
- No custom JS, no hooks, no imports, nothing that can throw at build time
- Collapsed by default, so the page isn't a 63-row wall of text (an improvement over the original 13 flat `###` tables)
- Full-text findable via page search (Cmd/Ctrl+F) and the site's own search, same as before

Verified structurally by rendering the file through the actual `@mdx-js/mdx` `evaluate()` + `react-dom/server` pipeline (same engine Mintlify's platform is built on) -- clean render, all 13 categories and 63 codes present, zero errors.

## Test plan
- [ ] Merge and confirm the page actually renders in production (given the track record on this page, please verify directly rather than assuming)
- [ ] Spot check a couple of accordions expand/collapse correctly and all codes are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)