### PR TITLE
docs: fill in real error response examples across platform OpenAPI specs

### DIFF
--- a/api-reference/agents/openapi.json
+++ b/api-reference/agents/openapi.json
@@ -192,7 +192,7 @@
         ]
       },
       "BatchUpdateConnectorsBody": {
-        "description": "Ordered list of connector updates.\n\nEach update is applied independently \u2014 partial success is possible.",
+        "description": "Ordered list of connector updates.\n\nEach update is applied independently — partial success is possible.",
         "type": "object",
         "properties": {
           "updates": {
@@ -771,7 +771,7 @@
         ]
       },
       "DeletePhoneNumbersResponse": {
-        "description": "Per-number results of a batch release \u2014 phone numbers that were\nsuccessfully released, plus any that couldn't be and why.",
+        "description": "Per-number results of a batch release — phone numbers that were\nsuccessfully released, plus any that couldn't be and why.",
         "type": "object",
         "properties": {
           "deleted": {
@@ -1619,7 +1619,7 @@
         "title": "UpdateVariantBody"
       },
       "UpdateVoiceRequest": {
-        "description": "Request schema for updating a voice.\n\nAll fields are optional \u2014 only provided fields are patched.",
+        "description": "Request schema for updating a voice.\n\nAll fields are optional — only provided fields are patched.",
         "type": "object",
         "properties": {
           "name": {
@@ -1767,7 +1767,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Audio cache entry ID. Although serialized as a string, the ID is numeric \u2014 endpoints that accept an `entryId` path parameter return `400 Invalid ID` if the value cannot be parsed as an integer."
+            "description": "Audio cache entry ID. Although serialized as a string, the ID is numeric — endpoints that accept an `entryId` path parameter return `400 Invalid ID` if the value cannot be parsed as an integer."
           },
           "transcript": {
             "type": "string",
@@ -1836,7 +1836,7 @@
       },
       "VoiceTuningConfig": {
         "type": "object",
-        "description": "Provider-specific voice tuning settings. All fields are optional \u2014 each TTS provider uses a different subset.",
+        "description": "Provider-specific voice tuning settings. All fields are optional — each TTS provider uses a different subset.",
         "properties": {
           "stability": {
             "type": "number",
@@ -2045,6 +2045,45 @@
             "example": ""
           }
         }
+      },
+      "Error": {
+        "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
+          }
+        }
       }
     }
   },
@@ -2167,13 +2206,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Account ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "ACCOUNT_NOT_FOUND",
+                  "error_message": "Account ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -2204,16 +2272,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Account ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "ACCOUNT_NOT_FOUND",
+                  "error_message": "Account ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -2246,13 +2350,34 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -2283,16 +2408,44 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -2333,13 +2486,34 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -2632,7 +2806,14 @@
             }
           },
           "404": {
-            "description": "Rules not found"
+            "description": "Rules not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         },
         "summary": "Get agent behavior rules",
@@ -2765,7 +2946,14 @@
             }
           },
           "404": {
-            "description": "Topic does not exist"
+            "description": "Topic does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         },
         "summary": "Get knowledge base topic",
@@ -2779,7 +2967,14 @@
             "description": "Topic deleted"
           },
           "404": {
-            "description": "Topic not found"
+            "description": "Topic not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         },
         "summary": "Delete knowledge base topic",
@@ -2793,7 +2988,14 @@
             "description": "Topic updated"
           },
           "404": {
-            "description": "Topic not found"
+            "description": "Topic not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         },
         "summary": "Update knowledge base topic",
@@ -3075,13 +3277,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3114,10 +3337,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3160,13 +3397,42 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Invalid or missing `environment` query parameter.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "DEPLOYMENTS_INVALID_ENVIRONMENT",
+                  "error_message": "Invalid or missing `environment` query parameter.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3195,7 +3461,22 @@
             }
           },
           "404": {
-            "description": "Deployment not found"
+            "description": "Deployment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Deployment ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "DEPLOYMENT_NOT_FOUND",
+                  "error_message": "Deployment ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         },
         "summary": "Promote a deployment to the next environment",
@@ -3245,7 +3526,22 @@
             }
           },
           "404": {
-            "description": "Deployment not found"
+            "description": "Deployment not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Deployment ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "DEPLOYMENT_NOT_FOUND",
+                  "error_message": "Deployment ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         },
         "summary": "Rollback to a previous deployment",
@@ -3338,10 +3634,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3374,13 +3684,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Not authorized to access real-time configs.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "REAL_TIME_CONFIG_FORBIDDEN_ACCESS",
+                  "error_message": "Not authorized to access real-time configs.",
+                  "data": null
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3431,16 +3770,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "JSON Schema definition is invalid.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "REAL_TIME_CONFIG_INVALID_SCHEMA",
+                  "error_message": "JSON Schema definition is invalid.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3491,16 +3866,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Config values fail JSON Schema validation.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "REAL_TIME_CONFIG_INVALID_FOR_SCHEMA",
+                  "error_message": "Config values fail JSON Schema validation.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3541,10 +3952,24 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3587,13 +4012,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3624,13 +4070,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3673,13 +4140,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3712,13 +4200,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Connector ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONNECTORS_NOT_FOUND",
+                  "error_message": "Connector ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -3739,13 +4256,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Connector ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONNECTORS_NOT_FOUND",
+                  "error_message": "Connector ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -3776,16 +4322,60 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Connector request body failed validation.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONNECTORS_VALIDATION_FAILED",
+                  "error_message": "Connector request body failed validation.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Connector ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONNECTORS_NOT_FOUND",
+                  "error_message": "Connector ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -3837,13 +4427,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3874,13 +4485,42 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Number is not in valid E.164 format.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "PHONE_NUMBERS_INVALID_PHONE_NUMBER_FORMAT",
+                  "error_message": "Number is not in valid E.164 format.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3911,13 +4551,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3960,13 +4621,42 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Number is not in valid E.164 format.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "PHONE_NUMBERS_INVALID_PHONE_NUMBER_FORMAT",
+                  "error_message": "Number is not in valid E.164 format.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -3999,13 +4689,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Phone number does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "PHONE_NUMBERS_NOT_FOUND",
+                  "error_message": "Phone number does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -4036,16 +4755,44 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4066,13 +4813,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Phone number does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "PHONE_NUMBERS_NOT_FOUND",
+                  "error_message": "Phone number does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -4103,16 +4879,44 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4188,13 +4992,34 @@
             }
           },
           "400": {
-            "description": "Invalid request \u2013 the `sort` or `filter` expression could not be parsed"
+            "description": "Invalid request – the `sort` or `filter` expression could not be parsed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `read` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `read` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4228,16 +5053,44 @@
             }
           },
           "400": {
-            "description": "Invalid request \u2013 `entryId` is not a numeric ID"
+            "description": "Invalid request – `entryId` is not a numeric ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `write` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `write` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4281,16 +5134,44 @@
             }
           },
           "400": {
-            "description": "Invalid request \u2013 `entryId` is not a numeric ID"
+            "description": "Invalid request – `entryId` is not a numeric ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `read` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `read` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4327,16 +5208,44 @@
             "description": "Audio file replaced"
           },
           "400": {
-            "description": "Invalid request. Returned when the request body is empty, the file exceeds the 6 MB limit, or `entryId` is not a numeric ID."
+            "description": "Invalid request. Returned when the request body is empty, the file exceeds the 6 MB limit, or `entryId` is not a numeric ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `write` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `write` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4397,16 +5306,44 @@
             "description": "Audio and settings updated"
           },
           "400": {
-            "description": "Invalid request. Returned when the `file` part is missing, the file exceeds the 6 MB limit, the `settings` part is not valid JSON, or the `entryId` is not a numeric ID."
+            "description": "Invalid request. Returned when the `file` part is missing, the file exceeds the 6 MB limit, the `settings` part is not valid JSON, or the `entryId` is not a numeric ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `write` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `write` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4460,16 +5397,44 @@
             }
           },
           "400": {
-            "description": "Invalid request. Returned when the request body fails validation against `SynthesizeAudioRequest`, or when `entryId` is not a numeric ID."
+            "description": "Invalid request. Returned when the request body fails validation against `SynthesizeAudioRequest`, or when `entryId` is not a numeric ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `read` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `read` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4496,7 +5461,7 @@
     "/v1/agents/{agentId}/audio-cache/bulk-delete": {
       "post": {
         "summary": "Bulk delete cached audio entries",
-        "description": "Delete multiple audio cache entries by ID in a single request. Operates best-effort \u2014 returns which IDs were successfully deleted and which failed, so partial failures can be retried. Maximum 20 IDs per request.",
+        "description": "Delete multiple audio cache entries by ID in a single request. Operates best-effort — returns which IDs were successfully deleted and which failed, so partial failures can be retried. Maximum 20 IDs per request.",
         "tags": [
           "Audio Cache"
         ],
@@ -4522,13 +5487,34 @@
             }
           },
           "400": {
-            "description": "Invalid request \u2013 `ids` must contain between 1 and 20 entries"
+            "description": "Invalid request – `ids` must contain between 1 and 20 entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2013 missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2013 the API key does not have `write` permission on the audio cache resource"
+            "description": "Forbidden – the API key does not have `write` permission on the audio cache resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4572,19 +5558,54 @@
             }
           },
           "400": {
-            "description": "Invalid request \u2014 malformed phone number, invalid environment, metadata too large, or outbound calling not configured for this environment."
+            "description": "Invalid request — malformed phone number, invalid environment, metadata too large, or outbound calling not configured for this environment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2014 missing or invalid API key."
+            "description": "Unauthorized — missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2014 insufficient permissions."
+            "description": "Forbidden — insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "No connector found for the specified environment."
+            "description": "No connector found for the specified environment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "502": {
-            "description": "Outbound calling service unavailable. Retry with exponential backoff."
+            "description": "Outbound calling service unavailable. Retry with exponential backoff.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -4634,16 +5655,44 @@
             }
           },
           "400": {
-            "description": "Invalid parameters \u2014 missing environment, invalid call SID, or no connector found."
+            "description": "Invalid parameters — missing environment, invalid call SID, or no connector found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized \u2014 missing or invalid API key."
+            "description": "Unauthorized — missing or invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden \u2014 insufficient permissions."
+            "description": "Forbidden — insufficient permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "502": {
-            "description": "Outbound calling service unavailable. Retry with exponential backoff."
+            "description": "Outbound calling service unavailable. Retry with exponential backoff.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },

--- a/api-reference/alerts/openapi.json
+++ b/api-reference/alerts/openapi.json
@@ -102,17 +102,31 @@
       "AlertOperator": {
         "type": "string",
         "description": "Comparison operator used by the alert rule.",
-        "enum": [">", "<", ">=", "<="]
+        "enum": [
+          ">",
+          "<",
+          ">=",
+          "<="
+        ]
       },
       "AlertState": {
         "type": "string",
         "description": "Current state of an alert rule.",
-        "enum": ["ok", "alert", "no_data", "unknown"]
+        "enum": [
+          "ok",
+          "alert",
+          "no_data",
+          "unknown"
+        ]
       },
       "WindowDuration": {
         "type": "string",
         "description": "Evaluation window duration. Allowed values: `5m`, `10m`, or `60m`.",
-        "enum": ["5m", "10m", "60m"]
+        "enum": [
+          "5m",
+          "10m",
+          "60m"
+        ]
       },
       "AlertRuleResponse": {
         "type": "object",
@@ -140,7 +154,10 @@
             "description": "Alert rule name"
           },
           "project_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Project ID"
           },
           "metric": {
@@ -169,17 +186,26 @@
             "description": "Current alert state"
           },
           "since": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When the current state started"
           },
           "last_evaluated_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "Last evaluation timestamp"
           },
           "current_value": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Current metric value"
           },
           "created_at": {
@@ -197,14 +223,23 @@
       "AlertRuleCreateRequest": {
         "type": "object",
         "description": "Fields for creating a new alert rule: which metric to watch, the threshold condition, and how long it must hold to fire.",
-        "required": ["name", "metric", "operator", "threshold_value", "window_duration"],
+        "required": [
+          "name",
+          "metric",
+          "operator",
+          "threshold_value",
+          "window_duration"
+        ],
         "properties": {
           "name": {
             "type": "string",
             "description": "Alert rule name"
           },
           "project_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Project ID (optional)"
           },
           "metric": {
@@ -250,7 +285,10 @@
             "description": "Alert rule name"
           },
           "project_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Project ID"
           },
           "metric": {
@@ -279,12 +317,16 @@
       "AlertRuleListResponse": {
         "type": "object",
         "description": "Every alert rule in scope, each with its current state.",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "array",
             "description": "An alert rule: its trigger condition, evaluation window, and current state.",
-            "items": { "$ref": "#/components/schemas/AlertRuleResponse" }
+            "items": {
+              "$ref": "#/components/schemas/AlertRuleResponse"
+            }
           }
         }
       },
