### PR TITLE
docs: fix variants Agents API example (branch flow + attributeValues shape)

### DIFF
--- a/knowledge/variants/introduction.mdx
+++ b/knowledge/variants/introduction.mdx
@@ -197,26 +197,42 @@ If your variants live in a source of truth outside Agent Studio — a locations 
   <Accordion title="Manage variants via the Agents API" icon="code">
     The [Agents API](/api-reference/agents/introduction) exposes full CRUD for both [attributes](/api-reference/agents/endpoint/variants/list-attributes) (the dimensions) and [variants](/api-reference/agents/endpoint/variants/list-variants) (the per-site combinations).
 
+    Attributes and variants can't be written to `main` directly — create a branch, add them there, then merge it into `main` (which also publishes to Sandbox).
+
+    Each attribute you create returns an **attribute ID** (e.g. `ATTRIBUTE-B8060842`). A variant maps those IDs to values under `attributeValues.values` — the keys are attribute **IDs**, not names, so capture each ID as you create it.
+
     <CodeGroup>
     ```bash curl
-    # Create an attribute (a variant dimension)
-    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches/main/attributes \
+    # Create a branch to hold the changes
+    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches \
+      -H "x-api-key: $POLYAI_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{ "branchName": "add-sites" }'   # response includes { "branchId": "BRANCH-…" }
+
+    # Create an attribute (a variant dimension) — response: { "id": "ATTRIBUTE-…", "name": "location_id" }
+    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches/BRANCH_ID/attributes \
       -H "x-api-key: $POLYAI_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{ "name": "location_id" }'
 
-    # Create a variant with attribute values
-    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches/main/variants \
+    # Create a variant, mapping each attribute ID to its value for this site
+    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches/BRANCH_ID/variants \
       -H "x-api-key: $POLYAI_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{
         "name": "London Flagship",
-        "attributes": {
-          "location_id": "LON-01",
-          "address": "12 Regent Street",
-          "hours": "9am - 10pm"
+        "attributeValues": {
+          "values": {
+            "ATTRIBUTE-B8060842": "LON-01"
+          }
         }
       }'
+
+    # Merge to main once every site is added
+    curl -X POST https://api.us.poly.ai/v1/agents/AGENT_ID/branches/BRANCH_ID/merge \
+      -H "x-api-key: $POLYAI_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{ "deploymentMessage": "Add site variants" }'
     ```
 
     ```python Python
@@ -225,20 +241,45 @@ If your variants live in a source of truth outside Agent Studio — a locations 
     BASE = "https://api.us.poly.ai"
     HEADERS = {"x-api-key": os.environ["POLYAI_API_KEY"]}
 
-    # Sync many sites in one pass
+    # Sync many sites in one pass.
+    # main is read-only, so build them on a branch and merge once.
+    branch_id = requests.post(
+        f"{BASE}/v1/agents/{AGENT_ID}/branches",
+        headers=HEADERS,
+        json={"branchName": "crm-sites"},
+    ).json()["branchId"]
+
+    # Create each dimension once and keep its attribute ID — variant values are keyed by ID.
+    attribute_ids = {}
+    for dimension in ("location_id", "address", "hours"):
+        resp = requests.post(
+            f"{BASE}/v1/agents/{AGENT_ID}/branches/{branch_id}/attributes",
+            headers=HEADERS,
+            json={"name": dimension},
+        )
+        attribute_ids[dimension] = resp.json()["id"]
+
     for site in load_locations_from_crm():
         requests.post(
-            f"{BASE}/v1/agents/{AGENT_ID}/branches/main/variants",
+            f"{BASE}/v1/agents/{AGENT_ID}/branches/{branch_id}/variants",
             headers=HEADERS,
             json={
                 "name": site["name"],
-                "attributes": {
-                    "location_id": site["id"],
-                    "address": site["address"],
-                    "hours": site["hours"],
+                "attributeValues": {
+                    "values": {
+                        attribute_ids["location_id"]: site["id"],
+                        attribute_ids["address"]: site["address"],
+                        attribute_ids["hours"]: site["hours"],
+                    }
                 },
             },
         )
+
+    requests.post(
+        f"{BASE}/v1/agents/{AGENT_ID}/branches/{branch_id}/merge",
+        headers=HEADERS,
+        json={"deploymentMessage": "Sync site variants from CRM"},
+    )
     ```
     </CodeGroup>
   </Accordion>


### PR DESCRIPTION
Splits the variants page fix out of #567 so its two related defects are reviewed together. Both were found and confirmed against the **live US Agents API**.

## Defects fixed in `knowledge/variants/introduction.mdx`

**1. Writes went to `branches/main`** — the API rejects that with `422 Cannot directly update main branch`. The example now creates a working branch, edits it, and merges back into `main` (which also publishes to Sandbox), matching the lifecycle correction in #567.

**2. Wrong `attributeValues` shape (the subtle one).** The variant body used a flat, name-keyed object:

```json
{ "name": "London Flagship", "attributeValues": { "location_id": "LON-01", ... } }
```

The real field is **`attributeValues.values`**, keyed by the **attribute ID** returned from the attribute-create call:

```json
{ "name": "London Flagship", "attributeValues": { "values": { "ATTRIBUTE-B8060842": "LON-01" } } }
```

The flat/name-keyed form is accepted with `201` but **silently stores empty values** — so the example looked right while configuring nothing. The curl + Python examples now capture each attribute's ID and map values by ID.

## Verified against the live API while here (no doc change needed)
- Attribute create — `{ "name" }` → `{ "id": "ATTRIBUTE-…", "name" }`
- Variant create with the nested body persists the value (`MAN-01` round-tripped correctly)
- First variant created is auto-marked `isDefault: true`

## Depends on
Reads best alongside #567 (the branch→merge lifecycle correction). No file overlap — #567 no longer touches this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)