### PR TITLE
docs: redesign home landing page + ADK GitHub link

### DIFF
--- a/adk/index.mdx
+++ b/adk/index.mdx
@@ -9,6 +9,10 @@ Build and edit Agent Studio projects locally with the **PolyAI ADK**, then push 
 
 The ADK gives you a local, Git-like workflow for Agent Studio projects: pull, edit with standard tooling, validate, and push.
 
+<Card title="View the ADK on GitHub" icon="github" href="https://github.com/polyai/adk" horizontal>
+  Source code, issues, and releases for the `polyai-adk` CLI.
+</Card>
+
 ## From zero to a local project
 
 A few commands take you from an empty machine to a working local copy of your agent:

--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -13,7 +13,7 @@ keywords:
 Create an account, build an agent, add knowledge, test it, and deploy. Five steps.
 
 <Tip>
-**Project admin?** [Studio Assistant](/studio-assistant/introduction) (Beta, admin-only) is the fastest way to scaffold an agent — describe what you want and it generates flows, topics, entities, and settings on a branch you can review. The manual steps below still work for any role.
+**Project admin?** [Studio Assistant](/studio-assistant/introduction) (admin-only) is the fastest way to scaffold an agent — describe what you want and it generates flows, topics, entities, and settings on a branch you can review. The manual steps below still work for any role.
 </Tip>
 
 ## Prerequisites

--- a/home.mdx
+++ b/home.mdx
@@ -15,42 +15,96 @@ keywords:
   - agentic platform
 ---
 
-<Frame>
-  <img src="/images/home/front-page-graphic.png" alt="PolyAI platform documentation" style={{ display: 'block', margin: '0 auto', maxWidth: '1200px', width: '100%' }} />
-</Frame>
+{/* ─────────────────────────  INTRO  ───────────────────────── */}
 
-## Welcome to PolyAI
+<span className="home-eyebrow">PolyAI Platform · Documentation</span>
 
-PolyAI is the Agentic Dialog Platform for building voice and chat agents that complete real customer tasks — taking bookings, processing payments, filing claims, handling escalations — across 24+ languages, with sub-300ms responses.
+<p className="home-lede">
+  The Agentic Dialog Platform for voice and chat agents that complete real
+  tasks — bookings, payments, claims, escalations — across 24+ languages.
+</p>
 
-- **Built for resolution, not deflection.** [Raven](/agent-settings/raven), [flows](/flows/introduction), and [grounded knowledge](/managed-topics/introduction) work together so the agent finishes the task.
-- **Voice-first and multilingual.** Sub-300ms responses across 24+ languages.
-- **Three surfaces for the same agent.** [Agent Studio](/get-started/introduction) for visual configuration, the [ADK](/extend/adk) for a local Git-based workflow, and the [REST APIs](/api-reference/introduction) for programmatic control.
-- **Test before promoting.** Every edit lands in a [shareable test environment](/widgets/test) before it reaches production.
+{/* ─────────────────────────  BENTO  ───────────────────────── */}
 
-If you're new, start with the [quickstart](/get-started/quickstart) to build a working agent in under 10 minutes.
+<div className="home-bento">
 
-## Where do you want to start?
+  {/* Hero — the one brand-tinted, taller tile */}
+  <div className="home-tile tile-hero">
+    <h2>From first draft to production.</h2>
+    <p>
+      Configure behavior, knowledge, voice, and flows — then test every change
+      in a shareable environment before it reaches production.
+    </p>
+    <div className="home-cta-row">
+      <a href="/get-started/quickstart" className="home-btn home-btn-primary">
+        <Icon icon="rocket" iconType="solid" size={15} color="#1f3a04" /> Start the quickstart
+      </a>
+      <a href="/platform/introduction" className="home-btn home-btn-ghost">
+        Platform overview →
+      </a>
+    </div>
+    <div className="home-metrics">
+      <span><b>24+</b> languages</span>
+      <span><b>300ms</b> responses</span>
+      <span><b>99.994%</b> uptime</span>
+    </div>
+  </div>
 
-<CardGroup cols={2}>
-  <Card title="Build with Studio Assistant" icon="wand-magic-sparkles" href="/studio-assistant/introduction">
-    Describe your agent in natural language. Beta — [admin-only](/user-management/access-control-scope) on enterprise clusters.
+  {/* API reference */}
+  <a href="/api-reference/introduction" className="home-tile tile-side">
+    <span className="home-tile-icon"><Icon icon="code" iconType="solid" size={18} color="#4a7c10" /></span>
+    <h3>API reference</h3>
+    <p className="home-tile-desc">Three REST API families to build, run, and observe agents.</p>
+    <span className="home-tile-arrow">Explore APIs →</span>
+  </a>
+
+  {/* Studio Assistant */}
+  <a href="/studio-assistant/introduction" className="home-tile tile-side">
+    <span className="home-tile-icon"><Icon icon="wand-magic-sparkles" iconType="solid" size={18} color="#4a7c10" /></span>
+    <h3>Studio Assistant</h3>
+    <p className="home-tile-desc">Describe your agent in natural language and draft it in minutes.</p>
+    <span className="home-tile-arrow">Try the beta →</span>
+  </a>
+
+  {/* Code / ADK tile */}
+  <div className="home-tile tile-code tile-half">
+    <div className="tile-code-head">
+      <Icon icon="terminal" iconType="solid" size={14} color="var(--home-muted)" /> Build like an engineer — the ADK
+    </div>
+    <pre>{['# pull agent config, edit locally, ship it', '$ polyai pull my-agent', '$ polyai push --env sandbox', '$ polyai test run ./suite'].join('\n')}</pre>
+  </div>
+
+  {/* What's new */}
+  <a href="/get-started/whats-new" className="home-tile tile-half">
+    <span className="home-pill"><Icon icon="sparkles" iconType="solid" size={11} color="#4a7c10" /> New</span>
+    <h3>Agent Studio has a new look</h3>
+    <p className="home-tile-desc">
+      A refreshed layout, dark mode, and the Studio Assistant side panel. See everything that changed in this release.
+    </p>
+    <span className="home-tile-arrow">Read what's new →</span>
+  </a>
+
+</div>
+
+{/* ─────────────────────────  CHOOSE HOW TO BUILD  ───────────────────────── */}
+
+## Choose how to build
+
+<p className="home-lede" style={{ marginBottom: '1.25rem' }}>
+  Same agent, three surfaces — mix them at any time.
+</p>
+
+<CardGroup cols={3}>
+  <Card title="Agent Studio" icon="browser" href="/get-started/introduction">
+    **No-code & low-code.** Configure your agent visually in the browser — the fastest way to something working.
   </Card>