@@ -312,7 +354,10 @@
             "description": "Alert rule name"
           },
           "project_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Project ID"
           },
           "metric": {
@@ -334,12 +379,18 @@
             "description": "When the alert started firing"
           },
           "last_evaluated_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "Last evaluation timestamp"
           },
           "current_value": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Current metric value"
           }
         }
@@ -347,29 +398,45 @@
       "ActiveAlertsListResponse": {
         "type": "object",
         "description": "Every alert rule currently in the firing state.",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ActiveAlertResponse" }
+            "items": {
+              "$ref": "#/components/schemas/ActiveAlertResponse"
+            }
           }
         }
       },
       "ValidationError": {
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "properties": {
           "loc": {
             "type": "array",
             "items": {
               "anyOf": [
-                { "type": "string" },
-                { "type": "integer" }
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
               ]
             }
           },
-          "msg": { "type": "string" },
-          "type": { "type": "string" }
+          "msg": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
         }
       },
       "HTTPValidationError": {
@@ -377,14 +444,49 @@
         "properties": {
           "detail": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/ValidationError" }
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
           }
         }
       },
       "Error": {
         "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
         "properties": {
-          "message": { "type": "string" }
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
+          }
         }
       }
     },
@@ -393,7 +495,9 @@
         "description": "Validation error.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -401,7 +505,9 @@
         "description": "Missing or invalid API key.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -409,7 +515,9 @@
         "description": "Resource not found.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -417,7 +525,9 @@
         "description": "Resource limit exceeded (e.g. maximum number of alert rules reached).",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -425,7 +535,9 @@
         "description": "Validation error or malformed resource ID.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+            "schema": {
