### PR TITLE
docs: Data MCP capabilities page + refreshed Builder tool list

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -919,7 +919,8 @@
             "group": "Data MCP",
             "icon": "chart-line",
             "pages": [
-              "mcp/data/introduction"
+              "mcp/data/introduction",
+              "mcp/data/capabilities"
             ]
           },
           {

--- a/mcp/builder/capabilities.mdx
+++ b/mcp/builder/capabilities.mdx
@@ -7,7 +7,7 @@ mode: wide
 
 Builder MCP exposes PolyAI's platform as MCP tools, grouped into the families below. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server; the parameter tables below reproduce that schema so you can see what each tool takes without connecting first.
 
-US, UK, and EU workspaces expose **97 tools**; self-serve Studio workspaces expose **91** (the Alerts family is enterprise-only). Tool names appear exactly as your client sees them in `tools/list`.
+US, UK, and EU workspaces expose **106 tools**; self-serve Studio workspaces expose **100** (the Alerts family is enterprise-only). Tool names appear exactly as your client sees them in `tools/list`.
 
 <Note>
 Every tool maps to a PolyAI REST endpoint. Parameters are named `path_*`, `query_*`, or nested under a request `body` in the raw schema — the tables below strip those prefixes and expand the body's top-level fields. For deeply nested request bodies, follow the **API reference** link on each tool for the complete schema. To see exactly what your client discovered, ask it to list its tools or query the endpoint's `tools/list` method (see [Quickstart → Verify](/mcp/quickstart#3-verify)).
@@ -27,12 +27,12 @@ API reference: [Create agent](/api-reference/agents/endpoint/agents/create-agent
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `accountId` | string | The account (workspace). **Required.** |
-| `llmSettings` | object | Nested object — see the API reference for the full schema. |
-| `responseSettings` | object | Nested object — see the API reference for the full schema. **Required.** |
-| `experimentalConfig` | object | Nested object — see the API reference for the full schema. |
 | `name` | string | 1–100 characters. **Required.** |
-| `agentId` | string | — |
+| `experimentalConfig` | object | Nested object — see the API reference for the full schema. |
+| `responseSettings` | object | Nested object — see the API reference for the full schema. **Required.** |
+| `llmSettings` | object | Nested object — see the API reference for the full schema. |
 | `voiceSettings` | object | Nested object — see the API reference for the full schema. |
+| `agentId` | string | — |
 
 #### `list-agents`
 
@@ -76,8 +76,8 @@ API reference: [Get agent behavior rules](/api-reference/agents/endpoint/behavio
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `update-agent-behavior-rules`
 
@@ -122,8 +122,8 @@ API reference: [Delete branch](/api-reference/agents/endpoint/branches/delete-br
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `merge-branch`
 
@@ -150,6 +150,17 @@ API reference: [Sync branch with parent](/api-reference/agents/introduction).
 | `branchId` | string | The branch. **Required.** |
 | `conflictResolutions` | array | Array. |
 
+#### `deploy-a-branch`
+
+Deploy a branch.
+
+API reference: [Deploy a branch](/api-reference/agents/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
 ### Deployments
 
 #### `publish-the-current-draft-to-an-environment`
@@ -172,10 +183,10 @@ API reference: [Promote a deployment to the next environment](/api-reference/age
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `deploymentId` | string | The deployment. **Required.** |
 | `agentId` | string | The agent. **Required.** |
-| `targetEnvironment` | string | One of `pre-release`, `live`. |
+| `deploymentId` | string | The deployment. **Required.** |
 | `deploymentMessage` | string | Default ``. |
+| `targetEnvironment` | string | One of `pre-release`, `live`. |
 
 #### `rollback-to-a-previous-deployment`
 
@@ -185,8 +196,8 @@ API reference: [Rollback to a previous deployment](/api-reference/agents/endpoin
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `deploymentId` | string | The deployment. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `deploymentId` | string | The deployment. **Required.** |
 | `deploymentMessage` | string | Default ``. |
 
 #### `list-deployments-for-an-environment`
@@ -198,8 +209,8 @@ API reference: [List deployments for an environment](/api-reference/agents/endpo
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `limit` | integer | Max number of deployments to return. |
 | `environment` | string | Environment to list deployments for (sandbox, pre-release, live). One of `sandbox`, `pre-release`, `live`. **Required.** |
+| `limit` | integer | Max number of deployments to return. |
 
 #### `get-active-deployment-per-environment`
 
@@ -223,11 +234,11 @@ API reference: [Create knowledge base topic](/api-reference/agents/endpoint/know
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
-| `content` | string | — **Required.** |
 | `name` | string | — **Required.** |
-| `exampleQueries` | object | Nested object — see the API reference for the full schema. |
+| `content` | string | — **Required.** |
 | `actions` | string | — |
 | `isActive` | boolean | — |
+| `exampleQueries` | object | Nested object — see the API reference for the full schema. |
 
 #### `get-knowledge-base-topic`
 
@@ -237,8 +248,8 @@ API reference: [Get knowledge base topic](/api-reference/agents/endpoint/knowled
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `topicId` | string | The knowledge base topic. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `topicId` | string | The knowledge base topic. **Required.** |
 | `branchId` | string | The branch. **Required.** |
 
 #### `list-knowledge-base-topics`
@@ -249,8 +260,8 @@ API reference: [List knowledge base topics](/api-reference/agents/endpoint/knowl
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `update-knowledge-base-topic`
 
@@ -260,14 +271,14 @@ API reference: [Update knowledge base topic](/api-reference/agents/endpoint/know
 
 | Parameter | Type | Description |
 | --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
 | `topicId` | string | The knowledge base topic. **Required.** |
 | `agentId` | string | The agent. **Required.** |
-| `branchId` | string | The branch. **Required.** |
 | `content` | string | — |
+| `name` | string | — |
+| `actions` | string | — |
 | `isActive` | boolean | — |
 | `exampleQueries` | object | Nested object — see the API reference for the full schema. |
-| `actions` | string | — |
-| `name` | string | — |
 
 #### `delete-knowledge-base-topic`
 
@@ -277,8 +288,8 @@ API reference: [Delete knowledge base topic](/api-reference/agents/endpoint/know
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `topicId` | string | The knowledge base topic. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `topicId` | string | The knowledge base topic. **Required.** |
 | `branchId` | string | The branch. **Required.** |
 
 ### Variants
@@ -293,9 +304,9 @@ API reference: [Create variant](/api-reference/agents/endpoint/variants/create-v
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `name` | string | — **Required.** |
 | `attributeValues` | object | Default `{'values': {}}`. |
 | `isDefault` | boolean | — |
-| `name` | string | — **Required.** |
 
 #### `list-variants`
 
@@ -305,8 +316,8 @@ API reference: [List variants](/api-reference/agents/endpoint/variants/list-vari
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `update-variant`
 
@@ -317,11 +328,11 @@ API reference: [Update variant](/api-reference/agents/endpoint/variants/update-v
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `branchId` | string | The branch. **Required.** |
-| `agentId` | string | The agent. **Required.** |
 | `variantId` | string | The variant. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 | `name` | string | — |
-| `isDefault` | boolean | — |
 | `attributeValues` | object | Nested object — see the API reference for the full schema. |
+| `isDefault` | boolean | — |
 
 #### `delete-variant`
 
@@ -332,8 +343,8 @@ API reference: [Delete variant](/api-reference/agents/endpoint/variants/delete-v
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `branchId` | string | The branch. **Required.** |
 | `variantId` | string | The variant. **Required.** |
+| `branchId` | string | The branch. **Required.** |
 
 ### Attributes
 
@@ -357,8 +368,8 @@ API reference: [List attributes](/api-reference/agents/endpoint/variants/list-at
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `update-attribute`
 
@@ -368,9 +379,9 @@ API reference: [Update attribute](/api-reference/agents/endpoint/variants/update
 
 | Parameter | Type | Description |
 | --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
 | `attributeId` | string | The attribute. **Required.** |
 | `agentId` | string | The agent. **Required.** |
-| `branchId` | string | The branch. **Required.** |
 | `name` | string | — **Required.** |
 
 #### `delete-attribute`
@@ -381,8 +392,8 @@ API reference: [Delete attribute](/api-reference/agents/endpoint/variants/delete
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `attributeId` | string | The attribute. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `attributeId` | string | The attribute. **Required.** |
 | `branchId` | string | The branch. **Required.** |
 
 ### Connectors
@@ -427,12 +438,12 @@ API reference: [Update a connector](/api-reference/agents/endpoint/connectors/up
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `connectorId` | string | The connector. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `connectorId` | string | The connector. **Required.** |
+| `voiceName` | string | Google TTS voice name (e.g. en-US-Neural2-A). tts_lang_code is auto-derived from the voice name prefix. Validated via TTS probe. |
 | `variantId` | string | Variant ID to assign, or null to unassign. |
 | `projectId` | string | Move connector to a different project. API key must have access to both projects. |
 | `asrLangCode` | string | ASR language code (e.g. en-US). |
-| `voiceName` | string | Google TTS voice name (e.g. en-US-Neural2-A). tts_lang_code is auto-derived from the voice name prefix. Validated via TTS probe. |
 
 #### `batch-update-connectors`
 
@@ -477,8 +488,8 @@ API reference: [Get a specific phone number](/api-reference/agents/endpoint/phon
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `phoneNumber` | string | The phone number (E.164). **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `batch-get-phone-numbers`
 
@@ -510,8 +521,8 @@ API reference: [Import a single phone number](/api-reference/agents/endpoint/pho
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `phoneNumber` | string | The phone number (E.164). **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
 | `clientEnv` | string | Client environment (sandbox, pre-release, live). Default `live`. |
 
 #### `import-phone-numbers-into-a-project`
@@ -534,8 +545,8 @@ API reference: [Delete a single phone number](/api-reference/agents/endpoint/pho
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `phoneNumber` | string | The phone number (E.164). **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `delete-phone-numbers-from-a-project`
 
@@ -556,8 +567,8 @@ API reference: [Reassign a phone number to a different connector](/api-reference
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `phoneNumber` | string | The phone number (E.164). **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `phoneNumber` | string | The phone number (E.164). **Required.** |
 | `connectorId` | string | Target connector ID to reassign the phone number to. **Required.** |
 
 ### Config pages (real-time config)
@@ -570,8 +581,8 @@ API reference: [Get a config page by environment](/api-reference/agents/endpoint
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `clientEnv` | string | The client environment. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `list-all-config-pages`
 
@@ -591,8 +602,8 @@ API reference: [Update config variables for an environment](/api-reference/agent
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `clientEnv` | string | The client environment. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `clientEnv` | string | The client environment. **Required.** |
 | `variables` | object | Key-value pairs to merge into the existing config. **Required.** |
 
 #### `upsert-the-json-schema-for-a-config-page`
@@ -603,9 +614,95 @@ API reference: [Upsert the JSON Schema for a config page](/api-reference/agents/
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `clientEnv` | string | The client environment. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `clientEnv` | string | The client environment. **Required.** |
 | `schema` | object | JSON Schema (Draft 7) definition. **Required.** |
+
+### Functions
+
+#### `start-function`
+
+Start function.
+
+API reference: [Start function](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `end-function-`
+
+End function.
+
+API reference: [End function.](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+
+#### `execute-a-function`
+
+Execute a function.
+
+API reference: [Execute a function](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `functionId` | string | Path parameter. **Required.** |
+| `flowId` | string | — |
+| `args` | object | Default `{}`. |
+
+#### `duplicate-a-function`
+
+Duplicate a function.
+
+API reference: [Duplicate a function](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
+| `functionId` | string | Path parameter. **Required.** |
+| `name` | string | — |
+
+#### `replace-the-start-function-code-`
+
+Replace the start function code.
+
+API reference: [Replace the start function code.](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `code` | string | — **Required.** |
+
+#### `replace-the-end-function-code-`
+
+Replace the end function code.
+
+API reference: [Replace the end function code.](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `branchId` | string | The branch. **Required.** |
+| `code` | string | — **Required.** |
+
+#### `get-python-type-stubs-for-a-function-`
+
+Get Python type stubs for a function.
+
+API reference: [Get Python type stubs for a function.](/tools/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `functionId` | string | Path parameter. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 ## Voice & audio
 
@@ -620,11 +717,11 @@ API reference: [Register a new voice in the voice library](/api-reference/agents
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `accountId` | string | The account (workspace). **Required.** |
-| `providerVoiceId` | string | Voice ID from the TTS provider. **Required.** |
-| `config` | object | Provider-specific voice config. **Required.** |
-| `name` | string | Human-readable voice name. **Required.** |
 | `voiceMetadata` | object | Additional voice metadata. |
+| `name` | string | Human-readable voice name. **Required.** |
+| `providerVoiceId` | string | Voice ID from the TTS provider. **Required.** |
 | `provider` | string | TTS provider (e.g. GOOGLE, OPENAI, ELEVENLABS). **Required.** |
+| `config` | object | Provider-specific voice config. **Required.** |
 
 #### `update-a-voice-in-the-voice-library`
 
@@ -636,9 +733,9 @@ API reference: [Update a voice in the voice library](/api-reference/agents/endpo
 | --- | --- | --- |
 | `voiceId` | string | The voice. **Required.** |
 | `accountId` | string | The account (workspace). **Required.** |
-| `providerVoiceId` | string | Voice ID from the TTS provider. |
 | `voiceMetadata` | object | Additional voice metadata. |
 | `name` | string | Human-readable voice name. |
+| `providerVoiceId` | string | Voice ID from the TTS provider. |
 | `provider` | string | TTS provider. |
 | `config` | object | Provider-specific voice config. |
 
@@ -650,8 +747,8 @@ API reference: [Get a single voice from the voice library](/api-reference/agents
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `voiceId` | string | The voice. **Required.** |
 | `accountId` | string | The account (workspace). **Required.** |
+| `voiceId` | string | The voice. **Required.** |
 
 #### `list-all-voices-in-the-account-s-voice-library`
 
@@ -662,10 +759,10 @@ API reference: [List all voices in the account's voice library](/api-reference/a
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `accountId` | string | The account (workspace). **Required.** |
-| `provider` | string | Filter by TTS provider, e.g. 'GOOGLE', 'ELEVENLABS'. |
-| `isPolyVoice` | boolean | If set, restrict to (or exclude) Poly's curated voices. |
-| `language` | string | Filter by voice metadata language, e.g. 'en-US'. |
 | `gender` | string | Filter by voice metadata gender. One of `male`, `female`, `neutral`. |
+| `provider` | string | Filter by TTS provider, e.g. 'GOOGLE', 'ELEVENLABS'. |
+| `language` | string | Filter by voice metadata language, e.g. 'en-US'. |
+| `isPolyVoice` | boolean | If set, restrict to (or exclude) Poly's curated voices. |
 
 #### `synthesize-a-short-audio-sample-of-a-voice`
 
@@ -675,8 +772,8 @@ API reference: [Synthesize a short audio sample of a voice](/api-reference/agent
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `voiceId` | string | The voice. **Required.** |
 | `accountId` | string | The account (workspace). **Required.** |
+| `voiceId` | string | The voice. **Required.** |
 
 #### `set-the-project-s-active-voice`
 
@@ -700,9 +797,9 @@ API reference: [Create or update a deployed voice configuration](/api-reference/
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `probability` | number | Traffic weight (0.0–1.0). **Required.** |
-| `id` | string | Deployed voice ID — omit to create, provide to update. |
 | `voiceId` | string | Voice ID to deploy. **Required.** |
+| `id` | string | Deployed voice ID — omit to create, provide to update. |
+| `probability` | number | Traffic weight (0.0–1.0). **Required.** |
 
 #### `list-deployed-voice-configurations`
 
@@ -722,8 +819,8 @@ API reference: [Delete a deployed voice configuration](/api-reference/agents/int
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `deployedVoiceId` | string | The deployed voice configuration. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 ### Voice & disclaimer tuning
 
@@ -747,13 +844,13 @@ API reference: [Update voice tuning settings](/api-reference/agents/introduction
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `voiceId` | string | The voice. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `voiceId` | string | The voice. **Required.** |
+| `resetToDefault` | boolean | Reset settings to provider defaults. |
+| `similarityBoost` | integer | Similarity boost (0–100). |
+| `modelId` | string | Provider model ID override. |
 | `speed` | number | Playback speed multiplier. |
 | `stability` | integer | Voice stability (0–100). |
-| `resetToDefault` | boolean | Reset settings to provider defaults. |
-| `modelId` | string | Provider model ID override. |
-| `similarityBoost` | integer | Similarity boost (0–100). |
 
 #### `get-disclaimer-voice-tuning-settings`
 
@@ -774,13 +871,13 @@ API reference: [Update disclaimer voice tuning settings](/api-reference/agents/i
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `voiceId` | string | The voice. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `voiceId` | string | The voice. **Required.** |
 | `resetToDefault` | boolean | Reset settings to provider defaults. |
-| `stability` | integer | Voice stability (0–100). |
 | `similarityBoost` | integer | Similarity boost (0–100). |
 | `modelId` | string | Provider model ID override. |
 | `speed` | number | Playback speed multiplier. |
+| `stability` | integer | Voice stability (0–100). |
 
 ### Audio cache
 
@@ -793,9 +890,9 @@ API reference: [List audio cache entries](/api-reference/agents/endpoint/audio-c
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
+| `sort` | string | Sort expression, e.g. "hit_count:desc", "duration:asc". |
 | `offset` | integer | Pagination offset. Min 0. Default `0`. |
 | `limit` | integer | Max entries to return (1-200). 1–200. Default `50`. |
-| `sort` | string | Sort expression, e.g. "hit_count:desc", "duration:asc". |
 
 #### `delete-audio-cache-entry`
 
@@ -805,8 +902,8 @@ API reference: [Delete audio cache entry](/api-reference/agents/endpoint/audio-c
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `entryId` | string | The audio cache entry. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `bulk-delete-audio-cache-entries`
 
@@ -827,8 +924,8 @@ API reference: [Download cached audio file](/api-reference/agents/endpoint/audio
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `entryId` | string | The audio cache entry. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `replace-audio-file-for-a-cache-entry`
 
@@ -838,8 +935,8 @@ API reference: [Replace audio file for a cache entry](/api-reference/agents/endp
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `entryId` | string | The audio cache entry. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `update-cache-entry-file-and-settings`
 
@@ -849,8 +946,8 @@ API reference: [Update cache entry file and settings](/api-reference/agents/endp
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `entryId` | string | The audio cache entry. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `generate-a-tts-audio-preview`
 
@@ -861,11 +958,11 @@ API reference: [Generate a TTS audio preview](/api-reference/agents/endpoint/aud
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `storeOnS3` | boolean | Store audio on S3 and return a presigned URL. |
+| `config` | object | Provider-specific synthesis config. **Required.** |
 | `language` | string | BCP-47 language tag, e.g. 'en-US'. **Required.** |
 | `provider` | string | TTS provider key, e.g. 'eleven_labs', 'cartesia'. Default `eleven_labs`. |
-| `config` | object | Provider-specific synthesis config. **Required.** |
 | `text` | string | Text to synthesize. **Required.** |
+| `storeOnS3` | boolean | Store audio on S3 and return a presigned URL. |
 
 #### `preview-tts-audio-for-a-cache-entry`
 
@@ -894,13 +991,13 @@ API reference: [Create a new debug chat session](/api-reference/debug-chat/creat
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `variantId` | string | Variant ID to use. |
-| `asrLangCode` | string | ASR language code (e.g. en-US). Defaults to server config. |
-| `channel` | string | Channel type (e.g. chat.polyai). |
-| `ttsLangCode` | string | TTS language code (e.g. en-US). Defaults to server config. |
-| `conversationId` | string | Custom conversation ID. Auto-generated if omitted. |
-| `clientEnv` | string | Client environment (sandbox, pre-release, live). **Required.** |
 | `integrationAttributes` | object | Custom attributes accessible via conv.integration_attributes in project functions. |
+| `variantId` | string | Variant ID to use. |
+| `channel` | string | Channel type (e.g. chat.polyai). |
+| `asrLangCode` | string | ASR language code (e.g. en-US). Defaults to server config. |
+| `conversationId` | string | Custom conversation ID. Auto-generated if omitted. |
+| `ttsLangCode` | string | TTS language code (e.g. en-US). Defaults to server config. |
+| `clientEnv` | string | Client environment (sandbox, pre-release, live). **Required.** |
 
 #### `send-a-message-to-a-debug-chat-session`
 
@@ -910,8 +1007,8 @@ API reference: [Send a message to a debug chat session](/api-reference/debug-cha
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `conversationId` | string | The conversation. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `conversationId` | string | The conversation. **Required.** |
 | `asrLangCode` | string | ASR language code (e.g. en-US). Defaults to server config. |
 | `metadata` | object | User input metadata. |
 | `ttsLangCode` | string | TTS language code (e.g. en-US). Defaults to server config. |
@@ -951,8 +1048,8 @@ API reference: [Get audio recording for a conversation](/api-reference/conversat
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `conversationId` | string | The conversation. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `conversationId` | string | The conversation. **Required.** |
 | `redacted` | boolean | Whether to return redacted audio. Default `False`. |
 | `direction` | string | Audio direction: "combined", "user", or "agent". One of `combined`, `user`, `agent`. Default `combined`. |
 
@@ -964,8 +1061,8 @@ API reference: [Add annotations to a conversation](/api-reference/conversations/
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `conversationId` | string | The conversation. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `conversationId` | string | The conversation. **Required.** |
 | `annotations` | array | Array. **Required.** |
 
 #### `upsert-a-note-on-a-conversation`
@@ -976,23 +1073,24 @@ API reference: [Upsert a note on a conversation](/api-reference/conversations/in
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `conversationId` | string | The conversation. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `conversationId` | string | The conversation. **Required.** |
 | `note` | string | — **Required.** |
 
 ### Test suites
 
 #### `trigger-a-test-run`
 
-Trigger a test run.
+Trigger a simulation test run. Select test cases explicitly by id, by severity, or by tag via the `select` field. The legacy flat `testCaseIds` body is deprecated but still accepted.
 
 API reference: [Trigger a test run](/testing/introduction).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `testCaseIds` | array | 1–1000 items. **Required.** |
+| `select` | string | — **Required.** |
 | `branchId` | string | — **Required.** |
+| `testCaseIds` | string | — |
 
 #### `get-a-test-run-by-id`
 
@@ -1002,8 +1100,8 @@ API reference: [Get a test run by ID](/testing/introduction).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `testRunId` | string | The test run. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `list-test-runs-for-a-project`
 
@@ -1014,10 +1112,10 @@ API reference: [List test runs for a project](/testing/introduction).
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `limit` | integer | Max number of test runs to return. Min 1. Default `100`. |
-| `branchId` | string | Filter by branch ID. |
 | `offset` | integer | Number of test runs to skip. Min 0. Default `0`. |
 | `testSetId` | string | Filter by test set ID. |
+| `limit` | integer | Max number of test runs to return. Min 1. Default `100`. |
+| `branchId` | string | Filter by branch ID. |
 
 #### `list-test-cases`
 
@@ -1027,8 +1125,8 @@ API reference: [List test cases](/testing/introduction).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `get-test-case`
 
@@ -1038,8 +1136,8 @@ API reference: [Get test case](/testing/introduction).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `testCaseId` | string | The test case. **Required.** |
 | `agentId` | string | The agent. **Required.** |
+| `testCaseId` | string | The test case. **Required.** |
 | `branchId` | string | The branch. **Required.** |
 
 #### `get-test-execution-history-for-a-project`
@@ -1051,10 +1149,10 @@ API reference: [Get test execution history for a project](/testing/introduction)
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `limit` | integer | Max number of history entries to return. Min 1. Default `100`. |
-| `testCaseId` | string | Filter by test case ID. |
-| `branchId` | string | Filter by branch ID. |
 | `offset` | integer | Number of history entries to skip. Min 0. Default `0`. |
+| `limit` | integer | Max number of history entries to return. Min 1. Default `100`. |
+| `branchId` | string | Filter by branch ID. |
+| `testCaseId` | string | Filter by test case ID. |
 
 ### Outbound calling
 
@@ -1067,12 +1165,12 @@ API reference: [Trigger an outbound call](/api-reference/agents/endpoint/outboun
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `variantId` | string | Variant ID to use for the call. If omitted, the default connector for the environment is used. |
 | `encryption` | string | Telephony encryption mode. Defaults to tls_srtp. |
+| `variantId` | string | Variant ID to use for the call. If omitted, the default connector for the environment is used. |
 | `metadata` | object | Arbitrary key-value metadata passed through to the call. Must be under 26 KB when base64-encoded. |
+| `countryCode` | string | ISO 3166-1 alpha-2 country code for number parsing (e.g. GB). Only needed when to_number lacks a country prefix. |
 | `toNumber` | string | Phone number to dial in E.164 format (e.g. +442012345678). **Required.** |
 | `environment` | string | Target environment: sandbox, pre-release, or live. **Required.** |
-| `countryCode` | string | ISO 3166-1 alpha-2 country code for number parsing (e.g. GB). Only needed when to_number lacks a country prefix. |
 
 #### `get-the-status-of-an-outbound-call`
 
@@ -1100,10 +1198,10 @@ API reference: [Add MCP server](/mcp/agent-studio-integrations).
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
-| `url` | string | — **Required.** |
-| `timeout` | number | 0–30. |
 | `providerId` | string | — **Required.** |
+| `timeout` | number | 0–30. |
 | `auth` | object | Nested object — see the API reference for the full schema. |
+| `url` | string | — **Required.** |
 
 #### `list-mcp-servers`
 
@@ -1113,8 +1211,8 @@ API reference: [List MCP servers](/mcp/agent-studio-integrations).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
+| `agentId` | string | The agent. **Required.** |
 
 #### `connect-mcp-server`
 
@@ -1124,9 +1222,9 @@ API reference: [Connect MCP server](/mcp/agent-studio-integrations).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
+| `serverId` | string | The MCP server. **Required.** |
 | `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
-| `serverId` | string | The MCP server. **Required.** |
 
 #### `update-mcp-server`
 
@@ -1137,11 +1235,11 @@ API reference: [Update MCP server](/mcp/agent-studio-integrations).
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `branchId` | string | The branch. **Required.** |
-| `agentId` | string | The agent. **Required.** |
 | `serverId` | string | The MCP server. **Required.** |
-| `url` | string | — |
+| `agentId` | string | The agent. **Required.** |
 | `timeout` | number | 0–30. |
 | `auth` | object | Nested object — see the API reference for the full schema. |
+| `url` | string | — |
 
 #### `delete-mcp-server`
 
@@ -1151,9 +1249,9 @@ API reference: [Delete MCP server](/mcp/agent-studio-integrations).
 
 | Parameter | Type | Description |
 | --- | --- | --- |
+| `serverId` | string | The MCP server. **Required.** |
 | `agentId` | string | The agent. **Required.** |
 | `branchId` | string | The branch. **Required.** |
-| `serverId` | string | The MCP server. **Required.** |
 
 ### Secrets
 
@@ -1166,9 +1264,22 @@ API reference: [Create a secret](/secrets/introduction).
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `agentId` | string | The agent. **Required.** |
-| `value` | string | — **Required.** |
-| `description` | string | Default ``. |
-| `name` | string | — **Required.** |
+| `value` | string | Secret value. **Required.** |
+| `name` | string | Display name of the secret. **Required.** |
+| `description` | string | Description of the secret. |
+
+#### `update-a-secret`
+
+Update a secret.
+
+API reference: [Update a secret](/secrets/introduction).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `agentId` | string | The agent. **Required.** |
+| `secretName` | string | The secret name. **Required.** |
+| `description` | string | Description of the secret (unchanged if omitted). |
+| `value` | string | New secret value. **Required.** |
 
 #### `delete-a-secret`
 
@@ -1198,6 +1309,6 @@ Watch live agents and react to issues. Backed by the [Alerts API](/api-reference
 | `delete-alert-rule` | Delete an alert rule and its associated state, including the Datadog monitor. |
 | `get-active-alerts` | Get active alerts (rules currently in `ALERT` state). Optional query params: `project_id` (filter by project ID), `metric` (filter by metric type). |
 
-## Enforcing limitations
+## Limiting what a client can do
 
 To narrow what a client can reach, scope the [API key](/mcp/authentication) itself. Create a [least-privilege key](/mcp/builder/security#restrict-the-tool-surface) limited to the agents and permissions that client needs — for example, a read-only key for a monitoring assistant. The key's scope governs which calls succeed, so a narrowly scoped key can't create, delete, or deploy even though the tools are still discovered.

--- a/mcp/data/capabilities.mdx
+++ b/mcp/data/capabilities.mdx
@@ -1,0 +1,97 @@
+---
+title: Capabilities
+sidebarTitle: Capabilities
+description: The tools Data MCP exposes, grouped by what they do — each with its parameters.
+mode: wide
+---
+
+Data MCP exposes PolyAI's conversation data as MCP tools. Your client discovers them automatically on connection — you don't configure tools by hand. Each tool carries its own input schema, which the client reads directly from the server; the parameter tables below reproduce that schema so you can see what each tool takes without connecting first.
+
+Data MCP exposes **5 tools**. Tool names appear exactly as your client sees them in `tools/list`.
+
+<Note>
+To see exactly what your client discovered, ask it to list its tools or query the endpoint's `tools/list` method. Parameters map to a PolyAI REST endpoint — they're sent as path segments, query parameters, or a request body — but your client handles that wiring from the schema; the tables below just list what you can set.
+</Note>
+
+## Search & read conversations
+
+Find conversations by their metrics, search across transcript text, and pull back the full turn-by-turn record.
+
+### `search-conversations`
+
+Search conversations by metric filters, with sorting and pagination.
+
+| Parameter         | Type     | Description                                                                                                        |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `from` / `to`     | datetime | Bounds on conversation start time (`from` inclusive, `to` exclusive).                                              |
+| `filters`         | array    | Metric filters: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `contains`, `not_contains`, `exists`. |
+| `filter_operator` | string   | How filters combine: `and` (default) or `or`.                                                                      |
+| `sort`            | object   | `{field, order}` — field is `started_at`, `duration`, or `conversation_id`. Defaults to `started_at` descending.   |
+| `limit` / `offset`| integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
+| `project_id`      | string   | Optional project scope.                                                                     |
+
+### `search-transcripts`
+
+Full-text search over transcript turns across conversations, returning matches with surrounding turns for context.
+
+| Parameter          | Type     | Description                                                     |
+| ------------------ | -------- | --------------------------------------------------------------- |
+| `q`                | string   | Search phrase, 3–300 characters. **Required.**                  |
+| `from` / `to`      | datetime | Bounds on conversation start time.                              |
+| `context_turns`    | integer  | Turns of context around each match, 0–3 (default 1).            |
+| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.        |
+| `project_id`       | string   | Project scope. Required when authenticating with a PAT.         |
+
+### `get-conversation`
+
+Fetch every turn of a single conversation.
+
+| Parameter         | Type   | Description                                    |
+| ----------------- | ------ | ---------------------------------------------- |
+| `conversation_id` | string | The conversation to fetch. **Required.**       |
+| `project_id`      | string | Optional project scope. |
+
+## Metrics & analytics
+
+Discover which metrics you can filter and aggregate on, then roll one up over time into buckets you can chart.
+
+### `get-metrics`
+
+List the filterable metrics for an account, optionally scoped to a project — built-in metrics plus any custom metrics the project defines. Use this first to discover what you can filter and aggregate on.
+
+| Parameter    | Type   | Description                                       |
+| ------------ | ------ | ------------------------------------------------- |
+| `project_id` | string | Optional project scope.    |
+
+### `-experimental--aggregate-a-metric-over-a-time-interval`
+
+Aggregate a metric over a time window into buckets you can chart — with grouping, cohort filters, and post-aggregation thresholds.
+
+<Note>This tool is **experimental** — its name (carrying the `-experimental-` prefix) and schema may change. Your client discovers the current name from `tools/list`.</Note>
+
+| Parameter          | Type     | Description                                                                                                     |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `metric`           | string   | Metric to aggregate (case-insensitive, e.g. `poly_score`). **Required.**                                          |
+| `aggs`             | array    | Aggregations to compute: `sum`, `avg`, `min`, `max`, `p50`, `p95`, `p99`, `conversation_count`, `distinct_count`. **Required.** |
+| `from` / `to`      | datetime | Window bounds (`from` inclusive, `to` exclusive).                                                                 |
+| `interval`         | string   | Time bucket: `hourly`, `daily`, `weekly`, `monthly`. Omit for a single unbucketed result.                          |
+| `group_by`         | array    | Group by `project_id`, `channel`, `deployment_id`, `variant_id`, `client_env`, or — for string metrics — `value_string`. |
+| `filters`          | array    | Cohort filters on other metrics: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `exists`. |
+| `filter_operator`  | string   | How filters combine: `and` (default) or `or`.                                                                     |
+| `having`           | array    | Post-aggregation thresholds: `{field, op, value}` where `field` is one of the `aggs`.                              |
+| `channel`          | array    | Restrict to channels: `VOICE-SIP`, `CHAT`, `WEBCHAT`, `SMS`.                                                       |
+| `client_env`       | array    | Restrict to environments: `test`, `sandbox`, `pre-release`, `live`, `scenarios`.                                   |
+| `deployment_id` / `variant_id` | array | Restrict to specific deployments or variants.                                                          |
+| `sort`             | object   | Secondary sort on a `group_by` or `aggs` field, applied after the ascending bucket sort.                            |
+| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
+| `project_id`       | string   | Optional project scope.                                                                     |
+
+## Errors
+
+| Status | Meaning                                                                                |
+| ------ | -------------------------------------------------------------------------------------- |
+| `400`  | Request validation error.                                                               |
+| `401`  | Missing or invalid `X-API-KEY`.                                                         |
+| `403`  | Authenticated, but missing the required permission.                                      |
+| `404`  | Not found or empty result — also returned when a credential can't access the account.   |
+| `422`  | Unsupported filter.                                                                     |

--- a/mcp/data/introduction.mdx
+++ b/mcp/data/introduction.mdx
@@ -125,78 +125,15 @@ export POLYAI_DATA_MCP_URL="https://api.us.poly.ai/data-mcp"   # use your region
   Working across regions? Add the server once per region under distinct names (e.g. `polyai-data-us`, `polyai-data-uk`, `polyai-data-eu`), each with that region's key.
 </Tip>
 
-## Tools
+## Capabilities
 
-Each tool carries its own input schema, which your client reads directly from the server. The tables below cover the parameters you'll actually use.
+Data MCP exposes 5 tools — conversation search, transcript search, single-conversation fetch, a metrics catalog, and metric aggregation. See [Capabilities](/mcp/data/capabilities) for each tool and its parameters.
 
-### `get-metrics`
-
-List the filterable metrics for an account, optionally scoped to a project — built-in metrics plus any custom metrics the project defines. Use this first to discover what you can filter and aggregate on.
-
-| Parameter    | Type   | Description                                       |
-| ------------ | ------ | ------------------------------------------------- |
-| `project_id` | string | Optional project scope.    |
-
-### `search-conversations`
-
-Search conversations by metric filters, with sorting and pagination.
-
-| Parameter         | Type     | Description                                                                                                        |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| `from` / `to`     | datetime | Bounds on conversation start time (`from` inclusive, `to` exclusive).                                              |
-| `filters`         | array    | Metric filters: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `contains`, `not_contains`, `exists`. |
-| `filter_operator` | string   | How filters combine: `and` (default) or `or`.                                                                      |
-| `sort`            | object   | `{field, order}` — field is `started_at`, `duration`, or `conversation_id`. Defaults to `started_at` descending.   |
-| `limit` / `offset`| integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
-| `project_id`      | string   | Optional project scope.                                                                     |
-
-### `search-transcripts`
-
-Full-text search over transcript turns across conversations, returning matches with surrounding turns for context.
-
-| Parameter          | Type     | Description                                                     |
-| ------------------ | -------- | --------------------------------------------------------------- |
-| `q`                | string   | Search phrase, 3–300 characters. **Required.**                  |
-| `from` / `to`      | datetime | Bounds on conversation start time.                              |
-| `context_turns`    | integer  | Turns of context around each match, 0–3 (default 1).            |
-| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.        |
-| `project_id`       | string   | Optional project scope.                  |
-
-### `get-conversation`
-
-Fetch every turn of a single conversation.
-
-| Parameter         | Type   | Description                                    |
-| ----------------- | ------ | ---------------------------------------------- |
-| `conversation_id` | string | The conversation to fetch. **Required.**       |
-| `project_id`      | string | Optional project scope. |
-
-### `aggregate-a-metric-over-a-time-interval`
-
-Aggregate a metric over a time window into buckets you can chart — with grouping, cohort filters, and post-aggregation thresholds.
-
-| Parameter          | Type     | Description                                                                                                     |
-| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `metric`           | string   | Metric to aggregate (case-insensitive, e.g. `poly_score`). **Required.**                                          |
-| `aggs`             | array    | Aggregations to compute: `sum`, `avg`, `min`, `max`, `p50`, `p95`, `p99`, `conversation_count`, `distinct_count`. **Required.** |
-| `from` / `to`      | datetime | Window bounds (`from` inclusive, `to` exclusive).                                                                 |
-| `interval`         | string   | Time bucket: `hourly`, `daily`, `weekly`, `monthly`. Omit for a single unbucketed result.                          |
-| `group_by`         | array    | Group by `project_id`, `channel`, `deployment_id`, `variant_id`, `client_env`, or — for string metrics — `value_string`. |
-| `filters`          | array    | Cohort filters on other metrics: `{metric, op, value}`. Operators: `eq`, `gt`, `gte`, `lt`, `lte`, `in`, `ex`, `exists`. |
-| `having`           | array    | Post-aggregation thresholds: `{field, op, value}` where `field` is one of the `aggs`.                              |
-| `channel`          | array    | Restrict to channels: `VOICE-SIP`, `CHAT`, `WEBCHAT`, `SMS`.                                                       |
-| `client_env`       | array    | Restrict to environments: `test`, `sandbox`, `pre-release`, `live`, `scenarios`.                                   |
-| `deployment_id` / `variant_id` | array | Restrict to specific deployments or variants.                                                          |
-| `sort`             | object   | Secondary sort on a `group_by` or `aggs` field, applied after the ascending bucket sort.                            |
-| `limit` / `offset` | integer  | Pagination. `limit` 1–100 (default 20), `offset` 0–1000.                                                           |
-| `project_id`       | string   | Optional project scope.                                                                     |
-
-## Errors
-
-| Status | Meaning                                                                                |
-| ------ | -------------------------------------------------------------------------------------- |
-| `400`  | Request validation error.                                                               |
-| `401`  | Missing or invalid `X-API-KEY`.                                                         |
-| `403`  | Authenticated, but missing the required permission.                                      |
-| `404`  | Not found or empty result — also returned when a credential can't access the account.   |
-| `422`  | Unsupported filter.                                                                     |
+<CardGroup cols={2}>
+  <Card title="Browse the tools" icon="list-check" href="/mcp/data/capabilities">
+    Every Data MCP tool, grouped by what it does, with its parameters.
+  </Card>
+  <Card title="Build with Builder MCP" icon="wrench" href="/mcp/builder/introduction">
+    Need to build, test, and deploy agents instead? That's the sibling Builder MCP.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Addresses Damian's feedback that Data MCP should have a **Capabilities** section mapping each tool call to an explanation, structured so the two servers stack up. Also re-tested both MCP servers live to refresh parameters.

## Changes

**Data MCP — now parallel to Builder MCP (Overview + Capabilities)**
- **New** `mcp/data/capabilities.mdx` — each of the 5 Data MCP tools mapped to an explanation and parameter table, grouped into *Search & read conversations* and *Metrics & analytics*. Schemas pulled live from the Data MCP `tools/list`.
- `mcp/data/introduction.mdx` — inline Tools/Errors moved to Capabilities; added a Capabilities pointer + sibling cards.
- `docs.json` — `mcp/data/capabilities` added to the Data MCP nav group.

**Builder MCP — refreshed from live `tools/list`**
- Studio now exposes **100 tools** (was 91). Added a **Functions** family (`start-function`, `end-function-`, `execute-a-function`, `duplicate-a-function`, `replace-the-start/end-function-code-`, `get-python-type-stubs-for-a-function-`), plus `deploy-a-branch` and `update-a-secret`. Counts updated to 100 (Studio) / 106 (US, UK, EU).

## Notes from live testing
- The Data MCP aggregate tool ships under an experimental name — `-experimental--aggregate-a-metric-over-a-time-interval` — documented as-is and flagged experimental.
- `tools/list` exposes input schemas only (no output/response schema), so tables document tool **inputs**; error statuses are listed separately.

## Verification
- Both servers tested live (Data MCP: 5 tools; Builder MCP Studio: 100 tools).
- 79/79 internal links resolve; `docs.json` valid; no MDX hazards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)