-  <Card title="Build an agent with or without code" icon="browser" href="/get-started/introduction">
-    Low-code and no-code agent building in Agent Studio.
+  <Card title="ADK" icon="terminal" href="/adk">
+    **Local Git workflow.** Pull, edit, and push config as YAML and Python. Review in PRs, ship from your terminal.
   </Card>
-  <Card title="Maintain or update your agent" icon="wrench" href="/learn/maintain/introduction">
-    Edit knowledge, voice, closures, and more on a live Agent Studio agent.
-  </Card>
-  <Card title="Build like an engineer" icon="terminal" href="/extend/adk">
-    Pull, edit, and push agent configuration as YAML and Python files with the ADK CLI.
-  </Card>
-  <Card title="Agent Studio APIs" icon="code" href="/api-reference/introduction">
-    REST APIs to update and configure agents programmatically.
+  <Card title="REST APIs" icon="code" href="/api-reference/introduction">
+    **Programmatic control.** Build, run, and observe agents from your own systems. No SDK required.
   </Card>
 </CardGroup>
-
-New here? See the [platform overview](/platform/introduction) for how Agent Studio, the ADK, and APIs fit together, or jump straight into the [quickstart](/get-started/quickstart).
 
 ## Build your agent
 

--- a/home.mdx
+++ b/home.mdx
@@ -78,9 +78,9 @@ you work — and mix them at any time.
     <span className="term-title">Prefer code? Use the ADK</span>
   </div>
   <div className="term-body">
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># link a local project</span></div>
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly pull</span><span className="term-c"># your agent → local files</span></div>
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship edits back to Studio</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># create a local copy of your agent</span></div>
+    <div className="term-line"><span className="term-cmd" /><span className="term-c"># edit flows, topics, and functions</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship your changes to Agent Studio</span></div>
   </div>
   <a href="/adk" className="term-foot">Explore the ADK →</a>
 </div>

--- a/home.mdx
+++ b/home.mdx
@@ -15,166 +15,107 @@ keywords:
   - agentic platform
 ---
 
-{/* ─────────────────────────  INTRO  ───────────────────────── */}
+{/* ─────────────────────────  HERO  ───────────────────────── */}
 
-<span className="home-eyebrow">PolyAI Platform · Documentation</span>
-
-<p className="home-lede">
-  The Agentic Dialog Platform for voice and chat agents that complete real
-  tasks — bookings, payments, claims, escalations — across 24+ languages.
-</p>
-
-{/* ─────────────────────────  BENTO  ───────────────────────── */}
-
-<div className="home-bento">
-
-  {/* Hero */}
-  <div className="home-tile tile-hero">
-    <h2>From first draft to production.</h2>
-    <p>
-      Configure behavior, knowledge, voice, and flows in Agent Studio — then
-      test every change in a shareable environment before it ships.
-    </p>
-    <div className="home-cta-row">
-      <a href="/get-started/quickstart" className="home-btn home-btn-primary">
-        <Icon icon="rocket" iconType="solid" size={15} color="#1f3a04" /> Start the quickstart
-      </a>
-      <a href="/platform/introduction" className="home-btn home-btn-ghost">
-        Platform overview →
-      </a>
-    </div>
+<div className="home-hero">
+  <span className="home-eyebrow">PolyAI Platform · Documentation</span>
+  <h2 className="home-hero-title">From first draft to production.</h2>
+  <p className="home-hero-sub">
+    PolyAI is the Agentic Dialog Platform for voice and chat agents that complete
+    real customer tasks — bookings, payments, claims, escalations — across 24+
+    languages, at sub-300ms latency. Built for resolution, not deflection.
+  </p>
+  <div className="home-cta-row">
+    <a href="/get-started/quickstart" className="home-btn home-btn-primary">
+      <Icon icon="rocket" iconType="solid" size={15} color="#1f3a04" /> Start the quickstart
+    </a>
+    <a href="/platform/introduction" className="home-btn home-btn-ghost">
+      Platform overview →
+    </a>
   </div>
-
-  {/* ADK terminal */}
-  <div className="home-tile tile-adk">
-    <div className="term-head">
-      <span className="term-dot" /><span className="term-dot" /><span className="term-dot" />
-      <span className="term-title">Prefer code? Use the ADK</span>
-    </div>
-    <div className="term-body">
-      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># link a local project</span></div>
-      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly pull</span><span className="term-c"># your agent → local files</span></div>
-      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship edits back to Studio</span></div>
-    </div>
-    <a href="/adk" className="term-foot">Explore the ADK →</a>
-  </div>
-
-  {/* API reference */}
-  <a href="/api-reference/introduction" className="home-tile tile-nav">
-    <span className="home-tile-icon"><Icon icon="code" iconType="solid" size={18} color="#4a7c10" /></span>
-    <h3>API reference</h3>
-    <p className="home-tile-desc">Three REST API families to build, run, and observe agents.</p>
-    <span className="home-tile-arrow">Explore APIs →</span>
-  </a>
-
-  {/* Studio Assistant */}
-  <a href="/studio-assistant/introduction" className="home-tile tile-nav">
-    <span className="home-tile-icon"><Icon icon="wand-magic-sparkles" iconType="solid" size={18} color="#4a7c10" /></span>
-    <h3>Studio Assistant</h3>
-    <p className="home-tile-desc">Describe your agent in natural language and draft it in minutes.</p>
-    <span className="home-tile-arrow">Try the beta →</span>
-  </a>
-
-  {/* What's new */}
-  <a href="/get-started/whats-new" className="home-tile tile-nav">
-    <span className="home-pill"><Icon icon="sparkles" iconType="solid" size={11} color="#4a7c10" /> New</span>
-    <h3>Agent Studio has a new look</h3>
-    <p className="home-tile-desc">A refreshed layout, dark mode, and the Studio Assistant side panel.</p>
-    <span className="home-tile-arrow">Read what's new →</span>
-  </a>
-
 </div>
 
-{/* ─────────────────────────  CHOOSE HOW TO BUILD  ───────────────────────── */}
+{/* ─────────────────────────  HOW IT WORKS  ───────────────────────── */}
 
-## Choose how to build
+## How a PolyAI agent works
 