+              "$ref": "#/components/schemas/HTTPValidationError"
+            }
           }
         }
       },
@@ -433,7 +545,9 @@
         "description": "Internal server error.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -441,7 +555,9 @@
         "description": "Monitoring backend sync failure.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       }
@@ -454,23 +570,60 @@
         "operationId": "listAlertRules",
         "description": "List alert rules with optional filters.",
         "parameters": [
-          { "$ref": "#/components/parameters/EnabledFilter" },
-          { "$ref": "#/components/parameters/MetricFilter" },
-          { "$ref": "#/components/parameters/ProjectIdFilter" },
-          { "$ref": "#/components/parameters/StateFilter" }
+          {
+            "$ref": "#/components/parameters/EnabledFilter"
+          },
+          {
+            "$ref": "#/components/parameters/MetricFilter"
+          },
+          {
+            "$ref": "#/components/parameters/ProjectIdFilter"
+          },
+          {
+            "$ref": "#/components/parameters/StateFilter"
+          }
         ],
         "responses": {
           "200": {
             "description": "Alert rules retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AlertRuleListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleListResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
@@ -481,7 +634,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AlertRuleCreateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleCreateRequest"
+              }
             }
           }
         },
@@ -490,16 +645,72 @@
             "description": "Alert rule created successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AlertRuleResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "409": { "$ref": "#/components/responses/Conflict" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" },
