### PR TITLE
docs: align Builder MCP capabilities page with validated prod tool list

### DIFF
--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -1,61 +1,85 @@
 ---
 title: Capabilities
 sidebarTitle: Capabilities
-description: The tools Builder MCP exposes, grouped by agents, data, and alerts.
+description: The tools Builder MCP exposes, grouped by what they do.
 mode: wide
 ---
 
-{/* REVIEW: The tool rows below are ILLUSTRATIVE, derived from the backing APIs — they are
-    not the verified live tool list. Replace with the exact tool names, descriptions, and
-    input schemas from DEVP-216 (README) before publishing. Confirm the three-way
-    agents/data/alerts grouping matches what the server actually exposes. */}
+{/* REVIEW: Validated live against the regenerated prod tools/list on 2026-07-09 —
+    US/UK/EU expose 97 tools; self-serve Studio exposes 91 (no Alerts family). Operations
+    map to real tool names. Joseph Perez to confirm the intended public grouping and whether
+    any tools should be hidden from customer docs. */}
 
-Builder MCP exposes PolyAI's platform as MCP tools, grouped into three areas. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
+Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
 
 <Note>
 To see exactly what your client discovered, ask it to list its available tools, or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#3-verify)).
 </Note>
 
-## Agents
+## Build & manage agents
 
-Create and manage agents and everything they contain. Backed by the [Agents API](/api-reference/agents/introduction).
+Create agents and manage everything they contain. Workspace- and agent-scoped, backed by the [Agents API](/api-reference/agents/introduction).
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `list-agents` | List agents in the workspace | — |
-| `create-agent` | Create a new agent | `name`, response settings |
-| `create-branch` | Branch an agent for isolated edits | `agent_id`, `name` |
-| `merge-branch` | Merge a branch back | `agent_id`, `branch_id` |
-| `update-behavior` | Update agent behavior rules | `agent_id`, rules |
-| `manage-knowledge-base` | Create, update, and delete KB topics | `agent_id`, topic |
-| `manage-variants` | Manage variant attributes and variants | `agent_id`, variant |
+| Resource | Operations |
+| --- | --- |
+| Agents | Create, list, duplicate, delete |
+| Behavior | Get and update an agent's behavior rules |
+| Branches | Create, list, delete, merge, sync with parent |
+| Deployments | Publish a draft to an environment, promote, roll back, list per environment, get the active deployment per environment |
+| Knowledge base | Create, get, list, update, delete topics |
+| Variants | Create, list, update, delete (A/B testing) |
+| Attributes | Create, list, update, delete |
+| Connectors | Get, batch get, list, update, batch update, delete, look up by phone number |
+| Phone numbers | Get, batch get, list, import (single and bulk), delete (single and bulk), reassign |
+| Config pages | Get by environment, list, update config variables, upsert a JSON schema |
 
-## Data
+## Voice & audio
 
-Retrieve conversation data to test and inspect agents. Backed by the [Data API](/api-reference/data/introduction).
+Manage the voices an agent uses and the audio it caches.
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `list-conversations` | List conversations for an agent | `agent_id`, filters |
-| `get-conversation` | Fetch a conversation by ID | `conversation_id` |
-| `debug-chat` | Start a debug chat session to test an agent | `agent_id`, environment |
+| Resource | Operations |
+| --- | --- |
+| Voice library | Register, update, get, list, synthesize a sample, set the active voice |
+| Deployed voice configs | Create or update, list, delete |
+| Voice & disclaimer tuning | Get and update voice tuning; get and update disclaimer tuning |
+| Audio cache | List, delete (single and bulk), download, replace a file, update a file and its settings, generate and preview TTS |
 
-## Alerts
+## Run, test & inspect
 
