### PR TITLE
docs: remove free-trial mentions

### DIFF
--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -13,7 +13,7 @@ keywords:
 <div className="simplified-only">
 
 <Note>
-  This quickstart uses [Studio Assistant](/studio-assistant/introduction) to scaffold the agent, then Web Calling to embed it. Available to project admins on enterprise clusters and to free-trial accounts. Free-trial users can switch to the full enterprise quickstart via the **Free trial — exit** pill.
+  This quickstart uses [Studio Assistant](/studio-assistant/introduction) to scaffold the agent, then Web Calling to embed it. Available to project admins on enterprise clusters.
 </Note>
 
 The fastest path from sign-up to a working voice agent on your site. Studio Assistant does most of the building: you describe what you want, and it scaffolds flows, knowledge, voice, and integrations for you.

--- a/learn/iterate-open-platform.mdx
+++ b/learn/iterate-open-platform.mdx
@@ -11,7 +11,7 @@ keywords:
 ---
 
 <Note>
-  This page covers the iterate-after-a-call loop with [Studio Assistant](/studio-assistant/introduction): read the transcript, ask Studio Assistant to fix it, share the link. Studio Assistant is available to **project admins on enterprise clusters** as well as free-trial accounts — the workflow is the same in both.
+  This page covers the iterate-after-a-call loop with [Studio Assistant](/studio-assistant/introduction): read the transcript, ask Studio Assistant to fix it, share the link. Studio Assistant is available to **project admins on enterprise clusters**.
 </Note>
 
 Real callers say things your prompts did not anticipate, mispronounce reference numbers, and go off-script in ways no demo covers. The fastest way to improve an agent is to read the transcripts, identify the failure, ask Studio Assistant to fix it, and share the resulting build for review.


### PR DESCRIPTION
## Scope check before deleting anything
Audited the whole repo (grep for every variant: "free trial," "free-trial," "trial account," "trial mode," "trial cluster," "exit pill," plus checked docs.json nav/redirects/banner and all 20 release notes) before touching anything, since "remove all the baggage" implied there might be a dedicated onboarding flow or nav entry.

**Turns out it's exactly two sentences in two files** -- no dedicated trial page, no nav entry, no docs.json redirect or banner, and it's never mentioned in any release note as being introduced or sunset.

## What changed
- `get-started/quickstart.mdx` -- dropped "and to free-trial accounts. Free-trial users can switch to the full enterprise quickstart via the **Free trial — exit** pill." from the intro Note.
- `learn/iterate-open-platform.mdx` -- dropped "as well as free-trial accounts — the workflow is the same in both." from the intro Note.

## What I deliberately left alone
The `simplified-only` / `full-only` content-mode toggle (used in quickstart.mdx and ~20 other pages to show a self-serve vs. full-enterprise-guided version of the same content) is a **separate, unrelated mechanism** -- it's not trial-specific, just happens to be the UI variant free-trial accounts also saw. Removing it would break the self-serve/enterprise split for everyone else, so it stays.

## Test plan
- [ ] Confirm no other trial-related copy exists in the product itself that should also be updated to match (this only touches docs)
- [ ] Spot check both pages read fine post-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)