-<p className="home-lede" style={{ marginBottom: '1.25rem' }}>
-  Same agent, three surfaces — mix them at any time.
-</p>
+Every agent handles a conversation the same way: it listens, decides what to do
+from your configuration and knowledge, then responds — in under 300ms, in 24+
+languages. [Raven](/behavior/models/raven), our voice-native model, drives each turn.
+
+You shape that behavior across four areas:
+
+- **Behavior** — the agent's personality, rules, and [guardrails](/behavior/guardrails/introduction).
+- **Knowledge** — grounded [FAQs and sources](/knowledge/faqs/introduction) so answers stay accurate, not hallucinated.
+- **Flows** — [multi-step logic](/flows/introduction) for tasks like booking, payment, or verification.
+- **Voice** — natural [text-to-speech](/voice-channel/introduction) tuned for real phone conversations.
+
+Every change lands in a [shareable test environment](/environments-and-versions/introduction)
+before it reaches production — so you can try the agent on a real call before your customers do.
+
+{/* ─────────────────────────  WAYS TO BUILD  ───────────────────────── */}
+
+## Choose how you build
+
+The same agent is available through three surfaces. Start in whichever fits how
+you work — and mix them at any time.
 
 <CardGroup cols={3}>
   <Card title="Agent Studio" icon="browser" href="/get-started/introduction">
-    **No-code & low-code.** Configure your agent visually in the browser — the fastest way to something working.
+    **No-code & low-code.** Configure behavior, knowledge, voice, and flows visually in the browser.
   </Card>
   <Card title="ADK" icon="terminal" href="/adk">
-    **Local Git workflow.** Pull, edit, and push config as YAML and Python. Review in PRs, ship from your terminal.
+    **Code & Git.** Pull your agent into local YAML and Python, edit in your IDE, and ship from the CLI.
   </Card>
   <Card title="REST APIs" icon="code" href="/api-reference/introduction">
-    **Programmatic control.** Build, run, and observe agents from your own systems. No SDK required.
+    **Programmatic.** Build, run, and observe agents from your own systems — no SDK required.
   </Card>
 </CardGroup>
 
-## Build your agent
+<div className="home-term">
+  <div className="term-head">
+    <span className="term-dot" /><span className="term-dot" /><span className="term-dot" />
+    <span className="term-title">Prefer code? Use the ADK</span>
+  </div>
+  <div className="term-body">
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># link a local project</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly pull</span><span className="term-c"># your agent → local files</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship edits back to Studio</span></div>
+  </div>
+  <a href="/adk" className="term-foot">Explore the ADK →</a>
+</div>
 
-Set up your agent's personality, knowledge, voice, and conversation flows.
+<Note>
+  **New — Studio Assistant (beta).** Describe your agent in natural language and let it draft the first version for you. [Get started](/studio-assistant/introduction).
+</Note>
 
-<CardGroup cols={3}>
-  <Card title="Behavior" icon="sliders" href="/behavior/introduction">
-    Configure personality and rules
-  </Card>
-  <Card title="Knowledge" icon="brain" href="/knowledge/faqs/introduction">
-    FAQs, sources, and variants
-  </Card>
-  <Card title="Voice" icon="microphone" href="/voice-channel/introduction">
-    Customize text-to-speech and audio
-  </Card>
-  <Card title="Messaging" icon="message" href="/messaging-channel/introduction">
-    Deploy chat and SMS alongside voice
-  </Card>
-  <Card title="Flows" icon="diagram-project" href="/flows/introduction">
-    Build multi-step conversations
-  </Card>
-  <Card title="Call handoffs" icon="phone-arrow-right" href="/voice-channel/handoffs">
-    Transfer users to human agents
-  </Card>
-</CardGroup>
+{/* ─────────────────────────  USE CASES  ───────────────────────── */}
 
-## Integrations ecosystem
+## What you can build
 
-Connect your agent to telephony, CRM, payments, and other systems. See the [full catalog](/integrations/introduction).
+PolyAI agents run in production for banks, hotels, healthcare providers, and
+retailers — handling the calls and chats that used to need a person:
+
+- **Bookings & reservations** — check availability, take a reservation, modify or cancel.
+- **Payments** — take secure payments and process refunds mid-conversation.
+- **Claims & servicing** — file a claim, check a balance, update an account.
+- **Escalations** — resolve what it can, then [hand off](/voice-channel/handoffs) to a human with full context.
+
+{/* ─────────────────────────  EXPLORE  ───────────────────────── */}
+
+## Explore the docs
 
 <CardGroup cols={2}>
-  <Card title="Telephony" icon="headset" href="/integrations/voice/introduction">
-    Five9, NICE CXone, Twilio, Amazon Connect, Genesys, Dialpad, and more
+  <Card title="Build your agent" icon="sliders" href="/behavior/introduction">
+    Behavior, knowledge, voice, flows, and messaging channels.
   </Card>
-  <Card title="CRM and ticketing" icon="ticket" href="/integrations/introduction">
-    Salesforce, ServiceNow, Zendesk: sync data and create tickets during calls
+  <Card title="Integrations" icon="plug" href="/integrations/introduction">
+    Telephony, CRM, payments, and custom or MCP connectors.
   </Card>
-  <Card title="Managed services" icon="gear" href="/integrations/managed-services">
-    Pre-built connectors for payments, reservations, and data
+  <Card title="Deploy & monitor" icon="chart-line" href="/environments-and-versions/introduction">
+    Environments, dashboards, and conversation review.
   </Card>
-  <Card title="Custom and MCP" icon="code" href="/integrations/api/introduction">
-    Build your own integrations through HTTP, Python, or Model Context Protocol
-  </Card>
-</CardGroup>
-
-## Deploy and monitor
-
-Track performance, review conversations, and manage your deployment pipeline.
-
-<CardGroup cols={3}>
-  <Card title="Environments" icon="code-branch" href="/environments-and-versions/introduction">
-    Manage sandbox to production
-  </Card>
-  <Card title="Dashboards" icon="chart-line" href="/analytics/dashboards/introduction">
-    Track performance metrics
-  </Card>
-  <Card title="Conversations" icon="messages" href="/analytics/conversations/introduction">
-    Review and diagnose calls
-  </Card>
-</CardGroup>
-
-## Resources
-
-<CardGroup cols={3}>
-  <Card title="Maintain" icon="wrench" href="/learn/maintain/introduction">
-    Ongoing agent maintenance
-  </Card>
-  <Card title="Troubleshooting" icon="circle-question" href="/troubleshoot/faq">
-    Common issues and solutions
-  </Card>
-  <Card title="Release notes" icon="megaphone" href="/releases/overview">
-    Latest features and updates
+  <Card title="Resources" icon="life-ring" href="/learn/maintain/introduction">
+    Maintenance, troubleshooting, and release notes.
   </Card>
 </CardGroup>

