### PR TITLE
fix: point "Pull conversation data" card to the Data API

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -286,7 +286,7 @@ keywords:
   <Card title="Make my first API call" icon="rocket" href="/api-reference/quickstart">
     Full walkthrough: key → list conversations → fetch transcript → audio → webhooks.
   </Card>
-  <Card title="Pull conversation data" icon="database" href="/api-reference/conversations/introduction">
+  <Card title="Pull conversation data" icon="database" href="/api-reference/data/introduction">
     Query transcripts, metrics, and audio for analytics and compliance pipelines.
   </Card>
   <Card title="Build & deploy an agent" icon="hammer" href="/api-reference/agents/introduction">


### PR DESCRIPTION
## What

The **Pull conversation data** card in the API reference "I want to..." section linked to the legacy **Conversations v3** introduction (`/api-reference/conversations/introduction`), even though its description ("Query transcripts, metrics, and audio for analytics and compliance pipelines") describes the **Data API** — the officially supported offering.

Repointed it to `/api-reference/data/introduction`.

## Why

The Data API is the recommended endpoint for pulling conversation data; the catalog already lists both APIs separately. This get-started panel now sends readers to the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)