### PR TITLE
docs: remove "beta" labels from Studio Assistant

### DIFF
--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -13,7 +13,7 @@ keywords:
 Create an account, build an agent, add knowledge, test it, and deploy. Five steps.
 
 <Tip>
-**Project admin?** [Studio Assistant](/studio-assistant/introduction) (Beta, admin-only) is the fastest way to scaffold an agent — describe what you want and it generates flows, topics, entities, and settings on a branch you can review. The manual steps below still work for any role.
+**Project admin?** [Studio Assistant](/studio-assistant/introduction) (admin-only) is the fastest way to scaffold an agent — describe what you want and it generates flows, topics, entities, and settings on a branch you can review. The manual steps below still work for any role.
 </Tip>
 
 ## Prerequisites

--- a/learn/maintain/introduction.mdx
+++ b/learn/maintain/introduction.mdx
@@ -10,7 +10,7 @@ sidebarTitle: "Home"
 Use this section when you have a live agent and need to make a targeted change — updating a topic, changing a voice, fixing a function, or adjusting a behavior. Each guide is scoped to a single task.
 
 <Tip>
-**Drive most maintenance through [Studio Assistant](/studio-assistant/introduction) (Beta).** Project admins on enterprise clusters can ask Studio Assistant in natural language to update topics, tweak flows, rewrite welcome messages, or fix a behavior that surfaced on a real call. Every change lands on a branch you review before merging — see the [prompting guide](/studio-assistant/prompting) for patterns that work well. Access is **admin-only** during Beta — see [Role permissions](/user-management/access-control-scope).
+**Drive most maintenance through [Studio Assistant](/studio-assistant/introduction).** Project admins on enterprise clusters can ask Studio Assistant in natural language to update topics, tweak flows, rewrite welcome messages, or fix a behavior that surfaced on a real call. Every change lands on a branch you review before merging — see the [prompting guide](/studio-assistant/prompting) for patterns that work well. Access is **admin-only** — see [Role permissions](/user-management/access-control-scope).
 </Tip>
 
 ## Quick decision guide
@@ -32,7 +32,7 @@ Use this section when you have a live agent and need to make a targeted change �
 
 <CardGroup cols={2}>
   <Card title="Studio Assistant" href="/studio-assistant/introduction" icon="wand-magic-sparkles">
-    Describe the change you want in plain language — Studio Assistant edits topics, flows, entities, and settings on a branch you review. <span className="badge">Beta</span>
+    Describe the change you want in plain language — Studio Assistant edits topics, flows, entities, and settings on a branch you review.
   </Card>
   <Card title="FAQs" href="/learn/maintain/knowledge-base" icon="book">
     Edit existing answers or add new topics to guide your agent's responses.

--- a/user-management/access-control-scope.mdx
+++ b/user-management/access-control-scope.mdx
@@ -26,10 +26,10 @@ Admins have **full access** to all workspace features:
 - Modify user permissions
 - Access billing and account settings
 - Full edit access to all navigation areas
-- Use [Studio Assistant](/studio-assistant/introduction) (Beta) on enterprise clusters
+- Use [Studio Assistant](/studio-assistant/introduction) on enterprise clusters
 
 <Note>
-During the Beta, [Studio Assistant](/studio-assistant/introduction) is **available only to project admins** on enterprise clusters. Permissions will become more granular over time.
+[Studio Assistant](/studio-assistant/introduction) is **available only to project admins** on enterprise clusters. Permissions will become more granular over time.
 </Note>
 
 ### Member


### PR DESCRIPTION
Studio Assistant is no longer referred to as being in **beta**. This strips the beta framing across the docs while preserving the factual access notes (admin-only, enterprise clusters).

### Changed
- **[get-started/quickstart.mdx](get-started/quickstart.mdx)** — `(Beta, admin-only)` → `(admin-only)`
- **[learn/maintain/introduction.mdx](learn/maintain/introduction.mdx)** — drop `(Beta)` and "during Beta"; remove the `Beta` badge
- **[user-management/access-control-scope.mdx](user-management/access-control-scope.mdx)** — drop `(Beta)` and "During the Beta,"

### Left as-is (unrelated betas)
A/B testing, Smart Analyst, and Zendesk/Gladly knowledge sources are still in beta and untouched.

### Note
The home page's Studio Assistant callout also mentioned beta — that's removed in the home-redesign PR #586 (which rewrites `home.mdx` wholesale), so it's intentionally not touched here to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)