--- a/home.mdx
+++ b/home.mdx
@@ -80,8 +80,8 @@ you work — and mix them at any time.
   <div className="term-body">
     <div className="term-line"><span className="term-c"># needs uv + Python 3.14</span></div>
     <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>pip install polyai-adk</span></div>
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly start</span><span className="term-c"># sign in and create your first agent</span></div>
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># pull it local, then edit as code</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly start</span><span className="term-c"># new account, key & first agent</span></div>
+    <div className="term-line"><span className="term-c"># edit flows, topics, and functions locally</span></div>
     <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship your changes to Agent Studio</span></div>
   </div>
   <a href="/adk" className="term-foot">Explore the ADK →</a>

--- a/home.mdx
+++ b/home.mdx
@@ -86,7 +86,7 @@ you work — and mix them at any time.
 </div>
 
 <Note>
-  **New — Studio Assistant (beta).** Describe your agent in natural language and let it draft the first version for you. [Get started](/studio-assistant/introduction).
+  **New — Studio Assistant.** Describe your agent in natural language and let it draft the first version for you. [Get started](/studio-assistant/introduction).
 </Note>
 
 {/* ─────────────────────────  USE CASES  ───────────────────────── */}

--- a/home.mdx
+++ b/home.mdx
@@ -28,12 +28,12 @@ keywords:
 
 <div className="home-bento">
 
-  {/* Hero — the one brand-tinted, taller tile */}
+  {/* Hero */}
   <div className="home-tile tile-hero">
     <h2>From first draft to production.</h2>
     <p>
-      Configure behavior, knowledge, voice, and flows — then test every change
-      in a shareable environment before it reaches production.
+      Configure behavior, knowledge, voice, and flows in Agent Studio — then
+      test every change in a shareable environment before it ships.
     </p>
     <div className="home-cta-row">
       <a href="/get-started/quickstart" className="home-btn home-btn-primary">
@@ -43,15 +43,24 @@ keywords:
         Platform overview →
       </a>
     </div>
-    <div className="home-metrics">
-      <span><b>24+</b> languages</span>
-      <span><b>300ms</b> responses</span>
-      <span><b>99.994%</b> uptime</span>
+  </div>
+
+  {/* ADK terminal */}
+  <div className="home-tile tile-adk">
+    <div className="term-head">
+      <span className="term-dot" /><span className="term-dot" /><span className="term-dot" />
+      <span className="term-title">Prefer code? Use the ADK</span>
     </div>
+    <div className="term-body">
+      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># link a local project</span></div>
+      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly pull</span><span className="term-c"># your agent → local files</span></div>
+      <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship edits back to Studio</span></div>
+    </div>
+    <a href="/adk" className="term-foot">Explore the ADK →</a>
   </div>
 
   {/* API reference */}
-  <a href="/api-reference/introduction" className="home-tile tile-side">
+  <a href="/api-reference/introduction" className="home-tile tile-nav">
     <span className="home-tile-icon"><Icon icon="code" iconType="solid" size={18} color="#4a7c10" /></span>
     <h3>API reference</h3>
     <p className="home-tile-desc">Three REST API families to build, run, and observe agents.</p>
@@ -59,28 +68,18 @@ keywords:
   </a>
 
   {/* Studio Assistant */}
-  <a href="/studio-assistant/introduction" className="home-tile tile-side">
+  <a href="/studio-assistant/introduction" className="home-tile tile-nav">
     <span className="home-tile-icon"><Icon icon="wand-magic-sparkles" iconType="solid" size={18} color="#4a7c10" /></span>
     <h3>Studio Assistant</h3>
     <p className="home-tile-desc">Describe your agent in natural language and draft it in minutes.</p>
     <span className="home-tile-arrow">Try the beta →</span>
   </a>
 
-  {/* Code / ADK tile */}
-  <div className="home-tile tile-code tile-half">
-    <div className="tile-code-head">
-      <Icon icon="terminal" iconType="solid" size={14} color="var(--home-muted)" /> Build like an engineer — the ADK
-    </div>
-    <pre>{['# pull agent config, edit locally, ship it', '$ polyai pull my-agent', '$ polyai push --env sandbox', '$ polyai test run ./suite'].join('\n')}</pre>
-  </div>
-
   {/* What's new */}
-  <a href="/get-started/whats-new" className="home-tile tile-half">
+  <a href="/get-started/whats-new" className="home-tile tile-nav">
     <span className="home-pill"><Icon icon="sparkles" iconType="solid" size={11} color="#4a7c10" /> New</span>
     <h3>Agent Studio has a new look</h3>
-    <p className="home-tile-desc">
-      A refreshed layout, dark mode, and the Studio Assistant side panel. See everything that changed in this release.
-    </p>
+    <p className="home-tile-desc">A refreshed layout, dark mode, and the Studio Assistant side panel.</p>
     <span className="home-tile-arrow">Read what's new →</span>
   </a>
 

--- a/home.mdx
+++ b/home.mdx
@@ -78,8 +78,10 @@ you work — and mix them at any time.
     <span className="term-title">Prefer code? Use the ADK</span>
   </div>
   <div className="term-body">
-    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># create a local copy of your agent</span></div>
-    <div className="term-line"><span className="term-cmd" /><span className="term-c"># edit flows, topics, and functions</span></div>
+    <div className="term-line"><span className="term-c"># needs uv + Python 3.14</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>pip install polyai-adk</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly start</span><span className="term-c"># sign in and create your first agent</span></div>
+    <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly init</span><span className="term-c"># pull it local, then edit as code</span></div>
     <div className="term-line"><span className="term-cmd"><span className="term-p">{'$'}</span>poly push</span><span className="term-c"># ship your changes to Agent Studio</span></div>
   </div>
   <a href="/adk" className="term-foot">Explore the ADK →</a>

--- a/learn/maintain/introduction.mdx
+++ b/learn/maintain/introduction.mdx
@@ -10,7 +10,7 @@ sidebarTitle: "Home"
 Use this section when you have a live agent and need to make a targeted change — updating a topic, changing a voice, fixing a function, or adjusting a behavior. Each guide is scoped to a single task.
 
 <Tip>