-          "502": { "$ref": "#/components/responses/BadGateway" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "502": {
+            "$ref": "#/components/responses/BadGateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -508,32 +719,80 @@
         "summary": "Get an alert rule",
         "operationId": "getAlertRule",
         "description": "Get a single alert rule by its ID.",
-        "parameters": [{ "$ref": "#/components/parameters/RuleId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RuleId"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Alert rule retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AlertRuleResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleResponse"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "patch": {
         "summary": "Update an alert rule",
         "operationId": "updateAlertRule",
         "description": "Update an alert rule. Only the fields included in the request body are changed.",
-        "parameters": [{ "$ref": "#/components/parameters/RuleId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RuleId"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AlertRuleUpdateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleUpdateRequest"
+              }
             }
           }
         },
@@ -542,31 +801,127 @@
             "description": "Alert rule updated successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AlertRuleResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" },
-          "502": { "$ref": "#/components/responses/BadGateway" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "502": {
+            "$ref": "#/components/responses/BadGateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Delete an alert rule",
         "operationId": "deleteAlertRule",
         "description": "Delete an alert rule by its ID.",
-        "parameters": [{ "$ref": "#/components/parameters/RuleId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RuleId"
+          }
+        ],
         "responses": {
           "204": {
             "description": "Alert rule deleted successfully."
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -576,20 +931,44 @@
         "operationId": "getActiveAlerts",
         "description": "List alert rules that are currently in the `alert` state.",
         "parameters": [
-          { "$ref": "#/components/parameters/ProjectIdFilter" },
-          { "$ref": "#/components/parameters/MetricFilter" }
+          {
+            "$ref": "#/components/parameters/ProjectIdFilter"
+          },
+          {
+            "$ref": "#/components/parameters/MetricFilter"
+          }
         ],
         "responses": {
           "200": {
             "description": "Active alerts retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ActiveAlertsListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveAlertsListResponse"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/api-reference/chat/openapi.json
+++ b/api-reference/chat/openapi.json
@@ -40,23 +40,57 @@
         "in": "header",
         "description": "Your PolyAI API key.",
         "required": true,
-        "schema": { "type": "string" }
+        "schema": {
+          "type": "string"
+        }
       },
       "TokenHeader": {
         "name": "X-TOKEN",
         "in": "header",
         "description": "Agent authentication token (connector).",
         "required": true,
-        "schema": { "type": "string" }
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "schemas": {
       "Error": {
         "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
         "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
           "error_message": {
             "type": "string",
-            "description": "Reason for error"
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
           }
         }
       },
@@ -80,7 +114,12 @@
             "type": "string",
             "description": "Channel identifier for the conversation.",
             "example": "webchat",
-            "enum": ["webchat", "whatsapp", "sms", "api"]
+            "enum": [
+              "webchat",
+              "whatsapp",
+              "sms",
+              "api"
+            ]
           },
           "asr_lang_code": {
             "type": "string",
@@ -113,7 +152,10 @@
             "example": "Hi, how can I help?"
           }
         },
-        "required": ["conversation_id", "response"]
+        "required": [
+          "conversation_id",
+          "response"
+        ]
       },
       "RespondChatRequest": {
         "type": "object",
@@ -129,7 +171,9 @@
             "example": "Hello again"
           }
         },
-        "required": ["conversation_id"]
+        "required": [
+          "conversation_id"
+        ]
       },
       "RespondChatResponse": {
         "type": "object",
@@ -166,7 +210,11 @@
             }
           }
         },
-        "required": ["conversation_id", "response", "end_conversation"]
+        "required": [
+          "conversation_id",
+          "response",
+          "end_conversation"
+        ]
       },
       "CloseChatRequest": {
         "type": "object",
@@ -177,7 +225,9 @@
             "example": "CONV-1234567890"
           }
         },
-        "required": ["conversation_id"]
+        "required": [
+          "conversation_id"
+        ]
       },
       "CloseChatResponse": {
         "type": "object",
@@ -188,7 +238,9 @@
             "example": true
           }
         },
-        "required": ["success"]
+        "required": [
+          "success"
+        ]
       }
     },
     "responses": {
@@ -196,7 +248,9 @@
         "description": "Bad Request",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -204,7 +258,9 @@
         "description": "Unauthorized",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -212,7 +268,9 @@
         "description": "Not Found",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -220,7 +278,9 @@
         "description": "Internal Server Error",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       }
@@ -233,14 +293,20 @@
         "summary": "Create a new chat conversation",
         "description": "Creates a new chat conversation and returns the conversation ID along with the agent's initial response.",
         "parameters": [
-          { "$ref": "#/components/parameters/ApiKeyHeader" },
-          { "$ref": "#/components/parameters/TokenHeader" },
+          {
+            "$ref": "#/components/parameters/ApiKeyHeader"
+          },
+          {
+            "$ref": "#/components/parameters/TokenHeader"
+          },
           {
             "name": "version",
             "in": "path",
             "description": "API version",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "v1"
           },
           {
@@ -248,7 +314,9 @@
             "in": "path",
             "description": "Account ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "ACCOUNT-xxxxxxxx"
           },
           {
@@ -256,7 +324,9 @@
             "in": "path",
             "description": "Project ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "PROJECT-xxxxxxxx"
           }
         ],
@@ -264,28 +334,89 @@
           "required": false,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateChatRequest"
+              }
             }
           }
         },
         "security": [
-          { "ApiKeyAuth": [] },
-          { "TokenAuth": [] }
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "TokenAuth": []
+          }
         ],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreateChatResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CreateChatResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "The draft you are attempting to chat with does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_DRAFT_NOT_EXIST",
+                  "error_message": "The draft you are attempting to chat with does not exist.",
+                  "data": null
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -295,14 +426,20 @@
         "summary": "Send a message to an existing chat conversation",
         "description": "Sends a user message to an existing conversation and returns the agent's response.",
         "parameters": [
-          { "$ref": "#/components/parameters/ApiKeyHeader" },
-          { "$ref": "#/components/parameters/TokenHeader" },
+          {
+            "$ref": "#/components/parameters/ApiKeyHeader"
+          },
+          {
+            "$ref": "#/components/parameters/TokenHeader"
+          },
           {
             "name": "version",
             "in": "path",
             "description": "API version",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "v1"
           },
           {
@@ -310,7 +447,9 @@
             "in": "path",
             "description": "Account ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "ACCOUNT-xxxxxxxx"
           },
           {
@@ -318,19 +457,27 @@
             "in": "path",
             "description": "Project ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "PROJECT-xxxxxxxx"
           }
         ],
         "security": [
-          { "ApiKeyAuth": [] },
-          { "TokenAuth": [] }
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "TokenAuth": []
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RespondChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/RespondChatRequest"
+              }
             }
           }
         },
