### PR TITLE
docs: add Data MCP page and expand Builder MCP tool reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -916,6 +916,13 @@
             ]
           },
           {
+            "group": "Data MCP",
+            "icon": "chart-line",
+            "pages": [
+              "mcp/data/introduction"
+            ]
+          },
+          {
             "group": "Agent Studio MCP integrations",
             "icon": "plug",
             "pages": [

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -15,9 +15,9 @@ PolyAI's MCP servers authenticate with a PolyAI API key sent in the `X-API-KEY` 
 | Server | Credential | Scope |
 | --- | --- | --- |
 | [Builder MCP](/mcp/builder/introduction) | [Workspace-scoped API key](/secrets/api-keys) | The agents and permissions you grant the key |
-| [Data MCP](/mcp/data/introduction) | Account API key **or** Personal Access Token (PAT) | The account, or your user's project access |
+| [Data MCP](/mcp/data/introduction) | Account API key | The account — any project in it |
 
-All three are created in Agent Studio and sent the same way — in the `X-API-KEY` header. They differ in where you create them and what they can reach.
+Both are created in Agent Studio and sent the same way — in the `X-API-KEY` header. They differ in where you create them and what they can reach.
 
 ## Get an API key
 
@@ -44,13 +44,10 @@ All three are created in Agent Studio and sent the same way — in the `X-API-KE
     </Frame>
   </Tab>
 
-  <Tab title="Account key or PAT (Data MCP)">
-    Data MCP accepts either of two credentials, depending on the scope you want:
+  <Tab title="Account API key (Data MCP)">
+    Data MCP uses an **account API key**, created from your account page in Agent Studio. It's scoped to the account and can query any project in it.
 
-    - **Account API key** — created from your account page in Agent Studio. Scoped to the account; can query any project in it.
-    - **Personal Access Token (PAT)** — created from your user profile in Agent Studio. Scoped to your user's project access.
-
-    Both are shown only once at creation. Copy the value immediately and store it in your client's secret settings.
+    The key is shown only once at creation. Copy the value immediately and store it in your client's secret settings — never paste it into a chat prompt.
   </Tab>
 </Tabs>
 
@@ -60,7 +57,7 @@ Pass the key in the `X-API-KEY` header. Both servers use the streamable HTTP tra
 
 | Header | Value |
 | --- | --- |
-| `X-API-KEY` | Your PolyAI API key or PAT |
+| `X-API-KEY` | Your PolyAI API key |
 | `Accept` | `application/json, text/event-stream` |
 
 Most clients set `Accept` automatically. See [Quickstart](/mcp/quickstart#2-add-the-server-to-your-client) for per-client configuration.

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -1,51 +1,75 @@
 ---
 title: Authentication
 sidebarTitle: Authentication
-description: Obtain a PolyAI API key and configure your MCP client to authenticate against the Builder MCP.
+description: Obtain a PolyAI API key and configure your MCP client to authenticate against Builder MCP or Data MCP.
 mode: wide
 ---
 
-{/* REVIEW: Confirm (1) which API-key permission/scope is required to reach the MCP server,
+{/* REVIEW: Confirm (1) which API-key permission/scope is required to reach each MCP server,
     and (2) the OAuth/self-serve credential timeline before publishing the roadmap note. */}
 
-PolyAI's MCP servers authenticate with the same [workspace-scoped API key](/secrets/api-keys) used across PolyAI's APIs, sent in the `X-API-KEY` header.
+PolyAI's MCP servers authenticate with a PolyAI API key sent in the `X-API-KEY` header. Which kind of key you need depends on the server.
+
+## Which credential do I need?
+
+| Server | Credential | Scope |
+| --- | --- | --- |
+| [Builder MCP](/mcp/builder/introduction) | [Workspace-scoped API key](/secrets/api-keys) | The agents and permissions you grant the key |
+| [Data MCP](/mcp/data/introduction) | Account API key **or** Personal Access Token (PAT) | The account, or your user's project access |
+
+All three are created in Agent Studio and sent the same way — in the `X-API-KEY` header. They differ in where you create them and what they can reach.
 
 ## Get an API key
 
-<Steps>
-  <Step title="Open the API Keys page">
-    Go to the **API Keys** tab on your workspace homepage in Agent Studio. See [API keys](/secrets/api-keys) for details.
-  </Step>
-  <Step title="Create a key">
-    Select **API key**, name it, choose the agents it can access, and set its permissions. Scope it to the least it needs — see [Security & safe use](/mcp/builder/security#use-least-privilege-keys).
-  </Step>
-  <Step title="Copy the value">
-    The full key is shown only once. Copy it immediately and store it in your client's secret settings — never paste it into a chat prompt.
-  </Step>
-</Steps>
+<Tabs>
+  <Tab title="Workspace-scoped key (Builder MCP)">
+    <Steps>
+      <Step title="Open the API Keys page">
+        Go to the **API Keys** tab on your workspace homepage in Agent Studio. See [API keys](/secrets/api-keys) for details.
+      </Step>
+      <Step title="Create a key">
+        Select **API key**, name it, choose the agents it can access, and set its permissions. Scope it to the least it needs — see [Security & safe use](/mcp/builder/security#use-least-privilege-keys).
+      </Step>
+      <Step title="Copy the value">
+        The full key is shown only once. Copy it immediately and store it in your client's secret settings — never paste it into a chat prompt.
+      </Step>
+    </Steps>
 
-<Frame caption="The API Keys tab on your workspace homepage in Agent Studio.">
-  <img
-    src="/images/secrets/api-keys-overview.png"
-    alt="The API Keys tab in Agent Studio, showing the list of keys and the 'API key' button to create a new one"
-    style={{ maxWidth: '820px', width: '100%', margin: '0 auto', display: 'block' }}
-  />
-</Frame>
+    <Frame caption="The API Keys tab on your workspace homepage in Agent Studio.">
+      <img
+        src="/images/secrets/api-keys-overview.png"
+        alt="The API Keys tab in Agent Studio, showing the list of keys and the 'API key' button to create a new one"
+        style={{ maxWidth: '820px', width: '100%', margin: '0 auto', display: 'block' }}
+      />
+    </Frame>
+  </Tab>
+
+  <Tab title="Account key or PAT (Data MCP)">
+    Data MCP accepts either of two credentials, depending on the scope you want:
+
+    - **Account API key** — created from your account page in Agent Studio. Scoped to the account; can query any project in it.
+    - **Personal Access Token (PAT)** — created from your user profile in Agent Studio. Scoped to your user's project access.
+
+    Both are shown only once at creation. Copy the value immediately and store it in your client's secret settings.
+  </Tab>
+</Tabs>
 
 ## Configure your client
 
-Pass the key in the `X-API-KEY` header. The MCP server uses the streamable HTTP transport, so clients also send an `Accept` header:
+Pass the key in the `X-API-KEY` header. Both servers use the streamable HTTP transport, so clients also send an `Accept` header:
 
 | Header | Value |
 | --- | --- |
-| `X-API-KEY` | Your workspace-scoped API key |
+| `X-API-KEY` | Your PolyAI API key or PAT |
 | `Accept` | `application/json, text/event-stream` |
 
 Most clients set `Accept` automatically. See [Quickstart](/mcp/quickstart#2-add-the-server-to-your-client) for per-client configuration.
 
 ## Pick your region
 
-PolyAI runs the MCP server in every region, on the same host family as the [platform APIs](/api-reference/introduction#pick-your-region). Your API key is scoped to a workspace, and each workspace lives in one region — connect to the matching endpoint.
+PolyAI runs each MCP server in every region, on the same host family as the [platform APIs](/api-reference/introduction#pick-your-region). Your key is region-specific — a US key doesn't work against the UK endpoint — so connect to the matching endpoint.
+
+**Builder MCP**
 
 | Region | Endpoint |
 | ------ | -------------------------------------- |
@@ -53,6 +77,14 @@ PolyAI runs the MCP server in every region, on the same host family as the [plat
 | UK     | `https://api.uk.poly.ai/builder-mcp`     |
 | EU     | `https://api.eu.poly.ai/builder-mcp`     |
 | Studio | `https://api.studio.poly.ai/builder-mcp` |
+
+**Data MCP**
+
+| Region | Endpoint |
+| ------ | -------------------------------------- |
+| US     | `https://api.us.poly.ai/data-mcp`     |
+| UK     | `https://api.uk.poly.ai/data-mcp`     |
+| EU     | `https://api.eu.poly.ai/data-mcp`     |
 
 ## OAuth (coming soon)
 

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -1198,6 +1198,6 @@ Watch live agents and react to issues. Backed by the [Alerts API](/api-reference
 | `delete-alert-rule` | Delete an alert rule and its associated state, including the Datadog monitor. |
 | `get-active-alerts` | Get active alerts (rules currently in `ALERT` state). Optional query params: `project_id` (filter by project ID), `metric` (filter by metric type). |
 
-## Limiting what a client can do
+## Enforcing limitations
 
 To narrow what a client can reach, scope the [API key](/mcp/authentication) itself. Create a [least-privilege key](/mcp/builder/security#restrict-the-tool-surface) limited to the agents and permissions that client needs — for example, a read-only key for a monitoring assistant. The key's scope governs which calls succeed, so a narrowly scoped key can't create, delete, or deploy even though the tools are still discovered.

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -1,209 +1,1193 @@
 ---
 title: Capabilities
 sidebarTitle: Capabilities
-description: The tools Builder MCP exposes, grouped by what they do.
+description: The tools Builder MCP exposes, grouped by what they do — each with its parameters and a link to the matching API reference.
 mode: wide
 ---
 
-Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server.
+Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server; the parameter tables below reproduce that schema so you can see what each tool takes without connecting first.
 
 US, UK, and EU workspaces expose **97 tools**; self-serve Studio workspaces expose **91** (the Alerts family is enterprise-only). Tool names appear exactly as your client sees them in `tools/list`.
 
 <Note>
-To see exactly what your client discovered, ask it to list its available tools, or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#3-verify)).
+Every tool maps to a PolyAI REST endpoint. Parameters are named `path_*`, `query_*`, or nested under a request `body` in the raw schema — the tables below strip those prefixes and expand the body's top-level fields. For deeply nested request bodies, follow the **API reference** link on each tool for the complete schema. To see exactly what your client discovered, ask it to list its tools or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#3-verify)).
 </Note>
+
 
 ## Build & manage agents
 
-Create agents and manage everything they contain. Workspace- and agent-scoped, backed by the [Agents API](/api-reference/agents/introduction).
+### Agents
 
-**Agents**
+#### `create-agent`
 
-| Tool | What it does |
-| --- | --- |
-| `create-agent` | Create agent |
-| `list-agents` | List agents |
-| `duplicate-agent` | Duplicate agent |
-| `delete-agent` | Delete agent |
+Create agent.
 
-**Behavior**
+API reference: [Create agent](/api-reference/agents/endpoint/agents/create-agent).
 
-| Tool | What it does |
-| --- | --- |
-| `get-agent-behavior-rules` | Get agent behavior rules |
-| `update-agent-behavior-rules` | Update agent behavior rules |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `accountId` | string | The account (workspace). **Required.** |
+| `llmSettings` | object | Nested object — see the API reference for the full schema. |
+| `responseSettings` | object | Nested object — see the API reference for the full schema. **Required.** |
+| `experimentalConfig` | object | Nested object — see the API reference for the full schema. |
+| `name` | string | 1–100 characters. **Required.** |
+| `agentId` | string | — |
+| `voiceSettings` | object | Nested object — see the API reference for the full schema. |
 
-**Branches**
+#### `list-agents`
 
-| Tool | What it does |
-| --- | --- |
-| `create-branch` | Create branch |
-| `list-branches` | List branches |
-| `delete-branch` | Delete branch |
-| `merge-branch` | Merge branch |
-| `sync-branch-with-parent` | Sync branch with parent |
+List agents.
 
-**Deployments**
+API reference: [List agents](/api-reference/agents/endpoint/agents/list-agents).
 
-| Tool | What it does |
-| --- | --- |
-| `publish-the-current-draft-to-an-environment` | Publish the current draft to an environment |
-| `promote-a-deployment-to-the-next-environment` | Promote a deployment to the next environment |
-| `rollback-to-a-previous-deployment` | Rollback to a previous deployment |
-| `list-deployments-for-an-environment` | List deployments for an environment |
-| `get-active-deployment-per-environment` | Get active deployment per environment |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `accountId` | string | The account (workspace). **Required.** |
 
-**Knowledge base**
+#### `duplicate-agent`
 
-| Tool | What it does |
-| --- | --- |
-| `create-knowledge-base-topic` | Create knowledge base topic |
-| `get-knowledge-base-topic` | Get knowledge base topic |
-| `list-knowledge-base-topics` | List knowledge base topics |
-| `update-knowledge-base-topic` | Update knowledge base topic |
-| `delete-knowledge-base-topic` | Delete knowledge base topic |
+Duplicate agent.
 
-**Variants**
+API reference: [Duplicate agent](/api-reference/agents/endpoint/agents/duplicate-agent).
 
-| Tool | What it does |
-| --- | --- |
-| `create-variant` | Create variant |
-| `list-variants` | List variants |
-| `update-variant` | Update variant |
-| `delete-variant` | Delete variant |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `newAgentName` | string | 1–100 characters. **Required.** |
+| `newAgentId` | string | — |
 
-**Attributes**
+#### `delete-agent`
 
-| Tool | What it does |
-| --- | --- |
-| `create-attribute` | Create attribute |
-| `list-attributes` | List attributes |
-| `update-attribute` | Update attribute |
-| `delete-attribute` | Delete attribute |
+Delete agent.
 
-**Connectors**
+API reference: [Delete agent](/api-reference/agents/endpoint/agents/delete-agent).
 
-| Tool | What it does |
-| --- | --- |
-| `get-a-connector-by-id` | Get a connector by ID |
-| `batch-get-connectors-by-id` | Batch get connectors by ID |
-| `list-all-connectors-for-a-project` | List all connectors for a project |
-| `update-a-connector` | Update a connector |
-| `batch-update-connectors` | Batch update connectors |
-| `delete-a-connector-and-its-phone-numbers` | Delete a connector and its phone numbers |
-| `look-up-connector-by-phone-number` | Look up connector by phone number |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
 
-**Phone numbers**
+### Behavior
 
-| Tool | What it does |
-| --- | --- |
-| `get-a-specific-phone-number` | Get a specific phone number |
-| `batch-get-phone-numbers` | Batch get phone numbers |
-| `list-all-phone-numbers-for-a-project` | List all phone numbers for a project |
-| `import-a-single-phone-number` | Import a single phone number |
-| `import-phone-numbers-into-a-project` | Import phone numbers into a project |
-| `delete-a-single-phone-number` | Delete a single phone number |
-| `delete-phone-numbers-from-a-project` | Delete phone numbers from a project |
-| `reassign-a-phone-number-to-a-different-connector` | Reassign a phone number to a different connector |
+#### `get-agent-behavior-rules`
 
-**Config pages (real-time config)**
+Get agent behavior rules.
 
-| Tool | What it does |
-| --- | --- |
-| `get-a-config-page-by-environment` | Get a config page by environment |
-| `list-all-config-pages` | List all config pages |
-| `update-config-variables-for-an-environment` | Update config variables for an environment |
-| `upsert-the-json-schema-for-a-config-page` | Upsert the JSON Schema for a config page |
+API reference: [Get agent behavior rules](/api-reference/agents/endpoint/behavior/get-agent-behavior-rules).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `update-agent-behavior-rules`
+
+Update agent behavior rules.
+
+API reference: [Update agent behavior rules](/api-reference/agents/endpoint/behavior/update-agent-behavior-rules).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `behavior` | string | — **Required.** |
+
+### Branches
+
+#### `create-branch`
+
+Create branch.
+
+API reference: [Create branch](/api-reference/agents/endpoint/branches/create-branch).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchName` | string | 1–100 characters. **Required.** |
+
+#### `list-branches`
+
+List branches.
+
+API reference: [List branches](/api-reference/agents/endpoint/branches/list-branches).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+
+#### `delete-branch`
+
+Delete branch.
+
+API reference: [Delete branch](/api-reference/agents/endpoint/branches/delete-branch).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `merge-branch`
+
+Merge branch.
+
+API reference: [Merge branch](/api-reference/agents/endpoint/branches/merge-branch).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `conflictResolutions` | array | Array. |
+| `deploymentMessage` | string | Default ``. |
+
+#### `sync-branch-with-parent`
+
+Sync branch with parent.
+
+API reference: [Sync branch with parent](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `conflictResolutions` | array | Array. |
+
+### Deployments
+
+#### `publish-the-current-draft-to-an-environment`
+
+Publish the current draft to an environment.
+
+API reference: [Publish the current draft to an environment](/api-reference/agents/endpoint/deployments/publish-the-current-draft-to-an-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `environment` | string | Environment to publish to (defaults to sandbox). |
+| `deploymentMessage` | string | Message describing this publish. Default ``. |
+
+#### `promote-a-deployment-to-the-next-environment`
+
+Promote a deployment to the next environment.
+
+API reference: [Promote a deployment to the next environment](/api-reference/agents/endpoint/deployments/promote-a-deployment-to-the-next-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `deploymentId` | string | The deployment. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `targetEnvironment` | string | One of `pre-release`, `live`. |
+| `deploymentMessage` | string | Default ``. |
+
+#### `rollback-to-a-previous-deployment`
+
+Rollback to a previous deployment.
+
+API reference: [Rollback to a previous deployment](/api-reference/agents/endpoint/deployments/rollback-to-a-previous-deployment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `deploymentId` | string | The deployment. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `deploymentMessage` | string | Default ``. |
+
+#### `list-deployments-for-an-environment`
+
+List deployments for an environment.
+
+API reference: [List deployments for an environment](/api-reference/agents/endpoint/deployments/list-deployments-for-an-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `limit` | integer | Max number of deployments to return. |
+| `environment` | string | Environment to list deployments for (sandbox, pre-release, live). One of `sandbox`, `pre-release`, `live`. **Required.** |
+
+#### `get-active-deployment-per-environment`
+
+Get active deployment per environment.
+
+API reference: [Get active deployment per environment](/api-reference/agents/endpoint/deployments/get-active-deployment-per-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+
+### Knowledge base
+
+#### `create-knowledge-base-topic`
+
+Create knowledge base topic.
+
+API reference: [Create knowledge base topic](/api-reference/agents/endpoint/knowledge-base/create-knowledge-base-topic).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `content` | string | — **Required.** |
+| `name` | string | — **Required.** |
+| `exampleQueries` | object | Nested object — see the API reference for the full schema. |
+| `actions` | string | — |
+| `isActive` | boolean | — |
+
+#### `get-knowledge-base-topic`
+
+Get knowledge base topic.
+
+API reference: [Get knowledge base topic](/api-reference/agents/endpoint/knowledge-base/get-knowledge-base-topic).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `topicId` | string | The knowledge base topic. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `list-knowledge-base-topics`
+
+List knowledge base topics.
+
+API reference: [List knowledge base topics](/api-reference/agents/endpoint/knowledge-base/list-knowledge-base-topics).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `update-knowledge-base-topic`
+
+Update knowledge base topic.
+
+API reference: [Update knowledge base topic](/api-reference/agents/endpoint/knowledge-base/update-knowledge-base-topic).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `topicId` | string | The knowledge base topic. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `content` | string | — |
+| `isActive` | boolean | — |
+| `exampleQueries` | object | Nested object — see the API reference for the full schema. |
+| `actions` | string | — |
+| `name` | string | — |
+
+#### `delete-knowledge-base-topic`
+
+Delete knowledge base topic.
+
+API reference: [Delete knowledge base topic](/api-reference/agents/endpoint/knowledge-base/delete-knowledge-base-topic).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `topicId` | string | The knowledge base topic. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+### Variants
+
+#### `create-variant`
+
+Create variant.
+
+API reference: [Create variant](/api-reference/agents/endpoint/variants/create-variant).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `attributeValues` | object | Default `{'values': {}}`. |
+| `isDefault` | boolean | — |
+| `name` | string | — **Required.** |
+
+#### `list-variants`
+
+List variants.
+
+API reference: [List variants](/api-reference/agents/endpoint/variants/list-variants).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `update-variant`
+
+Update variant.
+
+API reference: [Update variant](/api-reference/agents/endpoint/variants/update-variant).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `variantId` | string | The variant. **Required.** |
+| `name` | string | — |
+| `isDefault` | boolean | — |
+| `attributeValues` | object | Nested object — see the API reference for the full schema. |
+
+#### `delete-variant`
+
+Delete variant.
+
+API reference: [Delete variant](/api-reference/agents/endpoint/variants/delete-variant).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `variantId` | string | The variant. **Required.** |
+
+### Attributes
+
+#### `create-attribute`
+
+Create attribute.
+
+API reference: [Create attribute](/api-reference/agents/endpoint/variants/create-attribute).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `name` | string | — **Required.** |
+
+#### `list-attributes`
+
+List attributes.
+
+API reference: [List attributes](/api-reference/agents/endpoint/variants/list-attributes).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `update-attribute`
+
+Update attribute.
+
+API reference: [Update attribute](/api-reference/agents/endpoint/variants/update-attribute).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `attributeId` | string | The attribute. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `name` | string | — **Required.** |
+
+#### `delete-attribute`
+
+Delete attribute.
+
+API reference: [Delete attribute](/api-reference/agents/endpoint/variants/delete-attribute).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `attributeId` | string | The attribute. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+### Connectors
+
+#### `get-a-connector-by-id`
+
+Get a connector by ID.
+
+API reference: [Get a connector by ID](/api-reference/agents/endpoint/connectors/get-a-connector-by-id).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `connectorId` | string | The connector. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `batch-get-connectors-by-id`
+
+Batch get connectors by ID.
+
+API reference: [Batch get connectors by ID](/api-reference/agents/endpoint/connectors/batch-get-connectors-by-id).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `connectorIds` | array | List of connector IDs to retrieve. **Required.** |
+
+#### `list-all-connectors-for-a-project`
+
+List all connectors for a project.
+
+API reference: [List all connectors for a project](/api-reference/agents/endpoint/connectors/list-all-connectors-for-a-project).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+
+#### `update-a-connector`
+
+Update a connector.
+
+API reference: [Update a connector](/api-reference/agents/endpoint/connectors/update-a-connector).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `connectorId` | string | The connector. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `variantId` | string | Variant ID to assign, or null to unassign. |
+| `projectId` | string | Move connector to a different project. API key must have access to both projects. |
+| `asrLangCode` | string | ASR language code (e.g. en-US). |
+| `voiceName` | string | Google TTS voice name (e.g. en-US-Neural2-A). tts_lang_code is auto-derived from the voice name prefix. Validated via TTS probe. |
+
+#### `batch-update-connectors`
+
+Batch update connectors.
+
+API reference: [Batch update connectors](/api-reference/agents/endpoint/connectors/batch-update-connectors).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `updates` | array | List of connector updates. **Required.** |
+
+#### `delete-a-connector-and-its-phone-numbers`
+
+Delete a connector and its phone numbers.
+
+API reference: [Delete a connector and its phone numbers](/api-reference/agents/endpoint/connectors/delete-a-connector-and-its-phone-numbers).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `connectorId` | string | The connector. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `look-up-connector-by-phone-number`
+
+Look up connector by phone number.
+
+API reference: [Look up connector by phone number](/api-reference/agents/endpoint/connectors/look-up-connector-by-phone-number).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumber` | string | Phone number to look up (E.164 format). **Required.** |
+
+### Phone numbers
+
+#### `get-a-specific-phone-number`
+
+Get a specific phone number.
+
+API reference: [Get a specific phone number](/api-reference/agents/endpoint/phone-numbers/get-a-specific-phone-number).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
+
+#### `batch-get-phone-numbers`
+
+Batch get phone numbers.
+
+API reference: [Batch get phone numbers](/api-reference/agents/endpoint/phone-numbers/batch-get-phone-numbers).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumbers` | array | List of phone numbers to retrieve. **Required.** |
+
+#### `list-all-phone-numbers-for-a-project`
+
+List all phone numbers for a project.
+
+API reference: [List all phone numbers for a project](/api-reference/agents/endpoint/phone-numbers/list-all-phone-numbers-for-a-project).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `connectorId` | string | Filter by connector ID. |
+
+#### `import-a-single-phone-number`
+
+Import a single phone number.
+
+API reference: [Import a single phone number](/api-reference/agents/endpoint/phone-numbers/import-a-single-phone-number).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `clientEnv` | string | Client environment (sandbox, pre-release, live). Default `live`. |
+
+#### `import-phone-numbers-into-a-project`
+
+Import phone numbers into a project.
+
+API reference: [Import phone numbers into a project](/api-reference/agents/endpoint/phone-numbers/import-phone-numbers-into-a-project).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumbers` | array | List of phone numbers to import. **Required.** |
+| `clientEnv` | string | Client environment (sandbox, pre-release, live). Default `live`. |
+
+#### `delete-a-single-phone-number`
+
+Delete a single phone number.
+
+API reference: [Delete a single phone number](/api-reference/agents/endpoint/phone-numbers/delete-a-single-phone-number).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
+
+#### `delete-phone-numbers-from-a-project`
+
+Delete phone numbers from a project.
+
+API reference: [Delete phone numbers from a project](/api-reference/agents/endpoint/phone-numbers/delete-phone-numbers-from-a-project).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `phoneNumbers` | array | List of phone numbers to delete. **Required.** |
+
+#### `reassign-a-phone-number-to-a-different-connector`
+
+Reassign a phone number to a different connector.
+
+API reference: [Reassign a phone number to a different connector](/api-reference/agents/endpoint/phone-numbers/reassign-a-phone-number-to-a-different-connector).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `connectorId` | string | Target connector ID to reassign the phone number to. **Required.** |
+
+### Config pages (real-time config)
+
+#### `get-a-config-page-by-environment`
+
+Get a config page by environment.
+
+API reference: [Get a config page by environment](/api-reference/agents/endpoint/real-time-configs/get-a-config-page-by-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `clientEnv` | string | The client environment. **Required.** |
+
+#### `list-all-config-pages`
+
+List all config pages.
+
+API reference: [List all config pages](/api-reference/agents/endpoint/real-time-configs/list-all-config-pages).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+
+#### `update-config-variables-for-an-environment`
+
+Update config variables for an environment.
+
+API reference: [Update config variables for an environment](/api-reference/agents/endpoint/real-time-configs/update-config-variables-for-an-environment).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `clientEnv` | string | The client environment. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `variables` | object | Key-value pairs to merge into the existing config. **Required.** |
+
+#### `upsert-the-json-schema-for-a-config-page`
+
+Upsert the JSON Schema for a config page.
+
+API reference: [Upsert the JSON Schema for a config page](/api-reference/agents/endpoint/real-time-configs/upsert-the-json-schema-for-a-config-page).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `clientEnv` | string | The client environment. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `schema` | object | JSON Schema (Draft 7) definition. **Required.** |
 
 ## Voice & audio
 
-Manage the voices an agent uses and the audio it caches.
+### Voice library
 
-**Voice library**
+#### `register-a-new-voice-in-the-voice-library`
 
-| Tool | What it does |
-| --- | --- |
-| `register-a-new-voice-in-the-voice-library` | Register a new voice in the voice library |
-| `update-a-voice-in-the-voice-library` | Update a voice in the voice library |
-| `get-a-single-voice-from-the-voice-library` | Get a single voice from the voice library |
-| `list-all-voices-in-the-account-s-voice-library` | List all voices in the account's voice library |
-| `synthesize-a-short-audio-sample-of-a-voice` | Synthesize a short audio sample of a voice |
-| `set-the-project-s-active-voice` | Set the project's active voice |
+Register a new voice in the voice library.
 
-**Deployed voice configs**
+API reference: [Register a new voice in the voice library](/api-reference/agents/endpoint/voice-library/register-voice).
 
-| Tool | What it does |
-| --- | --- |
-| `create-or-update-a-deployed-voice-configuration` | Create or update a deployed voice configuration |
-| `list-deployed-voice-configurations` | List deployed voice configurations |
-| `delete-a-deployed-voice-configuration` | Delete a deployed voice configuration |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `accountId` | string | The account (workspace). **Required.** |
+| `providerVoiceId` | string | Voice ID from the TTS provider. **Required.** |
+| `config` | object | Provider-specific voice config. **Required.** |
+| `name` | string | Human-readable voice name. **Required.** |
+| `voiceMetadata` | object | Additional voice metadata. |
+| `provider` | string | TTS provider (e.g. GOOGLE, OPENAI, ELEVENLABS). **Required.** |
 
-**Voice & disclaimer tuning**
+#### `update-a-voice-in-the-voice-library`
 
-| Tool | What it does |
-| --- | --- |
-| `get-voice-tuning-settings` | Get voice tuning settings |
-| `update-voice-tuning-settings` | Update voice tuning settings |
-| `get-disclaimer-voice-tuning-settings` | Get disclaimer voice tuning settings |
-| `update-disclaimer-voice-tuning-settings` | Update disclaimer voice tuning settings |
+Update a voice in the voice library.
 
-**Audio cache**
+API reference: [Update a voice in the voice library](/api-reference/agents/endpoint/voice-library/update-voice).
 
-| Tool | What it does |
-| --- | --- |
-| `list-audio-cache-entries` | List audio cache entries |
-| `delete-audio-cache-entry` | Delete audio cache entry |
-| `bulk-delete-audio-cache-entries` | Bulk delete audio cache entries |
-| `download-cached-audio-file` | Download cached audio file |
-| `replace-audio-file-for-a-cache-entry` | Replace audio file for a cache entry |
-| `update-cache-entry-file-and-settings` | Update cache entry file and settings |
-| `generate-a-tts-audio-preview` | Generate a TTS audio preview |
-| `preview-tts-audio-for-a-cache-entry` | Preview TTS audio for a cache entry |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `accountId` | string | The account (workspace). **Required.** |
+| `providerVoiceId` | string | Voice ID from the TTS provider. |
+| `voiceMetadata` | object | Additional voice metadata. |
+| `name` | string | Human-readable voice name. |
+| `provider` | string | TTS provider. |
+| `config` | object | Provider-specific voice config. |
+
+#### `get-a-single-voice-from-the-voice-library`
+
+Get a single voice from the voice library.
+
+API reference: [Get a single voice from the voice library](/api-reference/agents/endpoint/voice-library/get-voice).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `accountId` | string | The account (workspace). **Required.** |
+
+#### `list-all-voices-in-the-account-s-voice-library`
+
+List all voices in the account's voice library.
+
+API reference: [List all voices in the account's voice library](/api-reference/agents/endpoint/voice-library/list-voices).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `accountId` | string | The account (workspace). **Required.** |
+| `provider` | string | Filter by TTS provider, e.g. 'GOOGLE', 'ELEVENLABS'. |
+| `isPolyVoice` | boolean | If set, restrict to (or exclude) Poly's curated voices. |
+| `language` | string | Filter by voice metadata language, e.g. 'en-US'. |
+| `gender` | string | Filter by voice metadata gender. One of `male`, `female`, `neutral`. |
+
+#### `synthesize-a-short-audio-sample-of-a-voice`
+
+Synthesize a short audio sample of a voice.
+
+API reference: [Synthesize a short audio sample of a voice](/api-reference/agents/endpoint/voice-library/synthesize-voice-sample).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `accountId` | string | The account (workspace). **Required.** |
+
+#### `set-the-project-s-active-voice`
+
+Set the project's active voice.
+
+API reference: [Set the project's active voice](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `voiceId` | string | Voice ID to set as the project voice. **Required.** |
+
+### Deployed voice configs
+
+#### `create-or-update-a-deployed-voice-configuration`
+
+Create or update a deployed voice configuration.
+
+API reference: [Create or update a deployed voice configuration](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `probability` | number | Traffic weight (0.0–1.0). **Required.** |
+| `id` | string | Deployed voice ID — omit to create, provide to update. |
+| `voiceId` | string | Voice ID to deploy. **Required.** |
+
+#### `list-deployed-voice-configurations`
+
+List deployed voice configurations.
+
+API reference: [List deployed voice configurations](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+
+#### `delete-a-deployed-voice-configuration`
+
+Delete a deployed voice configuration.
+
+API reference: [Delete a deployed voice configuration](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `deployedVoiceId` | string | The deployed voice configuration. **Required.** |
+
+### Voice & disclaimer tuning
+
+#### `get-voice-tuning-settings`
+
+Get voice tuning settings.
+
+API reference: [Get voice tuning settings](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `voiceId` | string | The voice. **Required.** |
+| `purpose` | string | Tuning purpose filter, e.g. 'disclaimer'. |
+
+#### `update-voice-tuning-settings`
+
+Update voice tuning settings.
+
+API reference: [Update voice tuning settings](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `speed` | number | Playback speed multiplier. |
+| `stability` | integer | Voice stability (0–100). |
+| `resetToDefault` | boolean | Reset settings to provider defaults. |
+| `modelId` | string | Provider model ID override. |
+| `similarityBoost` | integer | Similarity boost (0–100). |
+
+#### `get-disclaimer-voice-tuning-settings`
+
+Get disclaimer voice tuning settings.
+
+API reference: [Get disclaimer voice tuning settings](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `update-disclaimer-voice-tuning-settings`
+
+Update disclaimer voice tuning settings.
+
+API reference: [Update disclaimer voice tuning settings](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `voiceId` | string | The voice. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `resetToDefault` | boolean | Reset settings to provider defaults. |
+| `stability` | integer | Voice stability (0–100). |
+| `similarityBoost` | integer | Similarity boost (0–100). |
+| `modelId` | string | Provider model ID override. |
+| `speed` | number | Playback speed multiplier. |
+
+### Audio cache
+
+#### `list-audio-cache-entries`
+
+List audio cache entries.
+
+API reference: [List audio cache entries](/api-reference/agents/endpoint/audio-cache/list-audio-cache).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `offset` | integer | Pagination offset. Min 0. Default `0`. |
+| `limit` | integer | Max entries to return (1-200). 1–200. Default `50`. |
+| `sort` | string | Sort expression, e.g. "hit_count:desc", "duration:asc". |
+
+#### `delete-audio-cache-entry`
+
+Delete audio cache entry.
+
+API reference: [Delete audio cache entry](/api-reference/agents/endpoint/audio-cache/delete-audio-cache-entry).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `entryId` | string | The audio cache entry. **Required.** |
+
+#### `bulk-delete-audio-cache-entries`
+
+Bulk delete audio cache entries.
+
+API reference: [Bulk delete audio cache entries](/api-reference/agents/endpoint/audio-cache/bulk-delete-audio-cache).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `ids` | array | List of audio cache entry IDs to delete (max 20). 1–20 items. **Required.** |
+
+#### `download-cached-audio-file`
+
+Download cached audio file.
+
+API reference: [Download cached audio file](/api-reference/agents/endpoint/audio-cache/download-audio-file).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `entryId` | string | The audio cache entry. **Required.** |
+
+#### `replace-audio-file-for-a-cache-entry`
+
+Replace audio file for a cache entry.
+
+API reference: [Replace audio file for a cache entry](/api-reference/agents/endpoint/audio-cache/replace-audio-file).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `entryId` | string | The audio cache entry. **Required.** |
+
+#### `update-cache-entry-file-and-settings`
+
+Update cache entry file and settings.
+
+API reference: [Update cache entry file and settings](/api-reference/agents/endpoint/audio-cache/update-audio-cache-details).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `entryId` | string | The audio cache entry. **Required.** |
+
+#### `generate-a-tts-audio-preview`
+
+Generate a TTS audio preview.
+
+API reference: [Generate a TTS audio preview](/api-reference/agents/endpoint/audio-cache/synthesize-audio-preview).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `storeOnS3` | boolean | Store audio on S3 and return a presigned URL. |
+| `language` | string | BCP-47 language tag, e.g. 'en-US'. **Required.** |
+| `provider` | string | TTS provider key, e.g. 'eleven_labs', 'cartesia'. Default `eleven_labs`. |
+| `config` | object | Provider-specific synthesis config. **Required.** |
+| `text` | string | Text to synthesize. **Required.** |
+
+#### `preview-tts-audio-for-a-cache-entry`
+
+Preview TTS audio for a cache entry.
+
+API reference: [Preview TTS audio for a cache entry](/api-reference/agents/endpoint/audio-cache/synthesize-audio-preview).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `entryId` | string | The audio cache entry. **Required.** |
+| `config` | string | Voice tuning settings (provider-specific). **Required.** |
+| `language` | string | BCP-47 language tag, e.g. 'en-US'. |
+| `text` | string | Text to synthesize. **Required.** |
 
 ## Run, test & inspect
 
-Exercise agents, place calls, and pull back the data they produce. Backed by the [Debug Chat](/api-reference/debug-chat/introduction) and [Conversations](/api-reference/conversations/introduction) APIs.
+### Debug chat
 
-**Debug chat**
+#### `create-a-new-debug-chat-session`
 
-| Tool | What it does |
-| --- | --- |
-| `create-a-new-debug-chat-session` | Create a new debug chat session |
-| `send-a-message-to-a-debug-chat-session` | Send a message to a debug chat session |
+Create a new debug chat session.
 
-**Conversations**
+API reference: [Create a new debug chat session](/api-reference/debug-chat/create-debug-chat-session).
 
-| Tool | What it does |
-| --- | --- |
-| `get-a-conversation-by-id` | Get a conversation by ID |
-| `list-conversations-for-a-project` | List conversations for a project |
-| `get-audio-recording-for-a-conversation` | Get audio recording for a conversation |
-| `add-annotations-to-a-conversation` | Add annotations to a conversation |
-| `upsert-a-note-on-a-conversation` | Upsert a note on a conversation |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `variantId` | string | Variant ID to use. |
+| `asrLangCode` | string | ASR language code (e.g. en-US). Defaults to server config. |
+| `channel` | string | Channel type (e.g. chat.polyai). |
+| `ttsLangCode` | string | TTS language code (e.g. en-US). Defaults to server config. |
+| `conversationId` | string | Custom conversation ID. Auto-generated if omitted. |
+| `clientEnv` | string | Client environment (sandbox, pre-release, live). **Required.** |
+| `integrationAttributes` | object | Custom attributes accessible via conv.integration_attributes in project functions. |
 
-**Test suites**
+#### `send-a-message-to-a-debug-chat-session`
 
-| Tool | What it does |
-| --- | --- |
-| `trigger-a-test-run` | Trigger a test run |
-| `get-a-test-run-by-id` | Get a test run by ID |
-| `list-test-runs-for-a-project` | List test runs for a project |
-| `list-test-cases` | List test cases |
-| `get-test-case` | Get test case |
-| `get-test-execution-history-for-a-project` | Get test execution history for a project |
+Send a message to a debug chat session.
 
-**Outbound calling**
+API reference: [Send a message to a debug chat session](/api-reference/debug-chat/send-debug-chat-message).
 
-| Tool | What it does |
-| --- | --- |
-| `trigger-an-outbound-call` | Trigger an outbound call |
-| `get-the-status-of-an-outbound-call` | Get the status of an outbound call |
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `conversationId` | string | The conversation. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `asrLangCode` | string | ASR language code (e.g. en-US). Defaults to server config. |
+| `metadata` | object | User input metadata. |
+| `ttsLangCode` | string | TTS language code (e.g. en-US). Defaults to server config. |
+| `message` | string | User input message. Default ``. |
+| `clientEnv` | string | Client environment (sandbox, pre-release, live). **Required.** |
+
+### Conversations
+
+#### `get-a-conversation-by-id`
+
+Get a conversation by ID.
+
+API reference: [Get a conversation by ID](/api-reference/conversations/v3/endpoint/get-conversation-by-id).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `conversationId` | string | The conversation. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `list-conversations-for-a-project`
+
+List conversations for a project.
+
+API reference: [List conversations for a project](/api-reference/conversations/v3/endpoint/get-conversations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `limit` | integer | Max number of conversations to return. Min 1. Default `50`. |
+| `offset` | integer | Number of conversations to skip. Min 0. Default `0`. |
+
+#### `get-audio-recording-for-a-conversation`
+
+Get audio recording for a conversation.
+
+API reference: [Get audio recording for a conversation](/api-reference/conversations/v3/endpoint/get-conversation-audio).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `conversationId` | string | The conversation. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `redacted` | boolean | Whether to return redacted audio. Default `False`. |
+| `direction` | string | Audio direction: "combined", "user", or "agent". One of `combined`, `user`, `agent`. Default `combined`. |
+
+#### `add-annotations-to-a-conversation`
+
+Add annotations to a conversation.
+
+API reference: [Add annotations to a conversation](/api-reference/conversations/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `conversationId` | string | The conversation. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `annotations` | array | Array. **Required.** |
+
+#### `upsert-a-note-on-a-conversation`
+
+Upsert a note on a conversation.
+
+API reference: [Upsert a note on a conversation](/api-reference/conversations/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `conversationId` | string | The conversation. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `note` | string | — **Required.** |
+
+### Test suites
+
+#### `trigger-a-test-run`
+
+Trigger a test run.
+
+API reference: [Trigger a test run](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `testCaseIds` | array | 1–1000 items. **Required.** |
+| `branchId` | string | — **Required.** |
+
+#### `get-a-test-run-by-id`
+
+Get a test run by ID.
+
+API reference: [Get a test run by ID](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `testRunId` | string | The test run. **Required.** |
+
+#### `list-test-runs-for-a-project`
+
+List test runs for a project.
+
+API reference: [List test runs for a project](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `limit` | integer | Max number of test runs to return. Min 1. Default `100`. |
+| `branchId` | string | Filter by branch ID. |
+| `offset` | integer | Number of test runs to skip. Min 0. Default `0`. |
+| `testSetId` | string | Filter by test set ID. |
+
+#### `list-test-cases`
+
+List test cases.
+
+API reference: [List test cases](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `get-test-case`
+
+Get test case.
+
+API reference: [Get test case](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `testCaseId` | string | The test case. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `get-test-execution-history-for-a-project`
+
+Get test execution history for a project.
+
+API reference: [Get test execution history for a project](/testing/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `limit` | integer | Max number of history entries to return. Min 1. Default `100`. |
+| `testCaseId` | string | Filter by test case ID. |
+| `branchId` | string | Filter by branch ID. |
+| `offset` | integer | Number of history entries to skip. Min 0. Default `0`. |
+
+### Outbound calling
+
+#### `trigger-an-outbound-call`
+
+Trigger an outbound call.
+
+API reference: [Trigger an outbound call](/api-reference/agents/endpoint/outbound-calls/trigger-outbound-call).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `variantId` | string | Variant ID to use for the call. If omitted, the default connector for the environment is used. |
+| `encryption` | string | Telephony encryption mode. Defaults to tls_srtp. |
+| `metadata` | object | Arbitrary key-value metadata passed through to the call. Must be under 26 KB when base64-encoded. |
+| `toNumber` | string | Phone number to dial in E.164 format (e.g. +442012345678). **Required.** |
+| `environment` | string | Target environment: sandbox, pre-release, or live. **Required.** |
+| `countryCode` | string | ISO 3166-1 alpha-2 country code for number parsing (e.g. GB). Only needed when to_number lacks a country prefix. |
+
+#### `get-the-status-of-an-outbound-call`
+
+Get the status of an outbound call.
+
+API reference: [Get the status of an outbound call](/api-reference/agents/endpoint/outbound-calls/get-outbound-call-status).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `callSid` | string | The outbound call SID. **Required.** |
+| `environment` | string | Target environment: sandbox, pre-release, or live. **Required.** |
+
+## Manage agent infrastructure
+
+### MCP servers on an agent
+
+#### `add-mcp-server`
+
+Add MCP server.
+
+API reference: [Add MCP server](/mcp/agent-studio-integrations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `url` | string | — **Required.** |
+| `timeout` | number | 0–30. |
+| `providerId` | string | — **Required.** |
+| `auth` | object | Nested object — see the API reference for the full schema. |
+
+#### `list-mcp-servers`
+
+List MCP servers.
+
+API reference: [List MCP servers](/mcp/agent-studio-integrations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+
+#### `connect-mcp-server`
+
+Connect MCP server.
+
+API reference: [Connect MCP server](/mcp/agent-studio-integrations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `serverId` | string | The MCP server. **Required.** |
+
+#### `update-mcp-server`
+
+Update MCP server.
+
+API reference: [Update MCP server](/mcp/agent-studio-integrations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `serverId` | string | The MCP server. **Required.** |
+| `url` | string | — |
+| `timeout` | number | 0–30. |
+| `auth` | object | Nested object — see the API reference for the full schema. |
+
+#### `delete-mcp-server`
+
+Delete MCP server.
+
+API reference: [Delete MCP server](/mcp/agent-studio-integrations).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `serverId` | string | The MCP server. **Required.** |
+
+### Secrets
+
+#### `create-a-secret`
+
+Create a secret.
+
+API reference: [Create a secret](/secrets/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `value` | string | — **Required.** |
+| `description` | string | Default ``. |
+| `name` | string | — **Required.** |
+
+#### `delete-a-secret`
+
+Delete a secret.
+
+API reference: [Delete a secret](/secrets/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `secretName` | string | The secret name. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 ## Monitor deployed agents
 
+<Note>The Alerts family is **enterprise-only** — it's available on US, UK, and EU workspaces, not on self-serve Studio workspaces.</Note>
+
 Watch live agents and react to issues. Backed by the [Alerts API](/api-reference/alerts/introduction).
 
-**Alerts**
+### Alerts
 
 | Tool | What it does |
 | --- | --- |
@@ -214,28 +1198,6 @@ Watch live agents and react to issues. Backed by the [Alerts API](/api-reference
 | `delete-alert-rule` | Delete an alert rule and its associated state, including the Datadog monitor. |
 | `get-active-alerts` | Get active alerts (rules currently in `ALERT` state). Optional query params: `project_id` (filter by project ID), `metric` (filter by metric type). |
 
-## Manage agent infrastructure
-
-Configure the plumbing behind an agent.
-
-**MCP servers on an agent**
-
-| Tool | What it does |
-| --- | --- |
-| `add-mcp-server` | Add MCP server |
-| `list-mcp-servers` | List MCP servers |
-| `connect-mcp-server` | Connect MCP server |
-| `update-mcp-server` | Update MCP server |
-| `delete-mcp-server` | Delete MCP server |
-
-**Secrets**
-
-| Tool | What it does |
-| --- | --- |
-| `create-a-secret` | Create a secret |
-| `delete-a-secret` | Delete a secret |
-
 ## Limiting what a client can do
 
 To narrow what a client can reach, scope the [API key](/mcp/authentication) itself. Create a [least-privilege key](/mcp/builder/security#restrict-the-tool-surface) limited to the agents and permissions that client needs — for example, a read-only key for a monitoring assistant. The key's scope governs which calls succeed, so a narrowly scoped key can't create, delete, or deploy even though the tools are still discovered.
-

--- a/mcp/builder/introduction.mdx
+++ b/mcp/builder/introduction.mdx
@@ -13,6 +13,10 @@ mode: wide
 
 <iframe src="https://www.loom.com/embed/12af169c4b8240c3ab4625e4119e3113?hideEmbedTopBar=true" title="Loom video player" frameborder="0" className="w-full aspect-video rounded-xl" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen />
 
+<Note>
+Looking to query conversation data — transcripts, metrics, analytics — rather than build? That's the sibling [Data MCP](/mcp/data/introduction) server.
+</Note>
+
 ## Builder MCP vs Agent Studio MCP integrations
 
 The two point in opposite directions:

--- a/mcp/data/introduction.mdx
+++ b/mcp/data/introduction.mdx
@@ -14,7 +14,7 @@ Both are PolyAI-hosted servers you connect **in** to. They cover different jobs 
 |                   | **Data MCP**                                        | **Builder MCP**                                    |
 | ----------------- | --------------------------------------------------- | -------------------------------------------------- |
 | **What it's for** | Query conversation data: transcripts, metrics, analytics | Build, test, and deploy agents                     |
-| **Authenticates** | Account API key or Personal Access Token            | Workspace-scoped API key                           |
+| **Authenticates** | Account API key                                     | Workspace-scoped API key                           |
 | **Endpoint path** | `/data-mcp`                                         | `/builder-mcp`                                     |
 | **Docs**          | This page                                           | [Builder MCP](/mcp/builder/introduction)           |
 
@@ -44,12 +44,9 @@ To connect a client **out** from a live agent to a third-party server instead, s
 
 ## Get started
 
-### 1. Choose how to authenticate
+### 1. Get an account API key
 
-Every request carries a credential in the `X-API-KEY` header. Two kinds work — see [Authentication](/mcp/authentication) for how each is scoped:
-
-* **Account API key** — created from your account page in Agent Studio. Scoped to the account; can query any project in it.
-* **Personal Access Token (PAT)** — created from your user profile in Agent Studio. Scoped to your user's project access.
+Every request carries an API key in the `X-API-KEY` header. Data MCP uses an **account API key**, created from your account page in Agent Studio — it's scoped to the account and can query any project in it. See [Authentication](/mcp/authentication) for details.
 
 ### 2. Set your key and endpoint
 

--- a/mcp/data/introduction.mdx
+++ b/mcp/data/introduction.mdx
@@ -1,0 +1,205 @@
+---
+title: "Data MCP"
+sidebarTitle: Overview
+description: "Query PolyAI conversation data — transcripts, metrics, and analytics — from any MCP client."
+mode: wide
+---
+
+**Data MCP** is PolyAI's authenticated [MCP](https://modelcontextprotocol.io) server for conversation data. Connect an MCP client — [Claude Code](https://www.claude.com/product/claude-code), [Cursor](https://cursor.com), [Claude Desktop](https://claude.ai/download), or [Codex](https://developers.openai.com/codex/cli/) — and you can search conversations, read transcripts, and aggregate metrics in plain language, without calling the [REST API](/api-reference/introduction) directly.
+
+## Data MCP vs Builder MCP
+
+Both are PolyAI-hosted servers you connect **in** to. They cover different jobs and authenticate differently.
+
+|                   | **Data MCP**                                        | **Builder MCP**                                    |
+| ----------------- | --------------------------------------------------- | -------------------------------------------------- |
+| **What it's for** | Query conversation data: transcripts, metrics, analytics | Build, test, and deploy agents                     |
+| **Authenticates** | Account API key or Personal Access Token            | Workspace-scoped API key                           |
+| **Endpoint path** | `/data-mcp`                                         | `/builder-mcp`                                     |
+| **Docs**          | This page                                           | [Builder MCP](/mcp/builder/introduction)           |
+
+<Note>
+To connect a client **out** from a live agent to a third-party server instead, see [Agent Studio MCP integrations](/mcp/agent-studio-integrations).
+</Note>
+
+## What you can do
+
+<CardGroup cols={2}>
+  <Card title="Conversation search" icon="magnifying-glass">
+    Find conversations by their metrics and scores — filter and sort on quality scores, duration, and outcomes over a date range.
+  </Card>
+
+  <Card title="Transcripts" icon="file-lines">
+    Read the full, turn-by-turn record of a conversation, or search across many conversations for a word or phrase with surrounding context.
+  </Card>
+
+  <Card title="Metrics catalog" icon="list-check">
+    List the metrics available for an account or project — the built-in ones plus any custom metrics your projects define.
+  </Card>
+
+  <Card title="Analytics" icon="chart-line">
+    Roll a metric up over time into buckets you can chart — grouped, filtered, and thresholded however you like.
+  </Card>
+</CardGroup>
+
+## Get started
+
+### 1. Choose how to authenticate
+
+Every request carries a credential in the `X-API-KEY` header. Two kinds work — see [Authentication](/mcp/authentication) for how each is scoped:
+
+* **Account API key** — created from your account page in Agent Studio. Scoped to the account; can query any project in it.
+* **Personal Access Token (PAT)** — created from your user profile in Agent Studio. Scoped to your user's project access.
+
+### 2. Set your key and endpoint
+
+Keys are region-specific — a US key doesn't work against the UK endpoint. Match the region to where your account lives.
+
+| Region | Endpoint                            |
+| ------ | ----------------------------------- |
+| US     | `https://api.us.poly.ai/data-mcp`   |
+| UK     | `https://api.uk.poly.ai/data-mcp`   |
+| EU     | `https://api.eu.poly.ai/data-mcp`   |
+
+```bash
+export POLYAI_API_KEY="your_api_key_here"
+export POLYAI_DATA_MCP_URL="https://api.us.poly.ai/data-mcp"   # use your region
+```
+
+### 3. Add the server to your client
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http polyai-data "$POLYAI_DATA_MCP_URL" \
+      --header "X-API-KEY: $POLYAI_API_KEY" \
+      --header "Accept: application/json, text/event-stream"
+    ```
+
+    Verify with `claude mcp list`, then ask Claude to list its PolyAI data tools.
+  </Tab>
+
+  <Tab title="Cursor">
+    Add to `~/.cursor/mcp.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "polyai-data": {
+          "url": "https://api.us.poly.ai/data-mcp",
+          "headers": { "X-API-KEY": "your_api_key_here" }
+        }
+      }
+    }
+    ```
+
+    Restart Cursor, then open the MCP settings to confirm the tools loaded.
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    Add to your `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "polyai-data": {
+          "url": "https://api.us.poly.ai/data-mcp",
+          "headers": { "X-API-KEY": "your_api_key_here" }
+        }
+      }
+    }
+    ```
+
+    Restart Claude Desktop. The tools appear in the tools menu.
+  </Tab>
+
+  <Tab title="Codex">
+    Add to your Codex MCP config:
+
+    ```toml
+    [mcp_servers.polyai-data]
+    url = "https://api.us.poly.ai/data-mcp"
+    headers = { "X-API-KEY" = "your_api_key_here" }
+    ```
+  </Tab>
+</Tabs>
+
+<Tip>
+  Working across regions? Add the server once per region under distinct names (e.g. `polyai-data-us`, `polyai-data-uk`, `polyai-data-eu`), each with that region's key.
+</Tip>
+
+## Tools
+
+Each tool carries its own input schema, which your client reads directly from the server. The tables below cover the parameters you'll actually use.
+
+### `get-metrics`
+
+List the filterable metrics for an account, optionally scoped to a project — built-in metrics plus any custom metrics the project defines. Use this first to discover what you can filter and aggregate on.
+
+| Parameter    | Type   | Description                                       |
+| ------------ | ------ | ------------------------------------------------- |
+| `project_id` | string | Optional project scope.    |
+
+### `search-conversations`
+
+Search conversations by metric filters, with sorting and pagination.
+
+| Parameter         | Type     | Description                                                                                                        |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `from` / `to`     | datetime | Bounds on conversation start time (`from` inclusive, `to` exclusive).                                              |
+| `filters`         | array    | Metric filters: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `contains`, `not_contains`, `exists`. |
+| `filter_operator` | string   | How filters combine: `and` (default) or `or`.                                                                      |
+| `sort`            | object   | `{field, order}` — field is `started_at`, `duration`, or `conversation_id`. Defaults to `started_at` descending.   |
+| `limit` / `offset`| integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
+| `project_id`      | string   | Optional project scope.                                                                     |
+
+### `search-transcripts`
+
+Full-text search over transcript turns across conversations, returning matches with surrounding turns for context.
+
+| Parameter          | Type     | Description                                                     |
+| ------------------ | -------- | --------------------------------------------------------------- |
+| `q`                | string   | Search phrase, 3–300 characters. **Required.**                  |
+| `from` / `to`      | datetime | Bounds on conversation start time.                              |
+| `context_turns`    | integer  | Turns of context around each match, 0–3 (default 1).            |
+| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.        |
+| `project_id`       | string   | Optional project scope.                  |
+
+### `get-conversation`
+
+Fetch every turn of a single conversation.
+
+| Parameter         | Type   | Description                                    |
+| ----------------- | ------ | ---------------------------------------------- |
+| `conversation_id` | string | The conversation to fetch. **Required.**       |
+| `project_id`      | string | Optional project scope. |
+
+### `aggregate-a-metric-over-a-time-interval`
+
+Aggregate a metric over a time window into buckets you can chart — with grouping, cohort filters, and post-aggregation thresholds.
+
+| Parameter          | Type     | Description                                                                                                     |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `metric`           | string   | Metric to aggregate (case-insensitive, e.g. `poly_score`). **Required.**                                          |
+| `aggs`             | array    | Aggregations to compute: `sum`, `avg`, `min`, `max`, `p50`, `p95`, `p99`, `conversation_count`, `distinct_count`. **Required.** |
+| `from` / `to`      | datetime | Window bounds (`from` inclusive, `to` exclusive).                                                                 |
+| `interval`         | string   | Time bucket: `hourly`, `daily`, `weekly`, `monthly`. Omit for a single unbucketed result.                          |
+| `group_by`         | array    | Group by `project_id`, `channel`, `deployment_id`, `variant_id`, `client_env`, or — for string metrics — `value_string`. |
+| `filters`          | array    | Cohort filters on other metrics: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `exists`. |
+| `having`           | array    | Post-aggregation thresholds: `{field, op, value}` where `field` is one of the `aggs`.                              |
+| `channel`          | array    | Restrict to channels: `VOICE-SIP`, `CHAT`, `WEBCHAT`, `SMS`.                                                       |
+| `client_env`       | array    | Restrict to environments: `test`, `sandbox`, `pre-release`, `live`, `scenarios`.                                   |
+| `deployment_id` / `variant_id` | array | Restrict to specific deployments or variants.                                                          |
+| `sort`             | object   | Secondary sort on a `group_by` or `aggs` field, applied after the ascending bucket sort.                            |
+| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
+| `project_id`       | string   | Optional project scope.                                                                     |
+
+## Errors
+
+| Status | Meaning                                                                                |
+| ------ | -------------------------------------------------------------------------------------- |
+| `400`  | Request validation error.                                                               |
+| `401`  | Missing or invalid `X-API-KEY`.                                                         |
+| `403`  | Authenticated, but missing the required permission.                                      |
+| `404`  | Not found or empty result — also returned when a credential can't access the account.   |
+| `422`  | Unsupported filter.                                                                     |

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -37,14 +37,14 @@ PolyAI hosts two authenticated MCP servers. Both use the streamable HTTP transpo
     Build, test, and deploy PolyAI agents — agents, data, and alerts as tools. Authenticates with a **workspace-scoped API key**.
   </Card>
   <Card title="Data MCP" icon="chart-line" href="/mcp/data/introduction">
-    Query conversation data — search conversations, read transcripts, aggregate metrics. Authenticates with an **account API key or Personal Access Token**.
+    Query conversation data — search conversations, read transcripts, aggregate metrics. Authenticates with an **account API key**.
   </Card>
 </CardGroup>
 
 | | **Builder MCP** | **Data MCP** |
 | --- | --- | --- |
 | **What it's for** | Build, test, and deploy agents | Query conversations, transcripts, and metrics |
-| **Authenticates** | Workspace-scoped API key | Account API key or Personal Access Token |
+| **Authenticates** | Workspace-scoped API key | Account API key |
 | **Endpoint path** | `/builder-mcp` | `/data-mcp` |
 | **Regions** | US, UK, EU, Studio | US, UK, EU |
 

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: MCP
 sidebarTitle: Overview
-description: PolyAI's authenticated MCP servers let any MCP client build and manage your agents. Learn the two directions MCP works and which one you need.
+description: PolyAI's authenticated MCP servers let any MCP client build agents and query their data. Learn the two directions MCP works and which one you need.
 mode: wide
 ---
 
@@ -10,8 +10,8 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open 
 ## Two directions
 
 <CardGroup cols={2}>
-  <Card title="Builder MCP" icon="wrench" href="/mcp/builder/introduction">
-    **Build agents.** Point an MCP client — Cursor, Claude Code, Claude Desktop, Codex — at PolyAI's authenticated MCP server and build, test, and deploy your agents from your IDE. This is PolyAI's own hosted MCP.
+  <Card title="PolyAI's MCP servers" icon="server" href="#polyai-s-mcp-servers">
+    **Connect a client in.** Point an MCP client — Cursor, Claude Code, Claude Desktop, Codex — at one of PolyAI's authenticated, hosted MCP servers to build agents or query their data from your IDE. Your tool acts as a client of PolyAI's server.
   </Card>
   <Card title="Agent Studio MCP integrations" icon="plug" href="/mcp/agent-studio-integrations">
     **Consume external tools.** Add a third-party MCP server inside Agent Studio so your live agent can call its tools during conversations. This is your agent acting as a client of someone else's server.
@@ -21,32 +21,43 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open 
 | You want to… | Use | Direction |
 | --- | --- | --- |
 | Build and manage PolyAI agents from an IDE or AI coding tool | [Builder MCP](/mcp/builder/introduction) | Client → PolyAI |
+| Query conversation data — transcripts, metrics, analytics — from a client | [Data MCP](/mcp/data/introduction) | Client → PolyAI |
 | Let your live agent look up data or trigger actions in another system | [Agent Studio MCP integrations](/mcp/agent-studio-integrations) | PolyAI → external server |
 
 <Note>
-The rest of this section documents **PolyAI's authenticated MCP** — the Builder MCP and any servers we add later. For the connect-out direction, see [Agent Studio MCP integrations](/mcp/agent-studio-integrations).
+The rest of this section documents **PolyAI's authenticated MCP servers** — the ones you connect a client to. For the connect-out direction, see [Agent Studio MCP integrations](/mcp/agent-studio-integrations).
 </Note>
+
+## PolyAI's MCP servers
+
+PolyAI hosts two authenticated MCP servers. Both use the streamable HTTP transport, are region-specific, and take a credential in the `X-API-KEY` header — but they cover different jobs and authenticate differently.
+
+<CardGroup cols={2}>
+  <Card title="Builder MCP" icon="wrench" href="/mcp/builder/introduction">
+    Build, test, and deploy PolyAI agents — agents, data, and alerts as tools. Authenticates with a **workspace-scoped API key**.
+  </Card>
+  <Card title="Data MCP" icon="chart-line" href="/mcp/data/introduction">
+    Query conversation data — search conversations, read transcripts, aggregate metrics. Authenticates with an **account API key or Personal Access Token**.
+  </Card>
+</CardGroup>
+
+| | **Builder MCP** | **Data MCP** |
+| --- | --- | --- |
+| **What it's for** | Build, test, and deploy agents | Query conversations, transcripts, and metrics |
+| **Authenticates** | Workspace-scoped API key | Account API key or Personal Access Token |
+| **Endpoint path** | `/builder-mcp` | `/data-mcp` |
+| **Regions** | US, UK, EU, Studio | US, UK, EU |
 
 ## Get connected
 
 <Steps>
   <Step title="Authenticate">
-    Create a workspace-scoped API key and configure your client's auth. See [Authentication](/mcp/authentication).
+    Create the API key your server needs and configure your client's auth. See [Authentication](/mcp/authentication).
   </Step>
   <Step title="Connect a client">
     Add the server to Cursor, Claude Code, Claude Desktop, or Codex with a single command. See [Quickstart](/mcp/quickstart).
   </Step>
-  <Step title="Build">
-    Use the [Builder MCP](/mcp/builder/introduction) to create, test, and deploy agents conversationally.
+  <Step title="Build or query">
+    Use the [Builder MCP](/mcp/builder/introduction) to create, test, and deploy agents, or the [Data MCP](/mcp/data/introduction) to query conversation data — all conversationally.
   </Step>
 </Steps>
-
-## MCPs we offer
-
-<CardGroup cols={2}>
-  <Card title="Builder MCP" icon="wrench" href="/mcp/builder/introduction">
-    Build, test, and deploy PolyAI agents — agents, data, and alerts as tools.
-  </Card>
-</CardGroup>
-
-{/* REVIEW: This list grows as more MCP servers ship. Builder MCP is the only one at launch. */}

--- a/mcp/quickstart.mdx
+++ b/mcp/quickstart.mdx
@@ -18,11 +18,11 @@ Pick the server for the job:
     Build, test, and deploy agents. Uses a **workspace-scoped API key** and the `/builder-mcp` endpoint.
   </Card>
   <Card title="Data MCP" icon="chart-line" href="/mcp/data/introduction">
-    Query conversations, transcripts, and metrics. Uses an **account API key or PAT** and the `/data-mcp` endpoint.
+    Query conversations, transcripts, and metrics. Uses an **account API key** and the `/data-mcp` endpoint.
   </Card>
 </CardGroup>
 
-The steps below use Builder MCP. Data MCP connects the same way — swap the endpoint path to `/data-mcp` and the credential to an account key or PAT. See [Data MCP → Get started](/mcp/data/introduction#get-started) for its exact commands.
+The steps below use Builder MCP. Data MCP connects the same way — swap the endpoint path to `/data-mcp` and the credential to an account API key. See [Data MCP → Get started](/mcp/data/introduction#get-started) for its exact commands.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ The steps below use Builder MCP. Data MCP connects the same way — swap the end
     Create the credential your server needs (see [Authentication](/mcp/authentication)):
 
     - **Builder MCP** — a **workspace-scoped API key** from the **API Keys** tab on your workspace homepage in Agent Studio (see [API keys](/secrets/api-keys)).
-    - **Data MCP** — an **account API key** from your account page, or a **Personal Access Token** from your user profile.
+    - **Data MCP** — an **account API key** from your account page.
 
     Copy the value when it's shown — the full key only appears once.
 

--- a/mcp/quickstart.mdx
+++ b/mcp/quickstart.mdx
@@ -1,15 +1,28 @@
 ---
 title: Quickstart
 sidebarTitle: Quickstart
-description: Connect PolyAI's Builder MCP to your MCP client in one command.
+description: Connect one of PolyAI's MCP servers to your MCP client in one command.
 mode: wide
 ---
 
-{/* REVIEW: Confirm the public endpoint path is `/builder-mcp` and that the connect
-    commands below match the launch spec. Links to DEVP-333 (quickstart) and the
+{/* REVIEW: Confirm the public endpoint paths are `/builder-mcp` and `/data-mcp`, and that the
+    connect commands below match the launch spec. Links to DEVP-333 (quickstart) and the
     DEVP-380 how-to video are pending. */}
 
-Connect the [Builder MCP](/mcp/builder/introduction) to your MCP client — [Cursor](https://cursor.com), [Claude Code](https://www.claude.com/product/claude-code), [Claude Desktop](https://claude.ai/download), or [Codex](https://developers.openai.com/codex/cli/) — and you can build PolyAI agents from your IDE in minutes.
+Connect one of PolyAI's authenticated MCP servers to your MCP client — [Cursor](https://cursor.com), [Claude Code](https://www.claude.com/product/claude-code), [Claude Desktop](https://claude.ai/download), or [Codex](https://developers.openai.com/codex/cli/) — and you can drive PolyAI from your IDE in minutes.
+
+Pick the server for the job:
+
+<CardGroup cols={2}>
+  <Card title="Builder MCP" icon="wrench" href="/mcp/builder/introduction">
+    Build, test, and deploy agents. Uses a **workspace-scoped API key** and the `/builder-mcp` endpoint.
+  </Card>
+  <Card title="Data MCP" icon="chart-line" href="/mcp/data/introduction">
+    Query conversations, transcripts, and metrics. Uses an **account API key or PAT** and the `/data-mcp` endpoint.
+  </Card>
+</CardGroup>
+
+The steps below use Builder MCP. Data MCP connects the same way — swap the endpoint path to `/data-mcp` and the credential to an account key or PAT. See [Data MCP → Get started](/mcp/data/introduction#get-started) for its exact commands.
 
 ## Prerequisites
 
@@ -22,7 +35,12 @@ Connect the [Builder MCP](/mcp/builder/introduction) to your MCP client — [Cur
   </Step>
 
   <Step title="Get an API key">
-    Create a **workspace-scoped API key** from the **API Keys** tab on your workspace homepage in Agent Studio (see [API keys](/secrets/api-keys)). Copy the value when it's shown — the full key only appears once.
+    Create the credential your server needs (see [Authentication](/mcp/authentication)):
+
+    - **Builder MCP** — a **workspace-scoped API key** from the **API Keys** tab on your workspace homepage in Agent Studio (see [API keys](/secrets/api-keys)).
+    - **Data MCP** — an **account API key** from your account page, or a **Personal Access Token** from your user profile.
+
+    Copy the value when it's shown — the full key only appears once.
 
     <Frame caption="Create a key from the API Keys tab in Agent Studio.">
       <img
@@ -54,17 +72,17 @@ Connect the [Builder MCP](/mcp/builder/introduction) to your MCP client — [Cur
 
 ```bash
 export POLYAI_API_KEY="your_api_key_here"
-export POLYAI_MCP_URL="https://api.us.poly.ai/builder-mcp"   # use your region — see below
+export POLYAI_MCP_URL="https://api.us.poly.ai/builder-mcp"   # use your region and server — see below
 ```
 
-| Region | Endpoint |
-| ------ | -------------------------------------- |
-| US     | `https://api.us.poly.ai/builder-mcp`     |
-| UK     | `https://api.uk.poly.ai/builder-mcp`     |
-| EU     | `https://api.eu.poly.ai/builder-mcp`     |
-| Studio | `https://api.studio.poly.ai/builder-mcp` |
+| Region | Builder MCP | Data MCP |
+| ------ | ----------- | -------- |
+| US     | `https://api.us.poly.ai/builder-mcp`     | `https://api.us.poly.ai/data-mcp`     |
+| UK     | `https://api.uk.poly.ai/builder-mcp`     | `https://api.uk.poly.ai/data-mcp`     |
+| EU     | `https://api.eu.poly.ai/builder-mcp`     | `https://api.eu.poly.ai/data-mcp`     |
+| Studio | `https://api.studio.poly.ai/builder-mcp` | —                                     |
 
-Match the region to the workspace you build in. Connecting to the wrong region authenticates against the wrong workspace. See [Authentication](/mcp/authentication#pick-your-region) for how regions map to workspaces.
+Match the region to the workspace or account your key belongs to. Connecting to the wrong region authenticates against the wrong place. See [Authentication](/mcp/authentication#pick-your-region) for how regions map.
 
 ## 2. Add the server to your client
 
@@ -124,7 +142,11 @@ Match the region to the workspace you build in. Connecting to the wrong region a
 </Tabs>
 
 <Tip>
-Most clients set the `Accept: application/json, text/event-stream` header for you. If a client can't connect, add it explicitly — the server uses the streamable HTTP transport.
+Most clients set the `Accept: application/json, text/event-stream` header for you. If a client can't connect, add it explicitly — both servers use the streamable HTTP transport.
+</Tip>
+
+<Tip>
+Connecting to both servers at once? Add them under distinct names (e.g. `polyai-builder` and `polyai-data`), each with its own endpoint and key.
 </Tip>
 
 ## 3. Verify
@@ -150,5 +172,11 @@ A number greater than zero means the server is reachable and your key is valid.
   </Card>
   <Card title="Build, test & deploy" icon="rocket" href="/mcp/builder/walkthrough">
     Walk through the full lifecycle from branch to production.
+  </Card>
+  <Card title="Query data with Data MCP" icon="chart-line" href="/mcp/data/introduction">
+    Search conversations, read transcripts, and aggregate metrics.
+  </Card>
+  <Card title="Consume external tools" icon="plug" href="/mcp/agent-studio-integrations">
+    Connect a live agent out to a third-party MCP server.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What

Adds the **Data MCP** server to the docs and reworks the overarching MCP pages so they cover both of PolyAI's connect-in servers (Builder MCP + Data MCP), then rebuilds the Builder MCP capabilities page into a full per-tool parameter reference.

## Changes

**New**
- `mcp/data/introduction.mdx` — Data MCP overview: what it does, auth (account key or PAT), region endpoints, per-client setup, per-tool parameter tables, errors. Added to nav under a new **Data MCP** group.

**Overarching pages — now cover both servers**
- `mcp/overview.mdx` — presents Builder MCP and Data MCP as the two connect-in servers alongside the connect-out Agent Studio integrations; comparison table (purpose, credential, endpoint path, regions).
- `mcp/authentication.mdx` — documents both credential models (workspace-scoped key for Builder MCP; account key or PAT for Data MCP) with per-server region tables.
- `mcp/quickstart.mdx` — generalized to connecting either server.
- `mcp/builder/introduction.mdx` — cross-links the sibling Data MCP server.

**Builder MCP capabilities — full tool reference**
- `mcp/builder/capabilities.mdx` — rewritten with a parameter table for **all 91 Studio tools**, generated from the live `tools/list` schema (path/query/body params flattened, defaults/enums/ranges/required surfaced), matching the Data MCP page's format. Each tool links to its corresponding **API reference** endpoint. Alerts family retained as enterprise-only (not exposed on Studio).

## Verification

- Tool schemas pulled live from the Studio Builder MCP endpoint (`tools/list` → 91 tools, confirming the documented Studio count).
- **81/81** internal links across the changed pages resolve on this branch (validated programmatically), including the ~60 new API-reference deep links.
- `docs.json` is valid JSON; no MDX-breaking characters in generated tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