-**Drive most maintenance through [Studio Assistant](/studio-assistant/introduction) (Beta).** Project admins on enterprise clusters can ask Studio Assistant in natural language to update topics, tweak flows, rewrite welcome messages, or fix a behavior that surfaced on a real call. Every change lands on a branch you review before merging — see the [prompting guide](/studio-assistant/prompting) for patterns that work well. Access is **admin-only** during Beta — see [Role permissions](/user-management/access-control-scope).
+**Drive most maintenance through [Studio Assistant](/studio-assistant/introduction).** Project admins on enterprise clusters can ask Studio Assistant in natural language to update topics, tweak flows, rewrite welcome messages, or fix a behavior that surfaced on a real call. Every change lands on a branch you review before merging — see the [prompting guide](/studio-assistant/prompting) for patterns that work well. Access is **admin-only** — see [Role permissions](/user-management/access-control-scope).
 </Tip>
 
 ## Quick decision guide
@@ -32,7 +32,7 @@ Use this section when you have a live agent and need to make a targeted change �
 
 <CardGroup cols={2}>
   <Card title="Studio Assistant" href="/studio-assistant/introduction" icon="wand-magic-sparkles">
-    Describe the change you want in plain language — Studio Assistant edits topics, flows, entities, and settings on a branch you review. <span className="badge">Beta</span>
+    Describe the change you want in plain language — Studio Assistant edits topics, flows, entities, and settings on a branch you review.
   </Card>
   <Card title="FAQs" href="/learn/maintain/knowledge-base" icon="book">
     Edit existing answers or add new topics to guide your agent's responses.

