### PR TITLE
docs: document poly chat --sip-header on the ADK CLI reference

### DIFF
--- a/adk/reference/cli.mdx
+++ b/adk/reference/cli.mdx
@@ -432,6 +432,8 @@ Examples:
 poly chat
 poly chat --environment live
 poly chat --channel webchat
+poly chat --sip-header X-Customer-ID=12345
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 poly chat --metadata
 poly chat --lang fr-FR
 poly chat --input-lang en-US --output-lang fr-FR
@@ -490,6 +492,24 @@ Use language flags to specify the expected input and output language when chatti
 
 `--input-lang` and `--output-lang` take precedence over `--lang` when both are supplied.
 
+#### Simulating SIP headers
+
+Use `--sip-header NAME=VALUE` to simulate a SIP header when starting a conversation.
+
+Single header:
+
+~~~bash
+poly chat --sip-header X-Customer-ID=12345
+~~~
+
+Multiple headers are supported by repeating the flag:
+
+~~~bash
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
+~~~
+
+The values are exposed to project functions through `conv.sip_headers`. This is for testing agent behaviour only; it does not create a SIP call or reproduce carrier-level SIP behaviour. SIP headers cannot be changed when resuming an existing conversation.
+
 #### `poly chat` flags summary
 
 | Flag | Description |
@@ -501,6 +521,7 @@ Use language flags to specify the expected input and output language when chatti
 | `--json` | Emit a single JSON object when the session ends (see below). |
 | `--environment` | Target environment. Choices: `branch`, `sandbox`, `pre-release`, `live`. Defaults to `branch`. `branch` chats against the last **pushed** state of your current branch (not local uncommitted changes); on main it falls back to `sandbox`. Use `--push` to push local changes before chatting. |
 | `--channel` | Channel to use (e.g. `webchat`, `voice`). |
+| `--sip-header NAME=VALUE` | Simulate a SIP header at conversation start (repeatable). |
 | `--lang` | Set both input and output language. |
 | `--input-lang` | Set input language only. |
 | `--output-lang` | Set output language only. |


### PR DESCRIPTION
## What

Ports the `poly chat --sip-header` documentation from the ADK repo across to the Mintlify ADK tab, so the option is documented on docs.poly.ai and not only on the MkDocs site.

`--sip-header NAME=VALUE` lets a developer simulate SIP headers when starting a chat conversation, which exercises agent behaviour that reads `conv.sip_headers` without arranging a real SIP call.

## Dependency

Documents the option added in [polyai/adk#256](https://github.com/polyai/adk/pull/256), which is open (all checks green). That PR in turn depends on [PolyAI-LDN/poly_core#44668](https://github.com/PolyAI-LDN/poly_core/pull/44668) for the chat API to accept the headers. Worth holding this until adk#256 merges so the docs do not describe an unreleased flag.

## Changes

**`adk/reference/cli.mdx`**

- `poly chat` examples block: two `--sip-header` invocations, single and repeated.
- New `#### Simulating SIP headers` subsection under `poly chat`, covering the `NAME=VALUE` form, repeating the flag for multiple headers, exposure to project functions via `conv.sip_headers`, and the two limits (it does not create a SIP call or reproduce carrier behaviour, and headers cannot be changed when resuming a conversation).
- `poly chat` flags summary table: a `--sip-header NAME=VALUE` row.

Wording is carried over from the upstream `docs/docs/reference/cli.md` so the two sites stay in step. No `docs.json` change is needed, `adk/reference/cli` is already in the nav.

## Verification

- `mint validate`: build validation passed.
- `mint broken-links`: 3 broken links found, all pre-existing and all the same `/managed-topics/how-to-setup-action/handoff` target in `integrations/chat/amazon-connect.mdx`, `nice-cxone.mdx`, and `webex.mdx`. None are in the file this PR touches.

## Notes

- Ported by hand rather than by re-running `.migration/convert.py`. A full `rm -rf adk` regeneration would revert the hand edits on `adk/index.mdx` from #581 (`mode: "wide"`) and #586 (the "View the ADK on GitHub" card), since neither exists in the MkDocs source. Worth folding those into `convert.py` before anyone runs a full resync.
- Related drift, not in scope here: `poly audio-cache` ([polyai/adk#246](https://github.com/polyai/adk/pull/246), merged 4 Aug) is documented upstream with 7 subcommands and is still absent from `adk/reference/cli.mdx`.
