### PR TITLE
docs: usability-focused redesign of error codes page, waterfalled to quickstart

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -11,43 +11,40 @@ keywords:
 
 When a request fails, PolyAI APIs return a structured JSON error response. This page documents the HTTP status codes, error response format, and platform-specific error codes you may encounter.
 
-<div style={{
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-  gap: '1rem',
-  margin: '1.5rem 0 2rem',
-}}>
+63 platform error codes span the categories below — jump straight to yours:
+
+<div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', margin: '1.25rem 0 2rem' }}>
 {[
-  { icon: 'hashtag', value: '63', label: 'Platform error codes', color: '#4a7c10', bg: 'linear-gradient(160deg, rgba(74, 124, 16, 0.07), rgba(74, 124, 16, 0.01))', border: 'rgba(74, 124, 16, 0.18)' },
-  { icon: 'folder-tree', value: '13', label: 'Categories', color: '#386dbf', bg: 'linear-gradient(160deg, rgba(56, 109, 191, 0.07), rgba(56, 109, 191, 0.01))', border: 'rgba(56, 109, 191, 0.2)' },
-  { icon: 'fingerprint', value: '1', label: 'Correlation ID per response', color: '#b45a1e', bg: 'linear-gradient(160deg, rgba(180, 90, 30, 0.08), rgba(180, 90, 30, 0.01))', border: 'rgba(180, 90, 30, 0.2)' },
-].map((s) => (
-  <div key={s.label} style={{
-    display: 'flex',
+  { label: 'Authentication', icon: 'key', href: '#auth' },
+  { label: 'Conversations', icon: 'messages', href: '#conversations' },
+  { label: 'Chat', icon: 'comment', href: '#chat' },
+  { label: 'Deployments', icon: 'rocket', href: '#deployments' },
+  { label: 'Flows', icon: 'diagram-project', href: '#flows' },
+  { label: 'Functions', icon: 'code', href: '#functions' },
+  { label: 'Knowledge base', icon: 'book', href: '#knowledge-base' },
+  { label: 'Phone & connectors', icon: 'phone', href: '#phone-numbers' },
+  { label: 'Variants', icon: 'shuffle', href: '#variants' },
+  { label: 'Real-time config', icon: 'sliders', href: '#real-time-config' },
+  { label: 'Accounts & projects', icon: 'building', href: '#accounts-projects' },
+  { label: 'SMS', icon: 'comment-sms', href: '#sms' },
+  { label: 'Test suite', icon: 'flask-vial', href: '#test-suite' },
+].map((c) => (
+  <a key={c.href} href={c.href} style={{
+    display: 'inline-flex',
     alignItems: 'center',
-    gap: '0.9rem',
-    padding: '1rem 1.2rem',
-    borderRadius: '16px',
-    border: `1px solid ${s.border}`,
-    background: s.bg,
+    gap: '0.4rem',
+    padding: '0.4rem 0.85rem',
+    borderRadius: '999px',
+    border: '1px solid rgba(74, 124, 16, 0.22)',
+    background: 'rgba(74, 124, 16, 0.05)',
+    color: '#3a6b08',
+    fontSize: '0.82rem',
+    fontWeight: 600,
+    textDecoration: 'none',
   }}>
-    <div style={{
-      width: '44px',
-      height: '44px',
-      borderRadius: '12px',
-      background: s.color,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexShrink: 0,
-    }}>
-      <Icon icon={s.icon} iconType="solid" size={18} color="#fff" />
-    </div>
-    <div>
-      <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#1f2937', lineHeight: 1.15 }}>{s.value}</div>
-      <div style={{ fontSize: '0.82rem', color: '#6b7280' }}>{s.label}</div>
-    </div>
-  </div>
+    <Icon icon={c.icon} iconType="solid" size={12} color="#3a6b08" />
+    {c.label}
+  </a>
 ))}
 </div>
 
@@ -126,10 +123,10 @@ These standard codes apply across all PolyAI APIs. Client errors (4xx) mean fix 
 
 ## Platform error codes
 
-PolyAI APIs return domain-specific error codes alongside HTTP status codes. There are 63 of them across the 13 categories below — expand the category you're hitting, or use page search (Cmd/Ctrl+F) to jump straight to a code.
+Expand the category you're hitting, or use one of the jump links above.
 
 <AccordionGroup>
-  <Accordion title="Authentication and authorization" icon="key">
+  <Accordion id="auth" title="Authentication and authorization" icon="key">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `AUTH_USER_NOT_FOUND` | 3001 | 401 | User not found in the auth system. |
@@ -140,7 +137,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `ACCOUNT_INSUFFICIENT_PERMISSIONS` | 1003 | 403 | User lacks permissions for this account operation. |
   </Accordion>
 
-  <Accordion title="Conversations" icon="messages">
+  <Accordion id="conversations" title="Conversations" icon="messages">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `CONVERSATIONS_NOT_FOUND` | 5001 | 404 | Conversation ID does not exist. |
@@ -150,7 +147,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `GET_CONVERSATIONS_INVALID_SORT_PARAMETER` | — | 400 | Sort field is not in the allowed set. |
   </Accordion>
 
-  <Accordion title="Chat" icon="comment">
+  <Accordion id="chat" title="Chat" icon="comment">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `CHAT_DRAFT_NOT_EXIST` | 4001 | 400 | The draft you are attempting to chat with does not exist. |
@@ -159,7 +156,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `ChatConversationEnded` | — | 410 | You sent a message to a conversation that has already ended. |
   </Accordion>
 
-  <Accordion title="Deployments" icon="rocket">
+  <Accordion id="deployments" title="Deployments" icon="rocket">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `DEPLOYMENT_NOT_FOUND` | 6001 | 404 | Deployment ID does not exist. |
@@ -170,7 +167,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `ErrPreReleaseNotReady` | — | 412 | You must deploy to pre-release before promoting to live. |
   </Accordion>
 
-  <Accordion title="Flows" icon="diagram-project">
+  <Accordion id="flows" title="Flows" icon="diagram-project">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `FLOW_NOT_FOUND` | 8001 | 404 | Flow ID does not exist. |
@@ -180,7 +177,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `FLOWS_RESERVED_FUNCTION_NAME` | 8006 | 400 | You used a reserved function name. |
   </Accordion>
 
-  <Accordion title="Functions" icon="code">
+  <Accordion id="functions" title="Functions" icon="code">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `FUNCTION_NOT_FOUND` | 9001 | 404 | Function ID does not exist. |
@@ -191,7 +188,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `FUNCTIONS_RESERVED_NAME` | 9010 | 400 | You used a system-reserved function name. |
   </Accordion>
 
-  <Accordion title="Knowledge base" icon="book">
+  <Accordion id="knowledge-base" title="Knowledge base" icon="book">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `KNOWLEDGE_BASE_TOPIC_ALREADY_EXISTS` | 11001 | 409 | A topic with this name already exists. |
@@ -202,7 +199,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `KNOWLEDGE_BASE_RICH_TEXT_INVALID` | 11006 | 400 | Rich text markup is malformed or references a missing entity. |
   </Accordion>
 
-  <Accordion title="Phone numbers and connectors" icon="phone">
+  <Accordion id="phone-numbers" title="Phone numbers and connectors" icon="phone">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `PHONE_NUMBERS_NOT_FOUND` | 14006 | 404 | Phone number does not exist. |
@@ -213,7 +210,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `CONNECTORS_VALIDATION_FAILED` | 14101 | 400 | Connector request body failed validation. |
   </Accordion>
 
-  <Accordion title="Variants" icon="shuffle">
+  <Accordion id="variants" title="Variants" icon="shuffle">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `VARIANTS_BAD_ATTRIBUTES_ERROR` | 26001 | 400 | Attribute values do not match the expected schema. |
@@ -224,7 +221,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `VariantImportDuplicateColumnsHttp` | — | 400 | CSV has duplicate column headers. |
   </Accordion>
 
-  <Accordion title="Real-time configuration" icon="sliders">
+  <Accordion id="real-time-config" title="Real-time configuration" icon="sliders">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `REAL_TIME_CONFIG_FORBIDDEN_ACCESS` | 29001 | 403 | Not authorized to access real-time configs. |
@@ -233,7 +230,7 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `REAL_TIME_CONFIG_UNKNOWN_CLIENT_ENVIRONMENT` | 29006 | 400 | Client environment is not one of `sandbox`, `pre-release`, or `live`. |
   </Accordion>
 
-  <Accordion title="Accounts and projects" icon="building">
+  <Accordion id="accounts-projects" title="Accounts and projects" icon="building">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `ACCOUNT_NOT_FOUND` | 1002 | 404 | Account ID does not exist. |
@@ -244,13 +241,13 @@ PolyAI APIs return domain-specific error codes alongside HTTP status codes. Ther
     | `PROJECT_ID_INVALID` | 15006 | 400 | Project ID does not meet format requirements. |
   </Accordion>
 
-  <Accordion title="SMS" icon="comment-sms">
+  <Accordion id="sms" title="SMS" icon="comment-sms">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `SMS_TEMPLATE_NOT_FOUND` | 20001 | 404 | SMS template ID does not exist. |
   </Accordion>
 
-  <Accordion title="Test suite" icon="flask-vial">
+  <Accordion id="test-suite" title="Test suite" icon="flask-vial">
     | Code | ID | HTTP | Description |
     |------|----|------|-------------|
     | `MissingTestCasesHttp` | — | 422 | One or more test case IDs were not found. |
@@ -270,19 +267,39 @@ If you are using the WebRTC Gateway or webchat WebSocket connections, you may en
 
 ## Troubleshooting
 
-### Include the correlation ID in support requests
-
+<Tip>
 Every API response includes an `X-PolyAI-Correlation-Id` header. When contacting PolyAI support, include this value so the team can trace the request through the system.
+</Tip>
 
 ### Common patterns
 
-| Symptom | Likely cause | Resolution |
-|---------|-------------|------------|
-| 401 on every request | API key missing or malformed | Verify the `x-api-key` header is present and correctly formatted. |
-| 403 after key rotation | Old key revoked | Confirm you are using the new key. |
-| 404 for a known resource | Wrong region | Verify the base URL matches your account region. |
-| 409 on create | Duplicate identifier | Use a different name or ID, or check for existing resources. |
-| 422 on import | Schema mismatch | Verify CSV columns match the expected format. Check the error `data` field for column details. |
+<div style={{
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+  gap: '0.75rem',
+  margin: '1rem 0 1.5rem',
+}}>
+{[
+  { symptom: '401 on every request', cause: 'API key missing or malformed', resolution: <>Verify the <code>x-api-key</code> header is present and correctly formatted.</> },
+  { symptom: '403 after key rotation', cause: 'Old key revoked', resolution: 'Confirm you are using the new key.' },
+  { symptom: '404 for a known resource', cause: 'Wrong region', resolution: 'Verify the base URL matches your account region.' },
+  { symptom: '409 on create', cause: 'Duplicate identifier', resolution: 'Use a different name or ID, or check for existing resources.' },
+  { symptom: '422 on import', cause: 'Schema mismatch', resolution: <>Verify CSV columns match the expected format. Check the error <code>data</code> field for column details.</> },
+].map((p) => (
+  <div key={p.symptom} style={{
+    padding: '0.9rem 1.1rem',
+    borderRadius: '14px',
+    border: '1px solid rgba(0,0,0,0.08)',
+    background: 'rgba(0,0,0,0.015)',
+  }}>
+    <div style={{ fontWeight: 700, fontSize: '0.92rem', color: '#1f2937', marginBottom: '0.5rem' }}>{p.symptom}</div>
+    <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: '#9ca3af', marginBottom: '0.15rem' }}>Likely cause</div>
+    <div style={{ fontSize: '0.85rem', color: '#4b5563', marginBottom: '0.6rem' }}>{p.cause}</div>
+    <div style={{ fontSize: '0.76rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: '#9ca3af', marginBottom: '0.15rem' }}>Resolution</div>
+    <div style={{ fontSize: '0.85rem', color: '#374151' }}>{p.resolution}</div>
+  </div>
+))}
+</div>
 
 ## Related pages
 

--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -12,28 +12,43 @@ keywords:
 When a request fails, PolyAI APIs return a structured JSON error response. This page documents the HTTP status codes, error response format, and platform-specific error codes you may encounter.
 
 <div style={{
-  display: 'flex',
-  flexWrap: 'wrap',
-  justifyContent: 'center',
-  gap: '2rem',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+  gap: '1rem',
   margin: '1.5rem 0 2rem',
-  padding: '1rem 1.75rem',
-  borderRadius: '14px',
-  background: 'rgba(74, 124, 16, 0.05)',
-  border: '1px solid rgba(74, 124, 16, 0.15)',
 }}>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="hashtag" iconType="solid" size={14} color="#4a7c10" />
-    <span><strong>63</strong> platform error codes</span>
+{[
+  { icon: 'hashtag', value: '63', label: 'Platform error codes', color: '#4a7c10', bg: 'linear-gradient(160deg, rgba(74, 124, 16, 0.07), rgba(74, 124, 16, 0.01))', border: 'rgba(74, 124, 16, 0.18)' },
+  { icon: 'folder-tree', value: '13', label: 'Categories', color: '#386dbf', bg: 'linear-gradient(160deg, rgba(56, 109, 191, 0.07), rgba(56, 109, 191, 0.01))', border: 'rgba(56, 109, 191, 0.2)' },
+  { icon: 'fingerprint', value: '1', label: 'Correlation ID per response', color: '#b45a1e', bg: 'linear-gradient(160deg, rgba(180, 90, 30, 0.08), rgba(180, 90, 30, 0.01))', border: 'rgba(180, 90, 30, 0.2)' },
+].map((s) => (
+  <div key={s.label} style={{
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.9rem',
+    padding: '1rem 1.2rem',
+    borderRadius: '16px',
+    border: `1px solid ${s.border}`,
+    background: s.bg,
+  }}>
+    <div style={{
+      width: '44px',
+      height: '44px',
+      borderRadius: '12px',
+      background: s.color,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+    }}>
+      <Icon icon={s.icon} iconType="solid" size={18} color="#fff" />
+    </div>
+    <div>
+      <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#1f2937', lineHeight: 1.15 }}>{s.value}</div>
+      <div style={{ fontSize: '0.82rem', color: '#6b7280' }}>{s.label}</div>
+    </div>
   </div>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="folder-tree" iconType="solid" size={14} color="#4a7c10" />
-    <span><strong>13</strong> categories</span>
-  </div>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="fingerprint" iconType="solid" size={14} color="#4a7c10" />
-    <span>Always paired with a correlation ID</span>
-  </div>
+))}
 </div>
 
 ## Error response format
@@ -64,7 +79,12 @@ All API errors return a JSON body with the following structure:
 
 These standard codes apply across all PolyAI APIs. Client errors (4xx) mean fix the request; server errors (5xx) mean retry or contact support.
 
-<div>
+<div style={{
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+  gap: '0.75rem',
+  margin: '1rem 0 1.5rem',
+}}>
 {[
   { status: 400, meaning: 'Bad request', when: 'The request body or query parameters failed validation.' },
   { status: 401, meaning: 'Unauthorized', when: 'Missing, expired, or invalid API key or token.' },
@@ -82,30 +102,26 @@ These standard codes apply across all PolyAI APIs. Client errors (4xx) mean fix 
   { status: 501, meaning: 'Not implemented', when: 'The requested functionality is not yet available.' },
   { status: 502, meaning: 'Bad gateway', when: 'An upstream service returned an error or timed out.' },
   { status: 503, meaning: 'Service unavailable', when: 'The service is temporarily unavailable.' },
-].map((s) => (
-  <div key={s.status} style={{
-    display: 'flex',
-    flexWrap: 'wrap',
-    alignItems: 'baseline',
-    gap: '0.4rem 0.75rem',
-    padding: '0.55rem 0',
-    borderBottom: '1px solid rgba(0,0,0,0.07)',
-  }}>
-    <span style={{
-      display: 'inline-block',
-      minWidth: '3.4rem',
-      textAlign: 'center',
-      padding: '0.15rem 0.55rem',
-      borderRadius: '999px',
-      background: s.status < 500 ? 'rgba(180, 90, 30, 0.1)' : 'rgba(190, 40, 40, 0.1)',
-      color: s.status < 500 ? '#8a4517' : '#a02020',
-      fontWeight: 700,
-      fontSize: '0.82rem',
-    }}>{s.status}</span>
-    <strong style={{ fontSize: '0.92rem' }}>{s.meaning}</strong>
-    <span style={{ color: '#6b7280', fontSize: '0.88rem' }}>{s.when}</span>
-  </div>
-))}
+].map((s) => {
+  const isServerError = s.status >= 500
+  const fg = isServerError ? '#a02020' : '#8a4517'
+  const border = isServerError ? 'rgba(190, 40, 40, 0.22)' : 'rgba(180, 90, 30, 0.22)'
+  const bg = isServerError ? 'rgba(190, 40, 40, 0.045)' : 'rgba(180, 90, 30, 0.045)'
+  return (
+    <div key={s.status} style={{
+      padding: '0.9rem 1.1rem',
+      borderRadius: '14px',
+      border: `1px solid ${border}`,
+      background: bg,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.65rem', marginBottom: '0.3rem' }}>
+        <span style={{ fontWeight: 800, fontSize: '1.15rem', color: fg, fontVariantNumeric: 'tabular-nums' }}>{s.status}</span>
+        <strong style={{ fontSize: '0.92rem', color: '#1f2937' }}>{s.meaning}</strong>
+      </div>
+      <div style={{ fontSize: '0.85rem', color: '#6b7280', lineHeight: 1.45 }}>{s.when}</div>
+    </div>
+  )
+})}
 </div>
 
 ## Platform error codes

--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -11,6 +11,31 @@ keywords:
 
 When a request fails, PolyAI APIs return a structured JSON error response. This page documents the HTTP status codes, error response format, and platform-specific error codes you may encounter.
 
+<div style={{
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  gap: '2rem',
+  margin: '1.5rem 0 2rem',
+  padding: '1rem 1.75rem',
+  borderRadius: '14px',
+  background: 'rgba(74, 124, 16, 0.05)',
+  border: '1px solid rgba(74, 124, 16, 0.15)',
+}}>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="hashtag" iconType="solid" size={14} color="#4a7c10" />
+    <span><strong>63</strong> platform error codes</span>
+  </div>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="folder-tree" iconType="solid" size={14} color="#4a7c10" />
+    <span><strong>13</strong> categories</span>
+  </div>
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
+    <Icon icon="fingerprint" iconType="solid" size={14} color="#4a7c10" />
+    <span>Always paired with a correlation ID</span>
+  </div>
+</div>
+
 ## Error response format
 
 All API errors return a JSON body with the following structure:
@@ -37,26 +62,51 @@ All API errors return a JSON body with the following structure:
 
 ## Standard HTTP status codes
 
-These standard codes apply across all PolyAI APIs.
+These standard codes apply across all PolyAI APIs. Client errors (4xx) mean fix the request; server errors (5xx) mean retry or contact support.
 
-| Status | Meaning | When it occurs |
-|--------|---------|----------------|
-| 400 | Bad request | The request body or query parameters failed validation. |
-| 401 | Unauthorized | Missing, expired, or invalid API key or token. |
-| 403 | Forbidden | You do not have permission for the requested action. |
-| 404 | Not found | The requested resource does not exist. |
-| 405 | Method not allowed | The HTTP method is not supported for this endpoint. |
-| 408 | Request timeout | The request exceeded the server timeout. |
-| 409 | Conflict | A resource with the same identifier already exists. |
-| 410 | Gone | The resource has been permanently deleted. |
-| 412 | Precondition failed | A required precondition was not met (for example, deploying to live before pre-release). |
-| 415 | Unsupported media type | The uploaded file type is not supported. |
-| 422 | Unprocessable entity | The request is well-formed but contains semantic errors. |
-| 429 | Too many requests | Rate limit exceeded. Retry after the period indicated in the response headers. |
-| 500 | Internal server error | An unexpected error occurred on the server. |
-| 501 | Not implemented | The requested functionality is not yet available. |
-| 502 | Bad gateway | An upstream service returned an error or timed out. |
-| 503 | Service unavailable | The service is temporarily unavailable. |
+<div>
+{[
+  { status: 400, meaning: 'Bad request', when: 'The request body or query parameters failed validation.' },
+  { status: 401, meaning: 'Unauthorized', when: 'Missing, expired, or invalid API key or token.' },
+  { status: 403, meaning: 'Forbidden', when: 'You do not have permission for the requested action.' },
+  { status: 404, meaning: 'Not found', when: 'The requested resource does not exist.' },
+  { status: 405, meaning: 'Method not allowed', when: 'The HTTP method is not supported for this endpoint.' },
+  { status: 408, meaning: 'Request timeout', when: 'The request exceeded the server timeout.' },
+  { status: 409, meaning: 'Conflict', when: 'A resource with the same identifier already exists.' },
+  { status: 410, meaning: 'Gone', when: 'The resource has been permanently deleted.' },
+  { status: 412, meaning: 'Precondition failed', when: 'A required precondition was not met (for example, deploying to live before pre-release).' },
+  { status: 415, meaning: 'Unsupported media type', when: 'The uploaded file type is not supported.' },
+  { status: 422, meaning: 'Unprocessable entity', when: 'The request is well-formed but contains semantic errors.' },
+  { status: 429, meaning: 'Too many requests', when: 'Rate limit exceeded. Retry after the period indicated in the response headers.' },
+  { status: 500, meaning: 'Internal server error', when: 'An unexpected error occurred on the server.' },
+  { status: 501, meaning: 'Not implemented', when: 'The requested functionality is not yet available.' },
+  { status: 502, meaning: 'Bad gateway', when: 'An upstream service returned an error or timed out.' },
+  { status: 503, meaning: 'Service unavailable', when: 'The service is temporarily unavailable.' },
+].map((s) => (
+  <div key={s.status} style={{
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    gap: '0.4rem 0.75rem',
+    padding: '0.55rem 0',
+    borderBottom: '1px solid rgba(0,0,0,0.07)',
+  }}>
+    <span style={{
+      display: 'inline-block',
+      minWidth: '3.4rem',
+      textAlign: 'center',
+      padding: '0.15rem 0.55rem',
+      borderRadius: '999px',
+      background: s.status < 500 ? 'rgba(180, 90, 30, 0.1)' : 'rgba(190, 40, 40, 0.1)',
+      color: s.status < 500 ? '#8a4517' : '#a02020',
+      fontWeight: 700,
+      fontSize: '0.82rem',
+    }}>{s.status}</span>
+    <strong style={{ fontSize: '0.92rem' }}>{s.meaning}</strong>
+    <span style={{ color: '#6b7280', fontSize: '0.88rem' }}>{s.when}</span>
+  </div>
+))}
+</div>
 
 ## Platform error codes
 

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -17,32 +17,43 @@ This guide builds an agent from scratch using only the API — no Agent Studio r
 For an overview of the API families, see the [API overview](/api-reference/introduction). This page uses the [Agents](/api-reference/agents/introduction) API to build and ship, and the [Data](/api-reference/data/introduction) API to test — the same API key and host work for both.
 
 <div style={{
-  display: 'flex',
-  flexWrap: 'wrap',
-  justifyContent: 'center',
-  gap: '2rem',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+  gap: '1rem',
   margin: '1.5rem 0 2rem',
-  padding: '1rem 1.75rem',
-  borderRadius: '14px',
-  background: 'rgba(74, 124, 16, 0.05)',
-  border: '1px solid rgba(74, 124, 16, 0.15)',
 }}>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="key" iconType="solid" size={14} color="#4a7c10" />
-    <span><strong>1</strong> API key</span>
+{[
+  { icon: 'key', value: '1', label: 'API key needed', color: '#4a7c10', bg: 'linear-gradient(160deg, rgba(74, 124, 16, 0.07), rgba(74, 124, 16, 0.01))', border: 'rgba(74, 124, 16, 0.18)' },
+  { icon: 'list-ol', value: '4', label: 'Steps to production', color: '#386dbf', bg: 'linear-gradient(160deg, rgba(56, 109, 191, 0.07), rgba(56, 109, 191, 0.01))', border: 'rgba(56, 109, 191, 0.2)' },
+  { icon: 'globe', value: '4', label: 'Regions available', color: '#b45a1e', bg: 'linear-gradient(160deg, rgba(180, 90, 30, 0.08), rgba(180, 90, 30, 0.01))', border: 'rgba(180, 90, 30, 0.2)' },
+].map((s) => (
+  <div key={s.label} style={{
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.9rem',
+    padding: '1rem 1.2rem',
+    borderRadius: '16px',
+    border: `1px solid ${s.border}`,
+    background: s.bg,
+  }}>
+    <div style={{
+      width: '44px',
+      height: '44px',
+      borderRadius: '12px',
+      background: s.color,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+    }}>
+      <Icon icon={s.icon} iconType="solid" size={18} color="#fff" />
+    </div>
+    <div>
+      <div style={{ fontSize: '1.4rem', fontWeight: 700, color: '#1f2937', lineHeight: 1.15 }}>{s.value}</div>
+      <div style={{ fontSize: '0.82rem', color: '#6b7280' }}>{s.label}</div>
+    </div>
   </div>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="list-ol" iconType="solid" size={14} color="#4a7c10" />
-    <span><strong>4</strong> steps</span>
-  </div>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="globe" iconType="solid" size={14} color="#4a7c10" />
-    <span><strong>4</strong> regions</span>
-  </div>
-  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', color: '#374151' }}>
-    <Icon icon="route" iconType="solid" size={14} color="#4a7c10" />
-    <span>Draft → Sandbox → Pre-release → Live</span>
-  </div>
+))}
 </div>
 
 ## What you'll build


### PR DESCRIPTION
## What people actually want from this page
Someone landing here almost always has one specific error in hand and wants to find it fast -- not admire stat counters. Redesigned around that:

- **Jump-to-category nav** replaces the vanity stat-card grid (63 codes / 13 categories / ...). Mintlify Accordions support deep-linkable anchors (title auto-slugs to an `id`, or takes an explicit `id` prop -- confirmed via Mintlify's own docs), so each pill link jumps straight into its Accordion section. Plain `<a href="#...">`, zero JS.
- **Explicit `id`s added to every Accordion** so those anchors are stable rather than relying on title auto-slugging.
- **"Common patterns" troubleshooting table -> card grid.** This is arguably the most actionable content on the page for someone actively debugging, so it now gets the same card treatment as the HTTP status codes: symptom / cause / resolution scannable at a glance instead of squeezed into a table.
- **Correlation-ID guidance wrapped in a `<Tip>`** instead of a bare paragraph.
- **HTTP status card grid** (color-coded 4xx/5xx) from the previous commit is unchanged.

## Waterfalled to the quickstart page
Its pill-row stat strip is now the same colored icon-card grid used here (same colors, same structure) for visual consistency across the API reference tab. Dropped the "Draft -> Sandbox -> Pre-release -> Live" pill since the mermaid diagram directly below it already shows that lifecycle -- redundant info cut in the name of simplicity.

## Why this won't repeat the outage
Same pattern as every other commit in this PR: inline-styled JSX over a literal array, rendered with `.map()`. No `export`, `import`, hooks, state, or event handlers anywhere. Verified via the same `@mdx-js/mdx` `evaluate()` + `react-dom/server` reproduction used throughout -- both files render clean.

## Test plan
- [ ] Merge and confirm both pages render (please verify directly given this page's history)
- [ ] Click a couple of jump-nav pills and confirm they expand/scroll to the right Accordion
- [ ] Eyeball the quickstart page for visual consistency with error codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)