--- a/styles.css
+++ b/styles.css
@@ -323,7 +323,7 @@ html.dark .home-hero {
 
 .term-cmd {
   flex: none;
-  min-width: 5.5rem;
+  min-width: 6.5rem;
   color: var(--home-fg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -378,7 +378,7 @@ html[data-current-path="/home"] .mdx-content > ul > li {
 }
 
 /* extra air around the terminal and the beta callout */
-html[data-current-path="/home"] .home-term { margin: 2.25rem 0 0.5rem; }
+html[data-current-path="/home"] .home-term { margin: 2.25rem auto 0.5rem; }
 
 @media (max-width: 640px) {
   .home-hero { padding: 1.8rem 1.5rem 2rem; }

--- a/styles.css
+++ b/styles.css
@@ -175,6 +175,259 @@ nav [data-testid="tag"]:has-text("Advanced") {
   color: inherit;
 }
 
+/* ── Home landing: asymmetric bento ──────────────────────────────────────── */
+
+:root {
+  --home-tile-bg: #ffffff;
+  --home-tile-border: rgba(22, 22, 23, 0.09);
+  --home-fg: #161617;
+  --home-muted: #5b6270;
+  --home-eyebrow: #4a7c10;
+  --home-code-bg: #fbfcf6;
+}
+
+html.dark {
+  --home-tile-bg: #17181a;
+  --home-tile-border: rgba(255, 255, 255, 0.08);
+  --home-fg: #f4f5ef;
+  --home-muted: #99a0ab;
+  --home-eyebrow: #bcdb4d;
+  --home-code-bg: #101110;
+}
+
+.home-eyebrow {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--home-eyebrow);
+  margin-bottom: 0.4rem;
+}
+
+.home-lede {
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--home-muted);
+  max-width: 46rem;
+  margin: 0.1rem 0 0;
+}
+
+.home-bento {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-auto-rows: minmax(0, auto);
+  gap: 1rem;
+  margin: 1.75rem 0 2.5rem;
+}
+
+.home-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.4rem 1.5rem;
+  border-radius: 16px;
+  background: var(--home-tile-bg);
+  border: 1px solid var(--home-tile-border);
+  color: var(--home-fg);
+  text-decoration: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+a.home-tile:hover {
+  border-color: rgba(74, 124, 16, 0.45);
+  box-shadow: 0 14px 34px -22px rgba(74, 124, 16, 0.45);
+  transform: translateY(-2px);
+}
+
+html.dark a.home-tile:hover {
+  border-color: rgba(217, 238, 80, 0.4);
+  box-shadow: 0 14px 34px -22px rgba(0, 0, 0, 0.7);
+}
+
+/* Column spans — the asymmetry lives here */
+.tile-hero { grid-column: span 4; grid-row: span 2; }
+.tile-side { grid-column: span 2; }
+.tile-half { grid-column: span 3; }
+
+.tile-hero {
+  padding: 1.9rem 2rem;
+  background: linear-gradient(158deg, rgba(217, 238, 80, 0.16), rgba(74, 124, 16, 0.05) 70%);
+  border-color: rgba(74, 124, 16, 0.22);
+}
+
+html.dark .tile-hero {
+  background: linear-gradient(158deg, rgba(74, 124, 16, 0.28), rgba(217, 238, 80, 0.04) 75%);
+  border-color: rgba(217, 238, 80, 0.18);
+}
+
+.tile-hero h2 {
+  font-size: 2rem;
+  line-height: 1.12;
+  font-weight: 700;
+  margin: 0 0 0.6rem;
+  color: var(--home-fg);
+}
+
+.tile-hero p {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--home-muted);
+  margin: 0 0 1.3rem;
+  max-width: 32rem;
+}
+
+.home-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1.6rem;
+}
+
+.home-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.62rem 1.1rem;
+  border-radius: 11px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.home-btn-primary {
+  background: #d9ee50;
+  color: #1f3a04;
+  box-shadow: 0 8px 22px -10px rgba(74, 124, 16, 0.7);
+}
+
+.home-btn-primary:hover { transform: translateY(-1px); }
+
+.home-btn-ghost {
+  background: transparent;
+  color: var(--home-fg);
+  border: 1px solid var(--home-tile-border);
+  font-weight: 500;
+}
+
+.home-btn-ghost:hover { border-color: rgba(74, 124, 16, 0.45); }
+
+.home-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin-top: 1.3rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--home-tile-border);
+  font-size: 0.82rem;
+  color: var(--home-muted);
+}
+
+.home-metrics b { color: var(--home-fg); font-weight: 600; }
+
+/* Small companion tiles */
+.home-tile-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(74, 124, 16, 0.1);
+  margin-bottom: 0.85rem;
+}
+
+html.dark .home-tile-icon { background: rgba(217, 238, 80, 0.12); }
+
+.home-tile h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+  color: var(--home-fg);
+}
+
+.home-tile p.home-tile-desc {
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--home-muted);
+  margin: 0;
+}
+
+.home-tile-arrow {
+  margin-top: auto;
+  padding-top: 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--home-eyebrow);
+}
+
+/* Code tile */
+.tile-code { padding: 0; overflow: hidden; }
+
+.tile-code .tile-code-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.2rem;
+  border-bottom: 1px solid var(--home-tile-border);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--home-muted);
+}
+
+.tile-code pre {
+  margin: 0;
+  padding: 1.1rem 1.3rem;
+  background: var(--home-code-bg);
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 0.82rem;
+  line-height: 1.75;
+  color: var(--home-fg);
+  overflow-x: auto;
+}
+
+.tile-code .c-prompt { color: #4a7c10; }
+html.dark .tile-code .c-prompt { color: #bcdb4d; }
+.tile-code .c-comment { color: var(--home-muted); }
+
+/* "New" pill in the news tile */
+.home-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(74, 124, 16, 0.12);
+  color: var(--home-eyebrow);
+  margin-bottom: 0.7rem;
+}
+
+html.dark .home-pill { background: rgba(217, 238, 80, 0.14); }
+
+/* Tablet / narrow-content: 2-col, hero full width, keep some asymmetry */
+@media (max-width: 950px) {
+  .home-bento { grid-template-columns: repeat(2, 1fr); }
+  .tile-hero { grid-column: 1 / -1; grid-row: auto; }
+  .tile-side { grid-column: span 1; }
+  .tile-half { grid-column: 1 / -1; }
+}
+
+/* Mobile: single column */
+@media (max-width: 640px) {
+  .home-bento { grid-template-columns: 1fr; }
+  .home-bento > * { grid-column: 1 / -1 !important; grid-row: auto !important; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-tile, .home-btn { transition: none !important; transform: none !important; }
+}
+
 /* ── Hide the "Log in" button from the topbar ────────────────────────────── */
 
 #navbar a[href="/login"],

--- a/styles.css
+++ b/styles.css
@@ -345,10 +345,47 @@ html.dark .term-cmd .term-p { color: #bcdb4d; }
 .term-foot:hover { background: rgba(74, 124, 16, 0.06); }
 html.dark .term-foot:hover { background: rgba(217, 238, 80, 0.08); }
 
+/* Home-only rhythm: give the narrative room to breathe.
+   Scoped to /home so no other docs page is affected. Section headings are
+   direct children of .mdx-content; card titles (.not-prose) are nested. */
+html[data-current-path="/home"] .mdx-content {
+  max-width: 880px;
+}
+
+html[data-current-path="/home"] .home-hero {
+  margin: 1rem 0 4rem;
+  padding: 2.75rem 2.75rem 3rem;
+}
+
+html[data-current-path="/home"] .mdx-content > h2 {
+  margin-top: 4.5rem;
+  margin-bottom: 1.25rem;
+  scroll-margin-top: 6rem;
+}
+
+html[data-current-path="/home"] .mdx-content > p {
+  margin: 0 0 1.4rem;
+  line-height: 1.72;
+}
+
+html[data-current-path="/home"] .mdx-content > ul {
+  margin: 0.25rem 0 1.75rem;
+}
+
+html[data-current-path="/home"] .mdx-content > ul > li {
+  margin: 0.6rem 0;
+  line-height: 1.68;
+}
+
+/* extra air around the terminal and the beta callout */
+html[data-current-path="/home"] .home-term { margin: 2.25rem 0 0.5rem; }
+
 @media (max-width: 640px) {
   .home-hero { padding: 1.8rem 1.5rem 2rem; }
   .home-hero-title { font-size: 2rem; }
   .term-line { white-space: normal; }
+  html[data-current-path="/home"] .home-hero { padding: 1.9rem 1.6rem 2.1rem; margin-bottom: 3rem; }
+  html[data-current-path="/home"] .mdx-content > h2 { margin-top: 3.25rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/styles.css
+++ b/styles.css
@@ -175,7 +175,7 @@ nav [data-testid="tag"]:has-text("Advanced") {
   color: inherit;
 }
 
-/* ── Home landing: asymmetric bento ──────────────────────────────────────── */
+/* ── Home landing: narrative introduction ────────────────────────────────── */
 
 :root {
   --home-tile-bg: #ffffff;
@@ -205,86 +205,43 @@ html.dark {
   margin-bottom: 0.4rem;
 }
 
-.home-lede {
-  font-size: 1.05rem;
-  line-height: 1.5;
-  color: var(--home-muted);
-  max-width: 46rem;
-  margin: 0.1rem 0 0;
-}
-
-.home-bento {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  gap: 1rem;
-  margin: 1.75rem 0 2.5rem;
-  align-items: stretch;
-}
-
-.home-tile {
+/* Hero band */
+.home-hero {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  padding: 1.4rem 1.5rem;
-  border-radius: 16px;
-  background: var(--home-tile-bg);
-  border: 1px solid var(--home-tile-border);
-  color: var(--home-fg);
-  text-decoration: none;
-  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
-}
-
-a.home-tile:hover {
-  border-color: rgba(74, 124, 16, 0.45);
-  box-shadow: 0 14px 34px -22px rgba(74, 124, 16, 0.45);
-  transform: translateY(-2px);
-}
-
-html.dark a.home-tile:hover {
-  border-color: rgba(217, 238, 80, 0.4);
-  box-shadow: 0 14px 34px -22px rgba(0, 0, 0, 0.7);
-}
-
-/* Column spans — the asymmetry lives here.
-   Row 1: hero (7) + ADK terminal (5).  Row 2: three nav tiles (4 each). */
-.tile-hero { grid-column: span 6; }
-.tile-adk  { grid-column: span 6; }
-.tile-nav  { grid-column: span 4; }
-
-.tile-hero {
-  justify-content: center;
-  padding: 2rem 2.1rem;
+  margin: 0.75rem 0 3rem;
+  padding: 2.4rem 2.4rem 2.6rem;
+  border-radius: 20px;
   background: linear-gradient(158deg, rgba(217, 238, 80, 0.16), rgba(74, 124, 16, 0.05) 70%);
-  border-color: rgba(74, 124, 16, 0.22);
+  border: 1px solid rgba(74, 124, 16, 0.22);
 }
 
-html.dark .tile-hero {
+html.dark .home-hero {
   background: linear-gradient(158deg, rgba(74, 124, 16, 0.28), rgba(217, 238, 80, 0.04) 75%);
   border-color: rgba(217, 238, 80, 0.18);
 }
 
-.tile-hero h2 {
-  font-size: 2.1rem;
-  line-height: 1.1;
+.home-hero-title {
+  font-size: 2.4rem;
+  line-height: 1.08;
   font-weight: 700;
   letter-spacing: -0.01em;
-  margin: 0 0 0.7rem;
+  margin: 0.5rem 0 0.85rem;
   color: var(--home-fg);
+  max-width: 18ch;
 }
 
-.tile-hero p {
-  font-size: 1rem;
+.home-hero-sub {
+  font-size: 1.1rem;
   line-height: 1.55;
   color: var(--home-muted);
-  margin: 0;
-  max-width: 30rem;
+  margin: 0 0 1.7rem;
+  max-width: 62ch;
 }
 
 .home-cta-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  margin-top: 1.6rem;
 }
 
 .home-btn {
@@ -296,7 +253,7 @@ html.dark .tile-hero {
   font-size: 0.95rem;
   font-weight: 600;
   text-decoration: none;
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
 }
 
 .home-btn-primary {
@@ -316,44 +273,15 @@ html.dark .tile-hero {
 
 .home-btn-ghost:hover { border-color: rgba(74, 124, 16, 0.45); }
 
-/* Small companion tiles */
-.home-tile-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(74, 124, 16, 0.1);
-  margin-bottom: 0.85rem;
+/* ADK terminal */
+.home-term {
+  max-width: 620px;
+  margin: 1.75rem 0 0;
+  border-radius: 14px;
+  border: 1px solid var(--home-tile-border);
+  background: var(--home-tile-bg);
+  overflow: hidden;
 }
-
-html.dark .home-tile-icon { background: rgba(217, 238, 80, 0.12); }
-
-.home-tile h3 {
-  font-size: 1.05rem;
-  font-weight: 600;
-  margin: 0 0 0.25rem;
-  color: var(--home-fg);
-}
-
-.home-tile p.home-tile-desc {
-  font-size: 0.88rem;
-  line-height: 1.5;
-  color: var(--home-muted);
-  margin: 0;
-}
-
-.home-tile-arrow {
-  margin-top: auto;
-  padding-top: 0.9rem;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--home-eyebrow);
-}
-
-/* ADK terminal tile */
-.tile-adk { padding: 0; overflow: hidden; }
 
 .term-head {
   display: flex;
@@ -378,8 +306,6 @@ html.dark .home-tile-icon { background: rgba(217, 238, 80, 0.12); }
 }
 
 .term-body {
-  flex: 1;
-  margin: 0;
   padding: 1.1rem 1.3rem;
   background: var(--home-code-bg);
   font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
@@ -406,6 +332,7 @@ html.dark .term-cmd .term-p { color: #bcdb4d; }
 .term-c { color: var(--home-muted); }
 
 .term-foot {
+  display: block;
   padding: 0.85rem 1.3rem;
   border-top: 1px solid var(--home-tile-border);
   font-size: 0.85rem;
@@ -418,42 +345,16 @@ html.dark .term-cmd .term-p { color: #bcdb4d; }
 .term-foot:hover { background: rgba(74, 124, 16, 0.06); }
 html.dark .term-foot:hover { background: rgba(217, 238, 80, 0.08); }
 
-/* "New" pill in the news tile */
-.home-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  align-self: flex-start;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  background: rgba(74, 124, 16, 0.12);
-  color: var(--home-eyebrow);
-  margin-bottom: 0.7rem;
-}
-
-html.dark .home-pill { background: rgba(217, 238, 80, 0.14); }
-
-/* Tablet: hero + terminal stack full-width; nav tiles sit three-across */
-@media (max-width: 950px) {
-  .home-bento { grid-template-columns: repeat(6, 1fr); }
-  .tile-hero, .tile-adk { grid-column: 1 / -1; }
-  .tile-nav { grid-column: span 2; }
-}
-
-/* Mobile: single column */
 @media (max-width: 640px) {
-  .home-bento { grid-template-columns: 1fr; }
-  .home-bento > * { grid-column: 1 / -1 !important; }
+  .home-hero { padding: 1.8rem 1.5rem 2rem; }
+  .home-hero-title { font-size: 2rem; }
   .term-line { white-space: normal; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .home-tile, .home-btn { transition: none !important; transform: none !important; }
+  .home-btn { transition: none !important; transform: none !important; }
 }
+
 
 /* ── Hide the "Log in" button from the topbar ────────────────────────────── */
 

--- a/styles.css
+++ b/styles.css
@@ -215,10 +215,10 @@ html.dark {
 
 .home-bento {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  grid-auto-rows: minmax(0, auto);
+  grid-template-columns: repeat(12, 1fr);
   gap: 1rem;
   margin: 1.75rem 0 2.5rem;
+  align-items: stretch;
 }
 
 .home-tile {
@@ -245,13 +245,15 @@ html.dark a.home-tile:hover {
   box-shadow: 0 14px 34px -22px rgba(0, 0, 0, 0.7);
 }
 
-/* Column spans — the asymmetry lives here */
-.tile-hero { grid-column: span 4; grid-row: span 2; }
-.tile-side { grid-column: span 2; }
-.tile-half { grid-column: span 3; }
+/* Column spans — the asymmetry lives here.
+   Row 1: hero (7) + ADK terminal (5).  Row 2: three nav tiles (4 each). */
+.tile-hero { grid-column: span 6; }
+.tile-adk  { grid-column: span 6; }
+.tile-nav  { grid-column: span 4; }
 
 .tile-hero {
-  padding: 1.9rem 2rem;
+  justify-content: center;
+  padding: 2rem 2.1rem;
   background: linear-gradient(158deg, rgba(217, 238, 80, 0.16), rgba(74, 124, 16, 0.05) 70%);
   border-color: rgba(74, 124, 16, 0.22);
 }
@@ -262,19 +264,20 @@ html.dark .tile-hero {
 }
 
 .tile-hero h2 {
-  font-size: 2rem;
-  line-height: 1.12;
+  font-size: 2.1rem;
+  line-height: 1.1;
   font-weight: 700;
-  margin: 0 0 0.6rem;
+  letter-spacing: -0.01em;
+  margin: 0 0 0.7rem;
   color: var(--home-fg);
 }
 
 .tile-hero p {
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--home-muted);
-  margin: 0 0 1.3rem;
-  max-width: 32rem;
+  margin: 0;
+  max-width: 30rem;
 }
 
 .home-cta-row {
@@ -313,19 +316,6 @@ html.dark .tile-hero {
 
 .home-btn-ghost:hover { border-color: rgba(74, 124, 16, 0.45); }
 
-.home-metrics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem 1rem;
-  margin-top: 1.3rem;
-  padding-top: 1.1rem;
-  border-top: 1px solid var(--home-tile-border);
-  font-size: 0.82rem;
-  color: var(--home-muted);
-}
-
-.home-metrics b { color: var(--home-fg); font-weight: 600; }
-
 /* Small companion tiles */
 .home-tile-icon {
   width: 38px;
@@ -362,34 +352,71 @@ html.dark .home-tile-icon { background: rgba(217, 238, 80, 0.12); }
   color: var(--home-eyebrow);
 }
 
-/* Code tile */
-.tile-code { padding: 0; overflow: hidden; }
+/* ADK terminal tile */
+.tile-adk { padding: 0; overflow: hidden; }
 
-.tile-code .tile-code-head {
+.term-head {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.85rem 1.2rem;
+  gap: 0.4rem;
+  padding: 0.7rem 1.1rem;
   border-bottom: 1px solid var(--home-tile-border);
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--home-muted);
 }
 
-.tile-code pre {
+.term-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--home-tile-border);
+}
+
+.term-title {
+  margin-left: 0.45rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--home-fg);
+}
+
+.term-body {
+  flex: 1;
   margin: 0;
   padding: 1.1rem 1.3rem;
   background: var(--home-code-bg);
   font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
-  font-size: 0.82rem;
-  line-height: 1.75;
-  color: var(--home-fg);
+  font-size: 0.83rem;
+  line-height: 1.5;
   overflow-x: auto;
 }
 
-.tile-code .c-prompt { color: #4a7c10; }
-html.dark .tile-code .c-prompt { color: #bcdb4d; }
-.tile-code .c-comment { color: var(--home-muted); }
+.term-line {
+  display: flex;
+  gap: 1rem;
+  padding: 0.22rem 0;
+  white-space: nowrap;
+}
+
+.term-cmd {
+  flex: none;
+  min-width: 5.5rem;
+  color: var(--home-fg);
+}
+
+.term-cmd .term-p { color: #4a7c10; margin-right: 0.5rem; }
+html.dark .term-cmd .term-p { color: #bcdb4d; }
+.term-c { color: var(--home-muted); }
+
+.term-foot {
+  padding: 0.85rem 1.3rem;
+  border-top: 1px solid var(--home-tile-border);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--home-eyebrow);
+  text-decoration: none;
+  transition: background 140ms ease;
+}
+
+.term-foot:hover { background: rgba(74, 124, 16, 0.06); }
+html.dark .term-foot:hover { background: rgba(217, 238, 80, 0.08); }
 
 /* "New" pill in the news tile */
 .home-pill {
@@ -410,18 +437,18 @@ html.dark .tile-code .c-prompt { color: #bcdb4d; }
 
 html.dark .home-pill { background: rgba(217, 238, 80, 0.14); }
 
-/* Tablet / narrow-content: 2-col, hero full width, keep some asymmetry */
+/* Tablet: hero + terminal stack full-width; nav tiles sit three-across */
 @media (max-width: 950px) {
-  .home-bento { grid-template-columns: repeat(2, 1fr); }
-  .tile-hero { grid-column: 1 / -1; grid-row: auto; }
-  .tile-side { grid-column: span 1; }
-  .tile-half { grid-column: 1 / -1; }
+  .home-bento { grid-template-columns: repeat(6, 1fr); }
+  .tile-hero, .tile-adk { grid-column: 1 / -1; }
+  .tile-nav { grid-column: span 2; }
 }
 
 /* Mobile: single column */
 @media (max-width: 640px) {
   .home-bento { grid-template-columns: 1fr; }
-  .home-bento > * { grid-column: 1 / -1 !important; grid-row: auto !important; }
+  .home-bento > * { grid-column: 1 / -1 !important; }
+  .term-line { white-space: normal; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/user-management/access-control-scope.mdx
+++ b/user-management/access-control-scope.mdx
@@ -26,10 +26,10 @@ Admins have **full access** to all workspace features:
 - Modify user permissions
 - Access billing and account settings
 - Full edit access to all navigation areas
-- Use [Studio Assistant](/studio-assistant/introduction) (Beta) on enterprise clusters
+- Use [Studio Assistant](/studio-assistant/introduction) on enterprise clusters
 
 <Note>
-During the Beta, [Studio Assistant](/studio-assistant/introduction) is **available only to project admins** on enterprise clusters. Permissions will become more granular over time.
+[Studio Assistant](/studio-assistant/introduction) is **available only to project admins** on enterprise clusters. Permissions will become more granular over time.
 </Note>
 
 ### Member


### PR DESCRIPTION
## What

Rebuilds the docs **home landing page** as a bespoke, minimal, asymmetric **bento** layout — inspired by [platform.claude.com/docs/en/home](https://platform.claude.com/docs/en/home) — replacing the previous static-graphic + stacked-`CardGroup` layout.

### Home page ([home.mdx](home.mdx))
- Soft brand-tinted **hero tile** with the primary CTA ("Start the quickstart") + a quiet metrics row.
- Stacked companion tiles: **API reference** and **Studio Assistant**.
- A **live ADK code snippet** tile and a **"What's new"** tile.
- A quiet **"Choose how to build"** fork (Studio / ADK / REST APIs).
- Deep nav (Build / Integrations / Deploy / Resources) kept below the fold.
- ADK card now points to the new `/adk` tab.

### Styling ([styles.css](styles.css))
- Theme-aware CSS classes for the bento (light + dark), color used as accent not fill. Asymmetric CSS grid that reflows to 2-col (tablet) and 1-col (mobile).

### ADK overview ([adk/index.mdx](adk/index.mdx))
- Adds a hardcoded **"View the ADK on GitHub"** card linking to the `polyai-adk` repo.

## Verification
Previewed locally in `mint dev`, light and dark, at desktop/tablet/mobile widths. No console or build errors.

## Notes
- Scoped to just these three files — unrelated in-flight work (dark mode PR #576, Data MCP docs) is intentionally excluded.
- No emojis; all icons use Mintlify/FontAwesome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)