@@ -339,15 +486,70 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RespondChatResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RespondChatResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Chat session exceeded the timeout limit.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_TIMEOUT",
+                  "error_message": "Chat session exceeded the timeout limit.",
+                  "data": null
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -357,14 +559,20 @@
         "summary": "Close an existing chat conversation",
         "description": "Closes an active chat conversation and marks it as complete.",
         "parameters": [
-          { "$ref": "#/components/parameters/ApiKeyHeader" },
-          { "$ref": "#/components/parameters/TokenHeader" },
+          {
+            "$ref": "#/components/parameters/ApiKeyHeader"
+          },
+          {
+            "$ref": "#/components/parameters/TokenHeader"
+          },
           {
             "name": "version",
             "in": "path",
             "description": "API version",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "v1"
           },
           {
@@ -372,7 +580,9 @@
             "in": "path",
             "description": "Account ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "ACCOUNT-xxxxxxxx"
           },
           {
@@ -380,19 +590,27 @@
             "in": "path",
             "description": "Project ID",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "example": "PROJECT-xxxxxxxx"
           }
         ],
         "security": [
-          { "ApiKeyAuth": [] },
-          { "TokenAuth": [] }
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "TokenAuth": []
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CloseChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CloseChatRequest"
+              }
             }
           }
         },
@@ -401,21 +619,72 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CloseChatResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CloseChatResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "403": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "500": { "$ref": "#/components/responses/InternalError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     }
   },
   "security": [
-    { "ApiKeyAuth": [] },
-    { "TokenAuth": [] }
+    {
+      "ApiKeyAuth": []
+    },
+    {
+      "TokenAuth": []
+    }
   ]
 }

--- a/api-reference/conversations/v1/openapi.json
+++ b/api-reference/conversations/v1/openapi.json
@@ -137,7 +137,7 @@
               "type": "boolean"
             },
             "example": false
