### PR TITLE
docs: per-region MCP connect commands + full Builder MCP capabilities

### DIFF
--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -41,7 +41,7 @@ Pass the key in the `X-API-KEY` header. The MCP server uses the streamable HTTP 
 | `X-API-KEY` | Your workspace-scoped API key |
 | `Accept` | `application/json, text/event-stream` |
 
-Most clients set `Accept` automatically. See [Quickstart](/mcp/quickstart#2-add-the-server-to-your-client) for per-client configuration.
+Most clients set `Accept` automatically. See [Quickstart](/mcp/quickstart#1-connect-your-client) for per-client configuration.
 
 ## Pick your region
 

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -1,54 +1,68 @@
 ---
 title: Capabilities
 sidebarTitle: Capabilities
-description: The tools Builder MCP exposes, grouped by agents, data, and alerts.
+description: The tools Builder MCP exposes, grouped by build, test, monitor, and infrastructure.
 mode: wide
 ---
 
-{/* REVIEW: The tool rows below are ILLUSTRATIVE, derived from the backing APIs — they are
-    not the verified live tool list. Replace with the exact tool names, descriptions, and
-    input schemas from DEVP-216 (README) before publishing. Confirm the three-way
-    agents/data/alerts grouping matches what the server actually exposes. */}
+{/* REVIEW: The coverage below was compiled from a live Claude Code session against Builder
+    MCP (via Naorin, Jul 2026) and is PENDING validation by Joseph Perez. Before publishing:
+    confirm the operations per resource, add the exact tool names and input schemas from the
+    DEVP-216 tool list, and verify the workspace- vs project-scoped groupings. */}
 
-Builder MCP exposes PolyAI's platform as MCP tools, grouped into three areas. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
+Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
 
 <Note>
-To see exactly what your client discovered, ask it to list its available tools, or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#3-verify)).
+To see exactly what your client discovered, ask it to list its available tools, or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#2-verify)).
 </Note>
 
-## Agents
+## Build & manage agents
 
-Create and manage agents and everything they contain. Backed by the [Agents API](/api-reference/agents/introduction).
+Create agents and manage everything they contain. Workspace- and agent-scoped, backed by the [Agents API](/api-reference/agents/introduction).
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `list_agents` | List agents in the workspace | — |
-| `create_agent` | Create a new agent | `name`, response settings |
-| `create_branch` | Branch an agent for isolated edits | `agent_id`, `name` |
-| `merge_branch` | Merge a branch back | `agent_id`, `branch_id` |
-| `update_behavior` | Update agent behavior rules | `agent_id`, rules |
-| `manage_knowledge_base` | Create, update, and delete KB topics | `agent_id`, topic |
-| `manage_variants` | Manage variant attributes and variants | `agent_id`, variant |
+| Resource | Operations |
+| --- | --- |
+| Agents | Create, list, duplicate, delete |
+| Branches | Create, list, delete, merge, sync with parent |
+| Deployments | Publish a draft to an environment, promote, roll back, list active, get the active deployment per environment |
+| Knowledge base | Create, update, and delete topics |
+| Variants | Create, read, update, delete (A/B testing) |
+| Attributes | Create, read, update, delete |
+| Connectors | Get, list, update, delete, look up by phone number |
+| Phone numbers | Batch get, import (single and bulk), delete (single and bulk), reassign |
+| Voice library | Register, update, get, list, synthesize a sample |
+| Real-time configs | Get and list config pages, update environment variables, upsert JSON schema |
+| Audio cache | List, update, delete (single and bulk), download, replace a file, preview TTS |
 
-## Data
+## Test & inspect conversations
 
-Retrieve conversation data to test and inspect agents. Backed by the [Data API](/api-reference/data/introduction).
+Exercise agents and pull back the data they produce. Project-scoped, backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `list_conversations` | List conversations for an agent | `agent_id`, filters |
-| `get_conversation` | Fetch a conversation by ID | `conversation_id` |
-| `debug_chat` | Start a debug chat session to test an agent | `agent_id`, environment |
+| Resource | Operations |
+| --- | --- |
+| Debug chat | Create a session, send a message |
+| Conversations | Get by ID, list, fetch audio recording, manage annotations and notes |
+| Test runs & test cases | Trigger a run, list and get runs, list cases, view execution history |
+| Outbound calling | Trigger an outbound call, get call status |
 
-## Alerts
+## Monitor deployed agents
 
-Monitor deployed agents. Backed by the [Alerts API](/api-reference/alerts/introduction).
+Watch live agents and react to issues. Workspace-scoped, backed by the [Alerts API](/api-reference/alerts/introduction).
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `create_alert_rule` | Create an alert rule | rule definition |
-| `list_alert_rules` | List configured alert rules | — |
-| `list_active_alerts` | Read currently firing alerts | — |
+| Resource | Operations |
+| --- | --- |
+| Alerts | Create, read, update, and delete alert rules; read active alerts |
+
+## Manage agent infrastructure
+
+Configure the plumbing behind an agent.
+
+| Resource | Operations |
+| --- | --- |
+| MCP servers on an agent | Add, list, connect, update, delete — register other MCP servers onto your agent |
+| Secrets | Create, delete |
+| Deployed voice configs | Create, read, update, delete; set active |
+| Voice & disclaimer tuning | Get, update |
 
 ## Limiting which tools are exposed
 

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -1,14 +1,14 @@
 ---
 title: Capabilities
 sidebarTitle: Capabilities
-description: The tools Builder MCP exposes, grouped by build, test, monitor, and infrastructure.
+description: The tools Builder MCP exposes, grouped by what they do.
 mode: wide
 ---
 
-{/* REVIEW: The coverage below was validated live against the tools/list endpoint on
-    2026-07-09 — US/UK/EU expose 71 tools; self-serve Studio exposes 65 (no Alerts family).
-    Operations map to real tool names. Joseph Perez to confirm the intended public grouping
-    and whether any tools should be hidden from customer docs. */}
+{/* REVIEW: Validated live against the regenerated prod tools/list on 2026-07-09 —
+    US/UK/EU expose 97 tools; self-serve Studio exposes 91 (no Alerts family). Operations
+    map to real tool names. Joseph Perez to confirm the intended public grouping and whether
+    any tools should be hidden from customer docs. */}
 
 Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
 
@@ -33,15 +33,27 @@ Create agents and manage everything they contain. Workspace- and agent-scoped, b
 | Phone numbers | Get, batch get, list, import (single and bulk), delete (single and bulk), reassign |
 | Config pages | Get by environment, list, update config variables, upsert a JSON schema |
 
-## Test & inspect conversations
+## Voice & audio
 
-Exercise agents and pull back the data they produce. Backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
+Manage the voices an agent uses and the audio it caches.
+
+| Resource | Operations |
+| --- | --- |
+| Voice library | Register, update, get, list, synthesize a sample, set the active voice |
+| Deployed voice configs | Create or update, list, delete |
+| Voice & disclaimer tuning | Get and update voice tuning; get and update disclaimer tuning |
+| Audio cache | List, delete (single and bulk), download, replace a file, update a file and its settings, generate and preview TTS |
+
+## Run, test & inspect
+
+Exercise agents, place calls, and pull back the data they produce. Backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
 
 | Resource | Operations |
 | --- | --- |
 | Debug chat | Create a session, send a message |
 | Conversations | Get by ID, list, fetch audio recording, add annotations, upsert a note |
-| Test suites | Trigger a test run, list test cases, get a test case |
+| Test suites | Trigger a test run, get and list runs, list and get test cases, view execution history |
+| Outbound calling | Trigger an outbound call, get its status |
 
 ## Monitor deployed agents
 

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -5,10 +5,10 @@ description: The tools Builder MCP exposes, grouped by build, test, monitor, and
 mode: wide
 ---
 
-{/* REVIEW: The coverage below was compiled from a live Claude Code session against Builder
-    MCP (via Naorin, Jul 2026) and is PENDING validation by Joseph Perez. Before publishing:
-    confirm the operations per resource, add the exact tool names and input schemas from the
-    DEVP-216 tool list, and verify the workspace- vs project-scoped groupings. */}
+{/* REVIEW: The coverage below was validated live against the tools/list endpoint on
+    2026-07-09 — US/UK/EU expose 71 tools; self-serve Studio exposes 65 (no Alerts family).
+    Operations map to real tool names. Joseph Perez to confirm the intended public grouping
+    and whether any tools should be hidden from customer docs. */}
 
 Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
 
@@ -23,35 +23,37 @@ Create agents and manage everything they contain. Workspace- and agent-scoped, b
 | Resource | Operations |
 | --- | --- |
 | Agents | Create, list, duplicate, delete |
+| Behavior | Get and update an agent's behavior rules |
 | Branches | Create, list, delete, merge, sync with parent |
-| Deployments | Publish a draft to an environment, promote, roll back, list active, get the active deployment per environment |
-| Knowledge base | Create, update, and delete topics |
-| Variants | Create, read, update, delete (A/B testing) |
-| Attributes | Create, read, update, delete |
-| Connectors | Get, list, update, delete, look up by phone number |
-| Phone numbers | Batch get, import (single and bulk), delete (single and bulk), reassign |
-| Voice library | Register, update, get, list, synthesize a sample |
-| Real-time configs | Get and list config pages, update environment variables, upsert JSON schema |
-| Audio cache | List, update, delete (single and bulk), download, replace a file, preview TTS |
+| Deployments | Publish a draft to an environment, promote, roll back, list per environment, get the active deployment per environment |
+| Knowledge base | Create, get, list, update, delete topics |
+| Variants | Create, list, update, delete (A/B testing) |
+| Attributes | Create, list, update, delete |
+| Connectors | Get, batch get, list, update, batch update, delete, look up by phone number |
+| Phone numbers | Get, batch get, list, import (single and bulk), delete (single and bulk), reassign |
+| Config pages | Get by environment, list, update config variables, upsert a JSON schema |
 
 ## Test & inspect conversations
 
-Exercise agents and pull back the data they produce. Project-scoped, backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
+Exercise agents and pull back the data they produce. Backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
 
 | Resource | Operations |
 | --- | --- |
 | Debug chat | Create a session, send a message |
-| Conversations | Get by ID, list, fetch audio recording, manage annotations and notes |
-| Test runs & test cases | Trigger a run, list and get runs, list cases, view execution history |
-| Outbound calling | Trigger an outbound call, get call status |
+| Conversations | Get by ID, list, fetch audio recording, add annotations, upsert a note |
+| Test suites | Trigger a test run, list test cases, get a test case |
 
 ## Monitor deployed agents
 
-Watch live agents and react to issues. Workspace-scoped, backed by the [Alerts API](/api-reference/alerts/introduction).
+Watch live agents and react to issues. Backed by the [Alerts API](/api-reference/alerts/introduction).
 
 | Resource | Operations |
 | --- | --- |
-| Alerts | Create, read, update, and delete alert rules; read active alerts |
+| Alerts | Create, get, list, update, delete alert rules; read active alerts |
+
+<Note>
+The Alerts tools are available on enterprise (US, UK, EU) workspaces. Self-serve Studio workspaces don't expose them.
+</Note>
 
 ## Manage agent infrastructure
 
@@ -61,15 +63,11 @@ Configure the plumbing behind an agent.
 | --- | --- |
 | MCP servers on an agent | Add, list, connect, update, delete — register other MCP servers onto your agent |
 | Secrets | Create, delete |
-| Deployed voice configs | Create, read, update, delete; set active |
-| Voice & disclaimer tuning | Get, update |
 
-## Limiting which tools are exposed
+## Limiting what a client can do
 
-If a client should only see a subset of tools, restrict discovery with the `tools` query parameter on the endpoint URL:
+{/* REVIEW: A `?tools=` endpoint filter was previously documented here but does not work —
+    tested live on 2026-07-09, the endpoint returns all tools regardless of the query string.
+    Reinstate with the correct mechanism if per-endpoint tool filtering ships. */}
 
-```
-https://api.us.poly.ai/builder-mcp?tools=list_agents,create_branch
-```
-
-Only the listed tools are discovered — useful for read-only or narrowly scoped clients. Pair this with a [least-privilege key](/mcp/builder/security#use-least-privilege-keys).
+To narrow what a client can reach, scope the [API key](/mcp/authentication) itself. Create a [least-privilege key](/mcp/builder/security#use-least-privilege-keys) limited to the agents and permissions that client needs — for example, a read-only key for a monitoring assistant. The key's scope governs which calls succeed, so a narrowly scoped key can't create, delete, or deploy even though the tools are still discovered.

--- a/mcp/quickstart.mdx
+++ b/mcp/quickstart.mdx
@@ -50,11 +50,12 @@ Connect the [Builder MCP](/mcp/builder/introduction) to your MCP client — [Cur
   </Step>
 </Steps>
 
-## 1. Set your key and endpoint
+## 1. Connect your client
+
+Set your API key, then add the server with a single command using the endpoint for your workspace's region.
 
 ```bash
 export POLYAI_API_KEY="your_api_key_here"
-export POLYAI_MCP_URL="https://api.us.poly.ai/builder-mcp"   # use your region — see below
 ```
 
 | Region | Endpoint |
@@ -62,15 +63,46 @@ export POLYAI_MCP_URL="https://api.us.poly.ai/builder-mcp"   # use your region �
 | US     | `https://api.us.poly.ai/builder-mcp`     |
 | UK     | `https://api.uk.poly.ai/builder-mcp`     |
 | EU     | `https://api.eu.poly.ai/builder-mcp`     |
-| Studio | `https://api.studio.poly.ai/builder-mcp` |
+| Studio (self-serve) | `https://api.studio.poly.ai/builder-mcp` |
 
-Match the region to the workspace you build in. Connecting to the wrong region authenticates against the wrong workspace. See [Authentication](/mcp/authentication#pick-your-region) for how regions map to workspaces.
-
-## 2. Add the server to your client
+Match the region to the workspace you build in — connecting to the wrong region authenticates against the wrong workspace. See [Authentication](/mcp/authentication#pick-your-region) for how regions map to workspaces.
 
 <Tabs>
+  <Tab title="Claude Code">
+    Run the command for your region:
+
+    <CodeGroup>
+
+    ```bash US
+    claude mcp add --transport http polyai https://api.us.poly.ai/builder-mcp \
+      --header "X-API-KEY: $POLYAI_API_KEY" \
+      --header "Accept: application/json, text/event-stream"
+    ```
+
+    ```bash UK
+    claude mcp add --transport http polyai https://api.uk.poly.ai/builder-mcp \
+      --header "X-API-KEY: $POLYAI_API_KEY" \
+      --header "Accept: application/json, text/event-stream"
+    ```
+
+    ```bash EU
+    claude mcp add --transport http polyai https://api.eu.poly.ai/builder-mcp \
+      --header "X-API-KEY: $POLYAI_API_KEY" \
+      --header "Accept: application/json, text/event-stream"
+    ```
+
+    ```bash Studio
+    claude mcp add --transport http polyai https://api.studio.poly.ai/builder-mcp \
+      --header "X-API-KEY: $POLYAI_API_KEY" \
+      --header "Accept: application/json, text/event-stream"
+    ```
+
+    </CodeGroup>
+
+    Verify with `claude mcp list`, then ask Claude to list its PolyAI tools.
+  </Tab>
   <Tab title="Cursor">
-    Add to `~/.cursor/mcp.json`:
+    Add to `~/.cursor/mcp.json`, using your region's endpoint from the table above:
 
     ```json
     {
@@ -85,17 +117,8 @@ Match the region to the workspace you build in. Connecting to the wrong region a
 
     Restart Cursor, then open the MCP settings to confirm the PolyAI tools loaded.
   </Tab>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add --transport http polyai "$POLYAI_MCP_URL" \
-      --header "X-API-KEY: $POLYAI_API_KEY" \
-      --header "Accept: application/json, text/event-stream"
-    ```
-
-    Verify with `claude mcp list`, then ask Claude to list its PolyAI tools.
-  </Tab>
   <Tab title="Claude Desktop">
-    Add to your `claude_desktop_config.json`:
+    Add to your `claude_desktop_config.json`, using your region's endpoint from the table above:
 
     ```json
     {
@@ -111,7 +134,7 @@ Match the region to the workspace you build in. Connecting to the wrong region a
     Restart Claude Desktop. The PolyAI tools appear in the tools menu.
   </Tab>
   <Tab title="Codex">
-    Add to your Codex MCP config:
+    Add to your Codex MCP config, using your region's endpoint from the table above:
 
     ```toml
     [mcp_servers.polyai]
@@ -127,12 +150,12 @@ Match the region to the workspace you build in. Connecting to the wrong region a
 Most clients set the `Accept: application/json, text/event-stream` header for you. If a client can't connect, add it explicitly — the server uses the streamable HTTP transport.
 </Tip>
 
-## 3. Verify
+## 2. Verify
 
-Ask your client to list its available tools, or test the endpoint directly:
+Ask your client to list its available tools, or test the endpoint directly (swap in your region's endpoint):
 
 ```bash
-curl -s -X POST "$POLYAI_MCP_URL" \
+curl -s -X POST "https://api.us.poly.ai/builder-mcp" \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json, text/event-stream' \
   -H "X-API-KEY: $POLYAI_API_KEY" \
@@ -146,7 +169,7 @@ A number greater than zero means the server is reachable and your key is valid.
 
 <CardGroup cols={2}>
   <Card title="What Builder MCP can do" icon="wrench" href="/mcp/builder/capabilities">
-    Browse the tools, grouped by agents, data, and alerts.
+    Browse the full tool list, grouped by capability.
   </Card>
   <Card title="Build, test & deploy" icon="rocket" href="/mcp/builder/walkthrough">
     Walk through the full lifecycle from branch to production.


### PR DESCRIPTION
Addresses the second round of Naorin's feedback on the MCP docs, plus a live validation of the Builder MCP tool surface. Stacked on top of the MCP branch (`docs/mcp-top-level-category`) because the MCP pages don't exist on `main` yet — **retarget to `main` once that PR merges.**

## What's in here

**1. Quickstart — combine steps + per-region commands** ([mcp/quickstart.mdx](mcp/quickstart.mdx))
- Merged "Set your key and endpoint" + "Add the server to your client" into a single **Connect your client** step.
- Claude Code tab leads (matching Joey's how-to video) and shows ready-to-paste `claude mcp add` commands for **US / UK / EU / Studio (self-serve)** in a CodeGroup.
- Renumbered Verify to step 2; fixed the cross-ref anchors on the authentication and capabilities pages.

**2. Capabilities — validated against the live server** ([mcp/builder/capabilities.mdx](mcp/builder/capabilities.mdx))
- Rebuilt from a live `tools/list` call against the **regenerated prod spec**: **97 tools** on US/UK/EU, **91 on Studio**.
- Grouped into five families: **Build & manage / Voice & audio / Run, test & inspect / Monitor / Infrastructure**, with operations mapped to real tool names.
- **Alerts is enterprise-only** — Studio omits exactly those 6 tools (documented in a callout).
- Replaced the previously-documented `?tools=` endpoint filter (which the live server ignores) with **key-scoping** guidance for restricting a client.

## Validation notes (live `tools/list`)
- Verified across all four regions with a workspace key. US/UK/EU = 97 tools, Studio = 91 (no Alerts family).
- ⚠️ **`?tools=` filter appears unimplemented** — the endpoint returns all tools regardless of the query string (tested several param forms). Flagged to Joey; left a REVIEW comment in the page.

## Decisions worth a look
- **Server name / env var:** used a consistent `polyai` server name and `$POLYAI_API_KEY` across all regions rather than the video's region-specific names (`polyai-prod-uk`, `$POLY_API_KEY_UK`, …). Cleaner for docs; a user connects to one region.
- **Aaron flagged waiting for US** on the combine-steps change — implemented so it's reviewable, but hold the merge if you still want US eyes first.
- **Release-notes URL:** the thread also asked to swap a release-notes URL to `https://docs.poly.ai/mcp/builder/introduction`, but there's currently **no Builder MCP link in the release notes** to replace (only `/mcp/agent-studio-integrations`). Left untouched — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)