-Monitor deployed agents. Backed by the [Alerts API](/api-reference/alerts/introduction).
+Exercise agents, place calls, and pull back the data they produce. Backed by the [Data](/api-reference/data/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
 
-| Tool | Description | Key inputs |
-| --- | --- | --- |
-| `create-alert-rule` | Create an alert rule | rule definition |
-| `list-alert-rules` | List configured alert rules | — |
-| `list-active-alerts` | Read currently firing alerts | — |
+| Resource | Operations |
+| --- | --- |
+| Debug chat | Create a session, send a message |
+| Conversations | Get by ID, list, fetch audio recording, add annotations, upsert a note |
+| Test suites | Trigger a test run, get and list runs, list and get test cases, view execution history |
+| Outbound calling | Trigger an outbound call, get its status |
 
-## Limiting which tools are exposed
+## Monitor deployed agents
 
-If a client should only see a subset of tools, restrict discovery with the `tools` query parameter on the endpoint URL:
+Watch live agents and react to issues. Backed by the [Alerts API](/api-reference/alerts/introduction).
 
-```
-https://api.us.poly.ai/builder-mcp?tools=list-agents,create-branch
-```
+| Resource | Operations |
+| --- | --- |
+| Alerts | Create, get, list, update, delete alert rules; read active alerts |
 
-Only the listed tools are discovered — useful for read-only or narrowly scoped clients. Pair this with a [least-privilege key](/mcp/builder/security#use-least-privilege-keys).
+<Note>
+The Alerts tools are available on enterprise (US, UK, EU) workspaces. Self-serve Studio workspaces don't expose them.
+</Note>
+
+## Manage agent infrastructure
+
+Configure the plumbing behind an agent.
+
+| Resource | Operations |
+| --- | --- |
+| MCP servers on an agent | Add, list, connect, update, delete — register other MCP servers onto your agent |
+| Secrets | Create, delete |
+
+## Limiting what a client can do
+
+{/* REVIEW: A `?tools=` endpoint filter was previously documented here but does not work —
+    tested live on 2026-07-09, the endpoint returns all tools regardless of the query string.
+    Reinstate with the correct mechanism if per-endpoint tool filtering ships. */}
+
+To narrow what a client can reach, scope the [API key](/mcp/authentication) itself. Create a [least-privilege key](/mcp/builder/security#restrict-the-tool-surface) limited to the agents and permissions that client needs — for example, a read-only key for a monitoring assistant. The key's scope governs which calls succeed, so a narrowly scoped key can't create, delete, or deploy even though the tools are still discovered.


### PR DESCRIPTION
## What

The published [capabilities page](https://docs.poly.ai/mcp/builder/capabilities) on `main` is still the illustrative stub — an incomplete tool list, plus a documented `?tools=` endpoint filter that **does not exist on the server**.

This replaces it with the list **validated live against the regenerated prod `tools/list` on 2026-07-09** (after the specs were regenerated and provisioned to prod). US/UK/EU expose 97 tools; self-serve Studio exposes 91 (no Alerts family).

## Changes

- **Full tool families**, grouped by what they do: Build & manage agents (incl. Behavior, Connectors, Phone numbers, Config pages), Voice & audio, Run/test/inspect (Debug chat, Conversations, Test suites, Outbound calling), Monitor, and agent infrastructure (MCP-servers-on-an-agent, Secrets).
- **Removes the non-functional `?tools=` filter.** Live test returned all tools regardless of the query string. Documents least-privilege **API-key scoping** as the mechanism that actually restricts what a client can do.
- **Alerts flagged enterprise-only** (absent on self-serve Studio).
- Tool names stay **kebab-case** (per #577, already on main).
- Fixed cross-page anchors so links resolve on `main`: `quickstart#3-verify` and `security#restrict-the-tool-surface`.

## Notes

- Content mirrors the validated work on `docs/mcp-quickstart-commands-capabilities` (#572), which did not reach `main`. Scoped to `capabilities.mdx` only.
- Two `{/* REVIEW */}` breadcrumbs are retained pending @joseph.perez's confirmation of the public grouping — safe to clear on sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)