### PR TITLE
docs: fix broken Two directions card link on MCP overview

### DIFF
--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -10,7 +10,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open 
 ## Two directions
 
 <CardGroup cols={2}>
-  <Card title="PolyAI's MCP servers" icon="server" href="#polyai-s-mcp-servers">
+  <Card title="PolyAI's MCP servers" icon="server" href="/mcp/quickstart">
     **Connect a client in.** Point an MCP client — Cursor, Claude Code, Claude Desktop, Codex — at one of PolyAI's authenticated, hosted MCP servers to build agents or query their data from your IDE. Your tool acts as a client of PolyAI's server.
   </Card>
   <Card title="Agent Studio MCP integrations" icon="plug" href="/mcp/agent-studio-integrations">


### PR DESCRIPTION
The **PolyAI's MCP servers** card in the *Two directions* section pointed at a same-page anchor (`#polyai-s-mcp-servers`) whose slug didn't resolve. Point it at [`/mcp/quickstart`](/mcp/quickstart) — the server-agnostic connect-a-client-in flow — so the card lands on a real page.

Follow-up to #588 (merged after this fix was written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)