-          },
+          }
         ],
         "responses": {
           "200": {

--- a/api-reference/conversations/v3/openapi.json
+++ b/api-reference/conversations/v3/openapi.json
@@ -40,7 +40,9 @@
   "paths": {
     "/v3/{account_id}/{project_id}/conversations": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "List conversations for a project",
         "description": "Retrieves conversations for a given account and project. Supports three retrieval modes: transcript search, semantic search, and random sampling. When no retrieval mode is specified, the endpoint returns all conversations matching the given filters (default behavior). Only one retrieval mode may be specified per request.",
         "parameters": [
@@ -173,7 +175,7 @@
           {
             "name": "offset",
             "in": "query",
-            "description": "Offset within result set to fetch. Prefer `cursor` for paginating through large result sets \u2014 offset-based pagination becomes progressively slower at scale and may drift when conversations are written concurrently.",
+            "description": "Offset within result set to fetch. Prefer `cursor` for paginating through large result sets — offset-based pagination becomes progressively slower at scale and may drift when conversations are written concurrently.",
             "required": false,
             "schema": {
               "type": "integer",
@@ -241,33 +243,98 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Filter expression syntax is invalid.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "GET_CONVERSATIONS_FILTER_PARSE_ERROR",
+                  "error_message": "Filter expression syntax is invalid.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "$ref": "#/components/responses/NotFound"
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Project ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "PROJECT_NOT_FOUND",
+                  "error_message": "Project ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     },
     "/v1/agents/{agentId}/conversations/{conversationId}": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Get a conversation by ID",
         "description": "Retrieves a single conversation, including turn-by-turn transcript, metrics, and function events.\n\n**Host:** this endpoint is served from `api.{region}.poly.ai` — *not* the `api.{region}-1.platform.polyai.app` host used by the list-conversations and audio endpoints.",
         "servers": [
-          { "url": "https://api.us.poly.ai", "description": "US base url" },
-          { "url": "https://api.eu.poly.ai", "description": "EU base url" },
-          { "url": "https://api.uk.poly.ai", "description": "UK base url" },
-          { "url": "https://api.studio.poly.ai", "description": "Studio base url" }
+          {
+            "url": "https://api.us.poly.ai",
+            "description": "US base url"
+          },
+          {
+            "url": "https://api.eu.poly.ai",
+            "description": "EU base url"
+          },
+          {
+            "url": "https://api.uk.poly.ai",
+            "description": "UK base url"
+          },
+          {
+            "url": "https://api.studio.poly.ai",
+            "description": "Studio base url"
+          }
         ],
         "parameters": [
           {
@@ -302,33 +369,90 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "$ref": "#/components/responses/NotFound"
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     },
     "/v1/agents/{agentId}/conversations/{conversationId}/audio": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Get audio recording for a conversation",
         "description": "Returns the audio recording for a conversation as a WAV file.\n\n**Host:** this endpoint is served from `api.{region}.poly.ai` — *not* the `api.{region}-1.platform.polyai.app` host used by the list-conversations endpoint.\n\n**PII access enforcement.** Users without PII access always receive the redacted recording, regardless of the `redacted` query parameter. Users with PII access receive the raw recording by default and can opt into the redacted version by passing `redacted=true`. PII access is granted through your account's role and permission configuration in Agent Studio.",
         "servers": [
-          { "url": "https://api.us.poly.ai", "description": "US base url" },
-          { "url": "https://api.eu.poly.ai", "description": "EU base url" },
-          { "url": "https://api.uk.poly.ai", "description": "UK base url" },
-          { "url": "https://api.studio.poly.ai", "description": "Studio base url" }
+          {
+            "url": "https://api.us.poly.ai",
+            "description": "US base url"
+          },
+          {
+            "url": "https://api.eu.poly.ai",
+            "description": "EU base url"
+          },
+          {
+            "url": "https://api.uk.poly.ai",
+            "description": "UK base url"
+          },
+          {
+            "url": "https://api.studio.poly.ai",
+            "description": "Studio base url"
+          }
         ],
         "parameters": [
           {
@@ -389,13 +513,34 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
             "description": "Recording not found for the given conversation.",
@@ -408,21 +553,42 @@
             }
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     },
     "/v1/agents/{agentId}/debug-chat": {
       "post": {
-        "tags": ["Debug Chat"],
+        "tags": [
+          "Debug Chat"
+        ],
         "summary": "Create a new debug chat session",
         "description": "Starts a new debug chat session against an agent. Use this to interactively test an agent variant outside of production traffic.\n\n**Host:** this endpoint is served from `api.{region}.poly.ai` — *not* the `api.{region}-1.platform.polyai.app` host used by the list-conversations and audio endpoints.",
         "servers": [
-          { "url": "https://api.us.poly.ai", "description": "US base url" },
-          { "url": "https://api.eu.poly.ai", "description": "EU base url" },
-          { "url": "https://api.uk.poly.ai", "description": "UK base url" },
-          { "url": "https://api.studio.poly.ai", "description": "Studio base url" }
+          {
+            "url": "https://api.us.poly.ai",
+            "description": "US base url"
+          },
+          {
+            "url": "https://api.eu.poly.ai",
+            "description": "EU base url"
+          },
+          {
+            "url": "https://api.uk.poly.ai",
+            "description": "UK base url"
+          },
+          {
+            "url": "https://api.studio.poly.ai",
+            "description": "Studio base url"
+          }
         ],
         "parameters": [
           {
@@ -457,30 +623,80 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "The draft you are attempting to chat with does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_DRAFT_NOT_EXIST",
+                  "error_message": "The draft you are attempting to chat with does not exist.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     },
     "/v1/agents/{agentId}/debug-chat/{conversationId}": {
       "post": {
-        "tags": ["Debug Chat"],
+        "tags": [
+          "Debug Chat"
+        ],
         "summary": "Send a message to a debug chat session",
         "description": "Sends a user turn into an existing debug chat session and returns the agent's response.\n\n**Host:** this endpoint is served from `api.{region}.poly.ai` — *not* the `api.{region}-1.platform.polyai.app` host used by the list-conversations and audio endpoints.",
         "servers": [
-          { "url": "https://api.us.poly.ai", "description": "US base url" },
-          { "url": "https://api.eu.poly.ai", "description": "EU base url" },
-          { "url": "https://api.uk.poly.ai", "description": "UK base url" },
-          { "url": "https://api.studio.poly.ai", "description": "Studio base url" }
+          {
+            "url": "https://api.us.poly.ai",
+            "description": "US base url"
+          },
+          {
+            "url": "https://api.eu.poly.ai",
+            "description": "EU base url"
+          },
+          {
+            "url": "https://api.uk.poly.ai",
+            "description": "UK base url"
+          },
+          {
+            "url": "https://api.studio.poly.ai",
+            "description": "Studio base url"
+          }
         ],
         "parameters": [
           {
@@ -524,19 +740,70 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Chat session exceeded the timeout limit.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_TIMEOUT",
+                  "error_message": "Chat session exceeded the timeout limit.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "$ref": "#/components/responses/Unauthorized"
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "$ref": "#/components/responses/NotFound"
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           },
           "500": {
-            "$ref": "#/components/responses/InternalError"
+            "$ref": "#/components/responses/InternalError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -588,10 +855,40 @@
     "schemas": {
       "Error": {
         "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
         "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
           "error_message": {
-            "description": "Reason for error.",
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
           }
         }
       },
@@ -796,7 +1093,11 @@
       "ConversationDetailResponse": {
         "type": "object",
         "description": "Public-facing conversation detail (includes turns, metrics, and function events).",
-        "required": ["conversationId", "accountId", "projectId"],
+        "required": [
+          "conversationId",
+          "accountId",
+          "projectId"
+        ],
         "properties": {
           "conversationId": {
             "type": "string",
@@ -926,7 +1227,9 @@
       "GetConversationsResponse": {
         "type": "object",
         "description": "A page of conversations matching the query, plus pagination data.",
-        "required": ["conversations"],
+        "required": [
+          "conversations"
+        ],
         "properties": {
           "conversations": {
             "type": "array",
@@ -966,12 +1269,18 @@
       "CreateDebugChatBody": {
         "type": "object",
         "description": "Starting parameters for a debug chat session: which agent variant, which language codes, and which environment to run in.",
-        "required": ["clientEnv"],
+        "required": [
+          "clientEnv"
+        ],
         "properties": {
           "clientEnv": {
             "type": "string",
             "description": "Client environment (`sandbox`, `pre-release`, `live`).",
-            "enum": ["sandbox", "pre-release", "live"]
+            "enum": [
+              "sandbox",
+              "pre-release",
+              "live"
+            ]
           },
           "asrLangCode": {
             "type": "string",
@@ -1002,12 +1311,18 @@
       "RespondDebugChatBody": {
         "type": "object",
         "description": "A user turn sent into an existing debug chat session, with the runtime overrides that apply to this message.",
-        "required": ["clientEnv"],
+        "required": [
+          "clientEnv"
+        ],
         "properties": {
           "clientEnv": {
             "type": "string",
             "description": "Client environment (`sandbox`, `pre-release`, `live`).",
-            "enum": ["sandbox", "pre-release", "live"]
+            "enum": [
+              "sandbox",
+              "pre-release",
+              "live"
+            ]
           },
           "asrLangCode": {
             "type": "string",

--- a/api-reference/data/openapi.json
+++ b/api-reference/data/openapi.json
@@ -493,6 +493,45 @@
         "required": [
           "note"
         ]
+      },
+      "Error": {
+        "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
+          }
+        }
       }
     }
   },
@@ -539,13 +578,34 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -578,13 +638,42 @@
             }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -635,16 +724,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -713,16 +838,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Audio recording not found for this conversation.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_RECORDING_NOT_FOUND",
+                  "error_message": "Audio recording not found for this conversation.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -773,16 +934,52 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },
@@ -833,13 +1030,42 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "The draft you are attempting to chat with does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_DRAFT_NOT_EXIST",
+                  "error_message": "The draft you are attempting to chat with does not exist.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
@@ -882,16 +1108,60 @@
             }
           },
           "400": {
-            "description": "Validation error"
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Chat session exceeded the timeout limit.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CHAT_TIMEOUT",
+                  "error_message": "Chat session exceeded the timeout limit.",
+                  "data": null
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized – missing or invalid API key"
+            "description": "Unauthorized – missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden – insufficient permissions"
+            "description": "Forbidden – insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Conversation ID does not exist.",
+                  "error_id": "550e8400-e29b-41d4-a716-446655440000",
+                  "error_code": "CONVERSATIONS_NOT_FOUND",
+                  "error_message": "Conversation ID does not exist.",
+                  "data": null
+                }
+              }
+            }
           }
         }
       },

--- a/api-reference/webhooks/openapi.json
+++ b/api-reference/webhooks/openapi.json
@@ -64,7 +64,10 @@
     "schemas": {
       "WebhookEventType": {
         "type": "string",
-        "enum": ["alerts.triggered", "alerts.resolved"]
+        "enum": [
+          "alerts.triggered",
+          "alerts.resolved"
+        ]
       },
       "WebhookEndpoint": {
         "type": "object",
@@ -79,17 +82,35 @@
           "updated_at"
         ],
         "properties": {
-          "id": { "type": "string", "pattern": "^whe_[A-Za-z0-9]+$", "example": "whe_9ZtRcXw3nByK5pVqMaEfJs" },
-          "name": { "type": "string", "minLength": 1, "maxLength": 255 },
-          "url": { "type": "string", "format": "uri" },
-          "enabled": { "type": "boolean", "default": true },
+          "id": {
+            "type": "string",
+            "pattern": "^whe_[A-Za-z0-9]+$",
+            "example": "whe_9ZtRcXw3nByK5pVqMaEfJs"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
           "event_types": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/WebhookEventType" }
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
           },
           "headers": {
             "type": "object",
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "default": {}
           },
           "timeout_ms": {
@@ -98,16 +119,26 @@
             "maximum": 30000,
             "default": 5000
           },
-          "created_at": { "type": "string", "format": "date-time" },
-          "updated_at": { "type": "string", "format": "date-time" }
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "WebhookEndpointCreateResponse": {
         "allOf": [
-          { "$ref": "#/components/schemas/WebhookEndpoint" },
+          {
+            "$ref": "#/components/schemas/WebhookEndpoint"
+          },
           {
             "type": "object",
-            "required": ["signing_secret"],
+            "required": [
+              "signing_secret"
+            ],
             "properties": {
               "signing_secret": {
                 "type": "string",
@@ -119,9 +150,17 @@
       },
       "CreateWebhookEndpointRequest": {
         "type": "object",
-        "required": ["name", "url", "event_types"],
+        "required": [
+          "name",
+          "url",
+          "event_types"
+        ],
         "properties": {
-          "name": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
           "url": {
             "type": "string",
             "format": "uri",
@@ -129,12 +168,16 @@
           },
           "event_types": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/WebhookEventType" },
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            },
             "minItems": 1
           },
           "headers": {
             "type": "object",
-            "additionalProperties": { "type": "string" }
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "timeout_ms": {
             "type": "integer",
@@ -142,13 +185,19 @@
             "maximum": 30000,
             "default": 5000
           },
-          "enabled": { "type": "boolean", "default": true }
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          }
         },
         "additionalProperties": false,
         "example": {
           "name": "Production alerts",
           "url": "https://example.com/webhooks/polyai",
-          "event_types": ["alerts.triggered", "alerts.resolved"],
+          "event_types": [
+            "alerts.triggered",
+            "alerts.resolved"
+          ],
           "headers": {
             "X-Custom-Header": "my-value"
           },
@@ -159,7 +208,11 @@
       "UpdateWebhookEndpointAttributes": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "minLength": 1, "maxLength": 255 },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
           "url": {
             "type": "string",
             "format": "uri",
@@ -167,19 +220,25 @@
           },
           "event_types": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/WebhookEventType" },
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            },
             "minItems": 1
           },
           "headers": {
             "type": "object",
-            "additionalProperties": { "type": "string" }
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "timeout_ms": {
             "type": "integer",
             "minimum": 1000,
             "maximum": 30000
           },
-          "enabled": { "type": "boolean" }
+          "enabled": {
+            "type": "boolean"
+          }
         },
         "additionalProperties": false
       },
@@ -192,17 +251,23 @@
       },
       "WebhookEndpointListResponse": {
         "type": "object",
-        "required": ["data"],
+        "required": [
+          "data"
+        ],
         "properties": {
           "data": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/WebhookEndpoint" }
+            "items": {
+              "$ref": "#/components/schemas/WebhookEndpoint"
+            }
           }
         }
       },
       "RotateSigningSecretResponse": {
         "type": "object",
-        "required": ["signing_secret"],
+        "required": [
+          "signing_secret"
+        ],
         "properties": {
           "signing_secret": {
             "type": "string",
@@ -212,8 +277,41 @@
       },
       "Error": {
         "type": "object",
+        "description": "Standard PolyAI API error envelope.",
+        "required": [
+          "success",
+          "error",
+          "error_id",
+          "error_code",
+          "error_message",
+          "data"
+        ],
         "properties": {
-          "message": { "type": "string" }
+          "success": {
+            "type": "boolean",
+            "description": "Always false for error responses.",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "error_id": {
+            "type": "string",
+            "description": "Unique request identifier from the X-PolyAI-Correlation-Id header. Include this when contacting support."
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Machine-readable error code in UPPER_SNAKE_CASE."
+          },
+          "error_message": {
+            "type": "string",
+            "description": "Human-readable error message."
+          },
+          "data": {
+            "nullable": true,
+            "description": "Always null for error responses."
+          }
         }
       }
     },
@@ -222,7 +320,9 @@
         "description": "Validation error.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -230,7 +330,9 @@
         "description": "Missing or invalid API key.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -238,7 +340,9 @@
         "description": "Resource not found.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -246,7 +350,9 @@
         "description": "Resource limit exceeded (e.g. maximum number of webhook endpoints reached).",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -254,7 +360,9 @@
         "description": "Validation error or malformed resource ID.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -262,7 +370,9 @@
         "description": "Internal server error.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       },
@@ -270,7 +380,9 @@
         "description": "Monitoring backend sync failure.",
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/Error" }
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
           }
         }
       }
@@ -282,21 +394,54 @@
         "summary": "List webhook endpoints",
         "operationId": "listWebhookEndpoints",
         "parameters": [
-          { "$ref": "#/components/parameters/EnabledFilter" },
-          { "$ref": "#/components/parameters/EventTypeFilter" }
+          {
+            "$ref": "#/components/parameters/EnabledFilter"
+          },
+          {
+            "$ref": "#/components/parameters/EventTypeFilter"
+          }
         ],
         "responses": {
           "200": {
             "description": "Webhook endpoints retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WebhookEndpointListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointListResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
@@ -306,7 +451,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateWebhookEndpointRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebhookEndpointRequest"
+              }
             }
           }
         },
@@ -315,15 +462,62 @@
             "description": "Webhook endpoint created successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WebhookEndpointCreateResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointCreateResponse"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "409": { "$ref": "#/components/responses/Conflict" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -331,31 +525,79 @@
       "get": {
         "summary": "Get a webhook endpoint",
         "operationId": "getWebhookEndpoint",
-        "parameters": [{ "$ref": "#/components/parameters/EndpointId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EndpointId"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Webhook endpoint retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WebhookEndpoint" }
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "patch": {
         "summary": "Update a webhook endpoint",
         "operationId": "updateWebhookEndpoint",
-        "parameters": [{ "$ref": "#/components/parameters/EndpointId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EndpointId"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateWebhookEndpointRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWebhookEndpointRequest"
+              }
             }
           }
         },
@@ -364,29 +606,116 @@
             "description": "Webhook endpoint updated successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WebhookEndpoint" }
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "400": {
+            "$ref": "#/components/responses/BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "summary": "Delete a webhook endpoint",
         "operationId": "deleteWebhookEndpoint",
-        "parameters": [{ "$ref": "#/components/parameters/EndpointId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EndpointId"
+          }
+        ],
         "responses": {
           "204": {
             "description": "Webhook endpoint deleted successfully."
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -395,20 +724,62 @@
         "summary": "Rotate webhook signing secret",
         "operationId": "rotateWebhookSigningSecret",
         "description": "Generates a new signing secret for the webhook endpoint. The previous secret is immediately invalidated.",
-        "parameters": [{ "$ref": "#/components/parameters/EndpointId" }],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/EndpointId"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Signing secret rotated successfully.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RotateSigningSecretResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RotateSigningSecretResponse"
+                }
               }
             }
           },
-          "401": { "$ref": "#/components/responses/Unauthorized" },
-          "404": { "$ref": "#/components/responses/NotFound" },
-          "422": { "$ref": "#/components/responses/UnprocessableEntity" },
-          "500": { "$ref": "#/components/responses/InternalServerError" }
+          "401": {
+            "$ref": "#/components/responses/Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Why
Most 4xx/5xx responses in the platform-family OpenAPI specs only had a `description` string, no schema -- that's why the generated endpoint pages show Mintlify's generic `{"message": "<string>"}` fallback instead of anything real. Audited before touching anything: **126 of 188 error responses in Agents alone** were missing content, plus 25 in Alerts, 15 in Chat, 23 in Conversations v3, 25 in Data, 25 in Webhooks.

## Ground truth, not guesswork
Checked the code-intelligence layer before writing a single example:
- The real envelope is `platform_ui`'s `HTTPErrorResponse` TS type -- `{success, error_code, error_id, error_message, data}` -- which matches what's already documented on `api-reference/error-codes.mdx`. Added this as a shared `Error` schema in each spec's `components.schemas`.
- Outbound API's own spec declares a different `{error, code}` shape, and the Functions API (`genai_lambda_runtime`) uses `{success, error, message}` -- genuinely different envelopes per service, not a mistake. **Skipped both entirely** rather than force-fit the wrong shape.

## Scope discipline on error_code values
Only 63 error codes are documented anywhere (`error-codes.mdx`) and I could not find an exhaustive registry beyond that. So: **an example only gets a specific `error_code` where the endpoint's identifying resource confidently matches one of those 63** (verified programmatically -- every code used here exists verbatim on the error-codes page). Everywhere else -- most of Webhooks/Alerts (no resource-specific codes exist for either), plus several Agents sub-resources (branches, voice-library, audio-cache, outbound-calls) -- the response still gets the corrected 5-field `Error` shape via `$ref`, just without a fabricated code.

## Results
| Spec | Real sourced example | Shape-only fix |
|---|---|---|
| Agents | 16 | 110 |
| Data | 7 | 18 |
| Conversations v3 | 6 | 17 |
| Chat | 2 | 13 |
| Webhooks | 0 | 25 |
| Alerts | 0 | 25 |

Also fixes an unrelated pre-existing JSON syntax error (trailing comma) in `conversations/v1/openapi.json` that was breaking that spec's JSON parsing outright -- found it while auditing the other spec files.

## Test plan
- [ ] All 7 touched files pass `json.load` (verified locally, but please confirm Mintlify's build picks them up without complaint)
- [ ] Spot check a couple of endpoint pages (e.g. Agents > Deployments > Promote, Data > Debug Chat) to confirm the 401/403/404 examples render correctly
- [ ] Confirm the Webhooks/Alerts pages now show the correct 5-field shape (even without a specific code) instead of the old `{"message": "<string>"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)