### PR TITLE
fix: broken #base-urls anchor and missing heading ids on API overview

### DIFF
--- a/api-reference/alerts/introduction.mdx
+++ b/api-reference/alerts/introduction.mdx
@@ -67,7 +67,7 @@ curl -X POST https://api.us.poly.ai/v1/alert-rules \
   }'
 ```
 
-Replace `api.us.poly.ai` with the base URL for your deployment region. See [Getting started](/api-reference/introduction#regional-api-endpoints) for the full list of regional base URLs.
+Replace `api.us.poly.ai` with the base URL for your deployment region. See [Getting started](/api-reference/introduction#pick-your-region) for the full list of regional base URLs.
 
 ### 2. Check active alerts
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -277,7 +277,7 @@ keywords:
 
 {/* ─────────────────────────  COMMON TASKS  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2rem', marginBottom: '0.25rem' }}>I want to...</h2>
+<h2 id="i-want-to" style={{ marginTop: '2rem', marginBottom: '0.25rem' }}>I want to...</h2>
 <p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1.5rem' }}>
   Task-oriented entry points. Jump straight to a working example.
 </p>
@@ -305,7 +305,7 @@ keywords:
 
 {/* ─────────────────────────  REGIONS / BASE URLS  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2.5rem' }}>Pick your region</h2>
+<h2 id="pick-your-region" style={{ marginTop: '2.5rem' }}>Pick your region</h2>
 <p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1.25rem' }}>
   Your key is provisioned to a region. The host differs by API family — the platform.polyai.app host carries a <code>-1</code> suffix, the poly.ai host doesn't.
 </p>
@@ -380,7 +380,7 @@ Both the slug form (visible in the URL) and the prefixed form are accepted in AP
 
 {/* ─────────────────────────  AUTH  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2.5rem' }}>Authenticate</h2>
+<h2 id="authenticate" style={{ marginTop: '2.5rem' }}>Authenticate</h2>
 <p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
   Every PolyAI API uses an API key sent in the <code>x-api-key</code> header. Keys are provisioned by PolyAI — runtime and build keys are separate.
 </p>
@@ -426,7 +426,7 @@ const data = await response.json();
 
 {/* ─────────────────────────  AGENTS VS CONVERSATIONS  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2.5rem' }}>Agents API vs. Conversations API</h2>
+<h2 id="agents-api-vs-conversations-api" style={{ marginTop: '2.5rem' }}>Agents API vs. Conversations API</h2>
 <p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
   These two get confused most often. Use this table to pick the right one.
 </p>
@@ -443,7 +443,7 @@ In short: **Agents API creates and ships agents. Conversations API tells you wha
 
 {/* ─────────────────────────  VERSIONING  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2.5rem' }}>Versioning</h2>
+<h2 id="versioning" style={{ marginTop: '2.5rem' }}>Versioning</h2>
 
 Only the Conversations API is versioned today. Everything else is unversioned.
 
@@ -495,7 +495,7 @@ Only the Conversations API is versioned today. Everything else is unversioned.
 
 {/* ─────────────────────────  BROWSE  ───────────────────────── */}
 
-<h2 style={{ marginTop: '2.5rem' }}>Browse the catalog</h2>
+<h2 id="browse-the-catalog" style={{ marginTop: '2.5rem' }}>Browse the catalog</h2>
 <p style={{ color: 'var(--tw-prose-body, #4b5563)', margin: '0 0 1rem' }}>
   Every endpoint, grouped by API.
 </p>

--- a/api-reference/quickstart.mdx
+++ b/api-reference/quickstart.mdx
@@ -125,7 +125,7 @@ stateDiagram-v2
     | Studio | `https://api.studio.poly.ai`  |
 
     <Warning>
-    The Conversations v3 API (used in step 5) is on a *different* host — `api.{region}-1.platform.polyai.app`, with a `-1` suffix. Mixing these up is the most common cause of `404`s. See [base URLs](/api-reference/introduction#base-urls) for the full table across every API family.
+    The Conversations v3 API (used in step 5) is on a *different* host — `api.{region}-1.platform.polyai.app`, with a `-1` suffix. Mixing these up is the most common cause of `404`s. See [base URLs](/api-reference/introduction#pick-your-region) for the full table across every API family.
     </Warning>
   </Step>
 


### PR DESCRIPTION
## What
- `quickstart.mdx` linked to `/api-reference/introduction#base-urls` -- never existed. "REGIONS / BASE URLS" there is an HTML comment, not a heading (verified by grepping for it -- no heading text matches).
- `alerts/introduction.mdx` had the same broken link under a different fake anchor, `#regional-api-endpoints`.
- Root cause: `introduction.mdx`'s headings are hand-written JSX `<h2>` tags, not markdown `##` syntax, so they don't auto-slug the way real markdown headings do. Confirmed empirically: of 7 `<h2>` tags on that page, only `#api-families` had an explicit `id` -- because it's the only one anything links to (the hero's "Browse APIs" button). Nothing else on the page has ever been anchor-linkable.

## Fix
- Added explicit `id`s to all the remaining headings (`pick-your-region`, `i-want-to`, `authenticate`, `agents-api-vs-conversations-api`, `versioning`, `browse-the-catalog`) so this can't silently recur.
- Pointed both broken links at `#pick-your-region`, the section that actually has the base-URL table.

Verified via the `@mdx-js/mdx` `evaluate()` + `react-dom/server` reproduction used throughout this repo's recent history -- all three touched files render clean, and the literal `id="pick-your-region"` attribute shows up in the rendered output.

## Test plan
- [ ] Click the "base URLs" link from quickstart and confirm it jumps to Pick your region
- [ ] Click the "Getting started" link from the Alerts API intro and confirm the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)